### PR TITLE
added SPS 1.12.1-10 for comparison

### DIFF
--- a/01-su.su-1-31/01-su-vulgate-1931-1-31.txt
+++ b/01-su.su-1-31/01-su-vulgate-1931-1-31.txt
@@ -2461,20 +2461,36 @@
                         <caesura/>
                          yathovāca bhagavān dhanvantariḥ || </l>
 
-                    <l xml:id="SS.1.12.3">
-                        <label>1931 ed. 1.12.3</label>
+                    <l xml:id="SS.1.12.3a">
+                        <label>1931 ed. 1.12.3a</label>
                         <caesura/>
-                         kṣārād agnir garīyān kriyāsu vyākhyātaḥ tad dagdhānāṃ rogāṇām
+                         kṣārād agnir garīyān kriyāsu vyākhyātaḥ </l>
+                    
+                    <l xml:id="SS.1.12.3b">
+                        <label>1931 ed. 1.12.3b</label>
+                        <caesura/>tad dagdhānāṃ rogāṇām
                         apunarbhāvād bheṣajaśastrakṣārair asādhyānāṃ sat sādhyatvāc ca || </l>
 
-                    <l xml:id="SS.1.12.4">
-                        <label>1931 ed. 1.12.4</label>
+                    <l xml:id="SS.1.12.4a">
+                        <label>1931 ed. 1.12.4a</label>
                         <caesura/>
                          athemāni dahanopakaraṇāni tad yathā
                         pippalyajāśakṛdgodantaśaraśalākājāmbavauṣṭhetaralauhāḥ
-                        kṣaudraguḍasnehāś ca | tatra
-                        pippalyajāśakṛdgodantaśaraśalākāstvaggatānāṃ jāmbavauṣṭhetaralauhā
-                        māṃsagatānāṃ kṣaudraguḍasnehāḥ sirāsnāyusandhyasthigatānām || </l>
+                        kṣaudraguḍasnehāś ca |</l>
+                    
+                    <l xml:id="SS.1.12.4b">
+                        <label>1931 ed. 1.12.4b</label>
+                        <caesura/>tatra
+                        pippalyajāśakṛdgodantaśaraśalākāstvaggatānāṃ </l>
+                    
+                    <l xml:id="SS.1.12.4c">
+                        <label>1931 ed. 1.12.4c</label>
+                        <caesura/>jāmbavauṣṭhetaralauhā
+                        māṃsagatānāṃ </l>
+                    
+                    <l xml:id="SS.1.12.4d">
+                        <label>1931 ed. 1.12.4d</label>
+                        <caesura/>kṣaudraguḍasnehāḥ sirāsnāyusandhyasthigatānām || </l>
 
                     <l xml:id="SS.1.12.5">
                         <label>1931 ed. 1.12.5</label>
@@ -2483,11 +2499,18 @@
                         tatrāpyātyayike 'gnikarmasādhye vyādhau tat pratyanīkaṃ vidhiṃ
                         kṛtvā || </l>
 
-                    <l xml:id="SS.1.12.6">
-                        <label>1931 ed. 1.12.6</label>
+                   
+                    <l xml:id="SS.1.12.6a">
+                        <label>1931 ed. 1.12.6a</label>
                         <caesura/>
-                         sarvavyādhiṣv ṛtuṣu ca picchilam annaṃ bhuktavataḥ (? karma
+                         sarvavyādhiṣv ṛtuṣu ca picchilam annaṃ bhuktavataḥ </l>
+                    
+                    <l xml:id="SS.1.12.6b">
+                        <label>1931 ed. 1.12.6b</label>
+                        <caesura/>(? karma
                         kurvīta) aśmarībhagandarārśomukharogeṣv abhuktavataḥ || </l>
+                    
+                    
 
                     <l xml:id="SS.1.12.7">
                         <label>1931 ed. 1.12.7</label>
@@ -2503,10 +2526,14 @@
                         māṃsadagdhe kṛṣṇonnatavraṇatā srāvasannirodhaś ca sirāsnāyudagdhe
                         rūkṣāruṇatā karkaśasthiravraṇatā ca sandhyasthidagdhe || </l>
 
-                    <l xml:id="SS.1.12.9">
-                        <label>1931 ed. 1.12.9</label>
+                    <l xml:id="SS.1.12.9a">
+                        <label>1931 ed. 1.12.9a</label>
                         <caesura/>
-                         tatra śirorogādhimanthayor bhrūlalāṭaśaṅkhapradeśeṣu dahet
+                         tatra śirorogādhimanthayor bhrūlalāṭaśaṅkhapradeśeṣu dahet</l>
+                    
+                    <l xml:id="SS.1.12.9b">
+                        <label>1931 ed. 1.12.9b</label>
+                        <caesura/>
                         vartmarogeṣvārdrālaktakapraticchannāṃ dṛṣṭiṃ kṛvā vartmaromakūpān
                         (? dahet ) || </l>
 

--- a/01-su.su-1-31/01-su-vulgate-1938-1-31.txt
+++ b/01-su.su-1-31/01-su-vulgate-1938-1-31.txt
@@ -14,60 +14,55 @@
                     <p>Copyright Notice</p>
                     <p>Public Domain</p>
                     <p>
-                        <ref target="http://creativecommons.org/licenses/by-sa/3.0/"
-                            type="licence">Distributed by <ref
-                                target="http://sarit.indology.info" type="url">SARIT</ref>
-                            under a Creative Commons Attribution-ShareAlike 3.0 Unported
-                            License. </ref>
+                        <ref target="http://creativecommons.org/licenses/by-sa/3.0/" type="licence"
+                            >Distributed by <ref target="http://sarit.indology.info" type="url"
+                                >SARIT</ref> under a Creative Commons Attribution-ShareAlike 3.0
+                            Unported License. </ref>
                     </p>
                     <p>Under this licence, you are free<list>
-                            <item>to Share — to copy, distribute and transmit the
-                                work</item>
+                            <item>to Share — to copy, distribute and transmit the work</item>
                             <item>to Remix — to adapt the work </item>
                         </list></p>
                     <p>Under the following conditions:</p>
                     <p>
                         <list>
-                            <item>Attribution — You must attribute the work in the manner
-                                specified by the author or licensor (but not in any way
-                                that suggests that they endorse you or your use of the
-                                work)|</item>
-                            <item>Share Alike — If you alter, transform, or build upon
-                                this work, you may distribute the resulting work only
-                                under the same or similar license to this one|</item>
+                            <item>Attribution — You must attribute the work in the manner specified
+                                by the author or licensor (but not in any way that suggests that
+                                they endorse you or your use of the work)|</item>
+                            <item>Share Alike — If you alter, transform, or build upon this work,
+                                you may distribute the resulting work only under the same or similar
+                                license to this one|</item>
                         </list>
                     </p>
-                    <p>More information and fuller details of this license are given on
-                        the Creative Commons website|</p>
-                    <p>SARIT assumes no responsibility for unauthorised use that infringes
-                        the rights of any copyright owners, known or unknown|</p>
+                    <p>More information and fuller details of this license are given on the Creative
+                        Commons website|</p>
+                    <p>SARIT assumes no responsibility for unauthorised use that infringes the
+                        rights of any copyright owners, known or unknown|</p>
                 </availability>
                 <date>2025</date>
 
             </publicationStmt>
             <notesStmt>
-                <note type="footnote">Suśrutasaṃhitā (without commentaries) transcribed
-                    from Y. T. Ācārya's 1938 Bombay edition|</note>
+                <note type="footnote">Suśrutasaṃhitā (without commentaries) transcribed from Y. T.
+                    Ācārya's 1938 Bombay edition|</note>
             </notesStmt>
 
             <sourceDesc>
 
 
                 <bibl>
-                    <title>Suśrutasamhitā of Suśruta with the Nibandhasaṅgraha Commentary
-                        of Śrī Ḍalhanāchārya and the Nyāyacandrikā Pañjikā of Śrī
-                        Gayadāsāchārya on Nidānasthāna, edited from the begining to the
-                        9th ādhyāya of Cikitsāsthāna by Vaidya Jādavji Trikamji Āchārya
-                        and the rest by Nārāyaṇ Rām Āchārya</title>
-                    <editor role="sections:1.1-4.9">Yādavaśarman Trivikramātmaja
-                        Ācāryā</editor>
+                    <title>Suśrutasamhitā of Suśruta with the Nibandhasaṅgraha Commentary of Śrī
+                        Ḍalhanāchārya and the Nyāyacandrikā Pañjikā of Śrī Gayadāsāchārya on
+                        Nidānasthāna, edited from the begining to the 9th ādhyāya of Cikitsāsthāna
+                        by Vaidya Jādavji Trikamji Āchārya and the rest by Nārāyaṇ Rām
+                        Āchārya</title>
+                    <editor role="sections:1.1-4.9">Yādavaśarman Trivikramātmaja Ācāryā</editor>
                     <editor role="sections:4.10-6.66">Nārāyaṇ Rām Āchārya</editor>
                     <publisher>Nirṇaya Sāgar Press</publisher>
                     <pubPlace>Bombay</pubPlace>
                     <date>1938</date>
                     <edition>Revised third edition</edition>
-                    <edition>Reprint edition Varanasi/Delhi: Chaukhambha Orientalia,
-                        1992|</edition>
+                    <edition>Reprint edition Varanasi/Delhi: Chaukhambha Orientalia, 1992|</edition>
                     <note>This SARIT edition omits the commentarial material from this
                         edition|</note>
                 </bibl>
@@ -86,23 +81,21 @@
 
         </fileDesc>
         <revisionDesc>
-            <change who="Tyler Neil" when="2025-07-16">Provided initial raw text
-                file|</change>
+            <change who="Tyler Neil" when="2025-07-16">Provided initial raw text file|</change>
             <change who="Dominik Wujastyk" when="2025-07-17">Added initial TEI/XML
                 encoding|</change>
-            <change who="Dominik Wujastyk" when="2025-08-05">Deleted 1.13 (leeches) and
-                replaced it with 1.13 taken from the old 1931 vulgate TEI file which was
-                in fact the 1938 edition carefully edited by Lisa Brooks.</change>
-            <change who="Dominik Wujastyk" when="2025-08-05">Deleted 1.16 (ear and nose
-                surgery) and replaced it with 1.16 taken from the old 1931 vulgate TEI
-                file which was in fact the 1938 edition carefully edited by DW and
-                JB.</change>
+            <change who="Dominik Wujastyk" when="2025-08-05">Deleted 1.13 (leeches) and replaced it
+                with 1.13 taken from the old 1931 vulgate TEI file which was in fact the 1938
+                edition carefully edited by Lisa Brooks.</change>
+            <change who="Dominik Wujastyk" when="2025-08-05">Deleted 1.16 (ear and nose surgery) and
+                replaced it with 1.16 taken from the old 1931 vulgate TEI file which was in fact the
+                1938 edition carefully edited by DW and JB.</change>
             <change when="2025-08-05" who="Dominik Wujastyk">Fixed most xml:ids; labels;
                 caesuras.</change>
-            <change when="2025-08-28" who="Harshal Bhatt">XML IDs of Chapter 1-10 are
-                compared with 1931 and did some word breaks</change>
-            <change when="2025-08-31" who="Dominik Wujastyk">Further work on xml:ids;
-                labels; caesuras.</change>
+            <change when="2025-08-28" who="Harshal Bhatt">XML IDs of Chapter 1-10 are compared with
+                1931 and did some word breaks</change>
+            <change when="2025-08-31" who="Dominik Wujastyk">Further work on xml:ids; labels;
+                caesuras.</change>
 
         </revisionDesc>
     </teiHeader>
@@ -128,48 +121,44 @@
                     <l xml:id="SS.1.1.3">
                         <label>1938 ed. 1.1.3</label>
                         <caesura/>
-                         atha khalu bhagavantam amaravaram ṛṣigaṇaparivṛtam āśramasthaṃ
-                        kāśirājaṃ divodāsaṃ dhanvantarim aupadhenava<pc
-                            > </pc>vaitaraṇaurabhra<pc> </pc>pauṣkalāvata<pc
-                            > </pc>karavīrya(ra)<pc> </pc>gopurarakṣita<pc
-                            > </pc>suśruta<pc> </pc>prabhṛtaya ūcuḥ ||3|| </l>
+                         atha khalu bhagavantam amaravaram ṛṣigaṇaparivṛtam āśramasthaṃ kāśirājaṃ
+                        divodāsaṃ dhanvantarim aupadhenava<pc> </pc>vaitaraṇaurabhra<pc
+                            > </pc>pauṣkalāvata<pc> </pc>karavīrya(ra)<pc
+                            > </pc>gopurarakṣita<pc> </pc>suśruta<pc> </pc>prabhṛtaya ūcuḥ ||3|| </l>
 
                     <l xml:id="SS.1.1.4">
                         <label>1938 ed. 1.1.4</label>
                         <caesura/>
-                         bhagavan śārīramānasāgantubhir vyādhibhir
-                        vividhavedanābhighātopadrutān sanāthān apy anāthavad viceṣṭamānān
-                        vikrośataś ca mānavān abhisamīkṣya manasi naḥ pīḍā bhavati, </l>
+                         bhagavan śārīramānasāgantubhir vyādhibhir vividhavedanābhighātopadrutān
+                        sanāthān apy anāthavad viceṣṭamānān vikrośataś ca mānavān abhisamīkṣya
+                        manasi naḥ pīḍā bhavati, </l>
 
 
                     <l xml:id="SS.1.1.4b">
                         <label>1938 ed. 1.1.4b</label>
                         <caesura/>
-                         teṣāṃ sukhaiṣiṇāṃ rogopaśamārtham ātmanaś ca prāṇayātrārthaṃ
-                        prajāhitahetor āyurvedaṃ śrotum icchāma ihopadiśyamānam,
-                        atrāyattam aihikam āmuṣmikaṃ ca śreyaḥ; tadbhagavantam upapannāḥ
-                        smaḥ śiṣyatveneti ||4|| </l>
+                         teṣāṃ sukhaiṣiṇāṃ rogopaśamārtham ātmanaś ca prāṇayātrārthaṃ prajāhitahetor
+                        āyurvedaṃ śrotum icchāma ihopadiśyamānam, atrāyattam aihikam āmuṣmikaṃ ca
+                        śreyaḥ; tadbhagavantam upapannāḥ smaḥ śiṣyatveneti ||4|| </l>
 
                     <l xml:id="SS.1.1.5">
                         <label>1938 ed. 1.1.5</label>
                         <caesura/>
-                         tān uvāca bhagavān- svāgataṃ vaḥ; sarva evāmīmāṃsyā adhyāpyāś ca
-                        bhavanto vatsāḥ ||5|| </l>
+                         tān uvāca bhagavān- svāgataṃ vaḥ; sarva evāmīmāṃsyā adhyāpyāś ca bhavanto
+                        vatsāḥ ||5|| </l>
 
                     <l xml:id="SS.1.1.6">
                         <label>1938 ed. 1.1.6</label>
                         <caesura/>
                          iha khalv āyurvedaṃ nāmopāṅgam atharvavedasyānutpādyaiva prajāḥ
-                        ślokaśatasahasram adhyāyasahasraṃ ca kṛtavān svayambhūḥ, tato
-                        'lpāyuṣṭvam alpamedhastvaṃ cālokya narāṇāṃ bhūyo 'ṣṭadhā
-                        praṇītavān ||6|| </l>
+                        ślokaśatasahasram adhyāyasahasraṃ ca kṛtavān svayambhūḥ, tato 'lpāyuṣṭvam
+                        alpamedhastvaṃ cālokya narāṇāṃ bhūyo 'ṣṭadhā praṇītavān ||6|| </l>
 
                     <l xml:id="SS.1.1.7">
                         <label>1938 ed. 1.1.7</label>
                         <caesura/>
-                         tad yathā śalyaṃ, śālākyaṃ, kāyacikitsā, bhūtavidyā,
-                        kaumārabhṛtyam, agadatantraṃ, rasāyanatantraṃ, vājīkaraṇatantram
-                        iti ||7|| </l>
+                         tad yathā śalyaṃ, śālākyaṃ, kāyacikitsā, bhūtavidyā, kaumārabhṛtyam,
+                        agadatantraṃ, rasāyanatantraṃ, vājīkaraṇatantram iti ||7|| </l>
 
                     <l xml:id="SS.1.1.8.1">
                         <label>1938 ed. 1.1.8.1</label>
@@ -186,16 +175,14 @@
                     <l xml:id="SS.1.1.8.2">
                         <label>1938 ed. 1.1.8.2</label>
                         <caesura/>
-                         śālākyaṃ nāmordhvajatrugatānāṃ
-                        śravaṇanayanavadanaghrāṇādisaṃśritānāṃ vyādhīnām upaśamanārtham
-                        (2) |8| </l>
+                         śālākyaṃ nāmordhvajatrugatānāṃ śravaṇanayanavadanaghrāṇādisaṃśritānāṃ
+                        vyādhīnām upaśamanārtham (2) |8| </l>
 
                     <l xml:id="SS.1.1.8.3">
                         <label>1938 ed. 1.1.8.3</label>
                         <caesura/>
                          kāyacikitsā nāma sarvāṅgasaṃśritānāṃ vyādhīnāṃ
-                        jvararaktapittaśoṣonmādāpasmārakuṣṭhamehātisārādīnām
-                        upaśamanārtham (3) |8| </l>
+                        jvararaktapittaśoṣonmādāpasmārakuṣṭhamehātisārādīnām upaśamanārtham (3) |8| </l>
 
                     <l xml:id="SS.1.1.8.4">
                         <label>1938 ed. 1.1.8.4</label>
@@ -208,8 +195,7 @@
                         <label>1938 ed. 1.1.8.5</label>
                         <caesura/>
                          kaumārabhṛtyaṃ nāma kumārabharaṇadhātrīkṣīradoṣasaṃśodhanārthaṃ
-                        duṣṭastanyagrahasamutthānāṃ ca vyādhīnām upaśamanārtham (5)
-                        |8|</l>
+                        duṣṭastanyagrahasamutthānāṃ ca vyādhīnām upaśamanārtham (5) |8|</l>
 
                     <l xml:id="SS.1.1.8.6">
                         <label>1938 ed. 1.1.8.6</label>
@@ -220,27 +206,25 @@
                     <l xml:id="SS.1.1.8.7">
                         <label>1938 ed. 1.1.8.7</label>
                         <caesura/>
-                         rasāyanatantraṃ nāma vayaḥsthāpanamāyurmedhābalakaraṃ
-                        rogāpaharaṇasamarthaṃ ca (7) |8| </l>
+                         rasāyanatantraṃ nāma vayaḥsthāpanamāyurmedhābalakaraṃ rogāpaharaṇasamarthaṃ
+                        ca (7) |8| </l>
 
                     <l xml:id="SS.1.1.8.8">
                         <label>1938 ed. 1.1.8.8</label>
                         <caesura/>
                          vājīkaraṇatantraṃ nāmālpaduṣṭakṣīṇaviśuṣkaretasām
-                        āpyāyanaprasādopacayajanananimittaṃ praharṣajananārthaṃ ca (8)
-                        ||8|| </l>
+                        āpyāyanaprasādopacayajanananimittaṃ praharṣajananārthaṃ ca (8) ||8|| </l>
 
                     <l xml:id="SS.1.1.9">
                         <label>1938 ed. 1.1.9</label>
                         <caesura/>
-                         evam ayam āyurvedo 'ṣṭāṅga upadiśyate; atra kasmai kim ucyatām
-                        iti ||9|| </l>
+                         evam ayam āyurvedo 'ṣṭāṅga upadiśyate; atra kasmai kim ucyatām iti ||9|| </l>
 
                     <l xml:id="SS.1.1.10">
                         <label>1938 ed. 1.1.10</label>
                         <caesura/>
-                         ta ūcuḥ- asmākaṃ sarveṣām eva śalyajñānaṃ mūlaṃ kṛtvopadiśatu
-                        bhagavāniti ||10||</l>
+                         ta ūcuḥ- asmākaṃ sarveṣām eva śalyajñānaṃ mūlaṃ kṛtvopadiśatu bhagavāniti
+                        ||10||</l>
 
                     <l xml:id="SS.1.1.11">
                         <label>1938 ed. 1.1.11</label>
@@ -250,9 +234,9 @@
                     <l xml:id="SS.1.1.12">
                         <label>1938 ed. 1.1.12</label>
                         <caesura/>
-                         ta ūcur bhūyo 'pi bhagavantam asmākam ekamatīnāṃ matam
-                        abhisamīkṣya suśruto bhagavantaṃ prakṣyati, asmai copadiśyamānaṃ
-                        vayam apy upadhārayiṣyāmaḥ ||12|| </l>
+                         ta ūcur bhūyo 'pi bhagavantam asmākam ekamatīnāṃ matam abhisamīkṣya suśruto
+                        bhagavantaṃ prakṣyati, asmai copadiśyamānaṃ vayam apy upadhārayiṣyāmaḥ
+                        ||12|| </l>
 
                     <l xml:id="SS.1.1.13">
                         <label>1938 ed. 1.1.13</label>
@@ -268,64 +252,57 @@
                     <l xml:id="SS.1.1.15">
                         <label>1938 ed. 1.1.15</label>
                         <caesura/>
-                         ‘āyur asmin vidyate, anena vā''yur vindanti’ ity āyurvedaḥ
-                        ||15||</l>
+                         ‘āyur asmin vidyate, anena vā''yur vindanti’ ity āyurvedaḥ ||15||</l>
 
                     <l xml:id="SS.1.1.16">
                         <label>1938 ed. 1.1.16</label>
                         <caesura/>
-                         tasyāṅgavaramādyaṃ pratyakṣāgamānumānopamānair aviruddham
-                        ucyamānam upadhāraya ||16|| </l>
+                         tasyāṅgavaramādyaṃ pratyakṣāgamānumānopamānair aviruddham ucyamānam
+                        upadhāraya ||16|| </l>
 
                     <l xml:id="SS.1.1.17">
                         <label>1938 ed. 1.1.17</label>
                         <caesura/>
-                         etad dhy aṅgaṃ prathamaṃ, prāgabhighātavraṇasaṃrohād
-                        yajñaśiraḥsandhānāc ca | śrūyate hi yathā --- “rudreṇa yajñasya
-                        śiraś chinnam iti, tato devā aśvināvabhigamyocuḥ- bhagavantau naḥ
-                        śreṣṭhatamau yuvāṃ bhaviṣyathaḥ, bhavadbhyāṃ yajñasya śiraḥ
-                        sandhātavyam iti | tāv ūcatur evam astv iti | atha tayor arthe
-                        devā indraṃ yajñabhāgena prāsādayan | tābhyāṃ yajñasya śiraḥ
-                        saṃhitam” iti ||17|| </l>
+                         etad dhy aṅgaṃ prathamaṃ, prāgabhighātavraṇasaṃrohād yajñaśiraḥsandhānāc ca
+                        | śrūyate hi yathā --- “rudreṇa yajñasya śiraś chinnam iti, tato devā
+                        aśvināvabhigamyocuḥ- bhagavantau naḥ śreṣṭhatamau yuvāṃ bhaviṣyathaḥ,
+                        bhavadbhyāṃ yajñasya śiraḥ sandhātavyam iti | tāv ūcatur evam astv iti |
+                        atha tayor arthe devā indraṃ yajñabhāgena prāsādayan | tābhyāṃ yajñasya
+                        śiraḥ saṃhitam” iti ||17|| </l>
 
                     <l xml:id="SS.1.1.18">
                         <label>1938 ed. 1.1.18</label>
                         <caesura/>
                          aṣṭāsvapi cāyurvedatantreṣvetadevādhikamabhimatam,
-                        āśukriyākaraṇādyantraśastrakṣārāgnipraṇidhānāt sarvatantrasāmānyāc
-                        ca ||18|| </l>
+                        āśukriyākaraṇādyantraśastrakṣārāgnipraṇidhānāt sarvatantrasāmānyāc ca ||18|| </l>
 
                     <l xml:id="SS.1.1.19">
                         <label>1938 ed. 1.1.19</label>
                         <caesura/>
-                         tad idaṃ śāśvataṃ puṇyaṃ svargyaṃ yaśasyam āyuṣyaṃ vṛttikaraṃ
-                        ceti ||19|| </l>
+                         tad idaṃ śāśvataṃ puṇyaṃ svargyaṃ yaśasyam āyuṣyaṃ vṛttikaraṃ ceti ||19|| </l>
 
                     <l xml:id="SS.1.1.20">
                         <label>1938 ed. 1.1.20</label>
                         <caesura/>
-                         brahmā provāca tataḥ prajāpatir adhijage, tasmād aśvinau,
-                        aśvibhyām indraḥ, indrād ahaṃ, mayā tv iha pradeyam arthibhyaḥ
-                        prajāhitahetoḥ ||20|| </l>
+                         brahmā provāca tataḥ prajāpatir adhijage, tasmād aśvinau, aśvibhyām indraḥ,
+                        indrād ahaṃ, mayā tv iha pradeyam arthibhyaḥ prajāhitahetoḥ ||20|| </l>
 
                     <l xml:id="SS.1.1.21">
                         <label>1938 ed. 1.1.21</label>
                         <caesura/>
-                         bhavati cātra ahaṃ hi dhanvantarir ādidevo jarārujāmṛtyuharo
-                        'marāṇām |
+                         bhavati cātra ahaṃ hi dhanvantarir ādidevo jarārujāmṛtyuharo 'marāṇām |
                         <caesura/>
-                         śalyāṅgam aṅgair aparair upetaṃ prāpto 'smi gāṃ bhūya ihopadeṣṭum
-                        ||21|| </l>
+                         śalyāṅgam aṅgair aparair upetaṃ prāpto 'smi gāṃ bhūya ihopadeṣṭum ||21|| </l>
 
                     <l xml:id="SS.1.1.22">
                         <label>1938 ed. 1.1.22</label>
                         <caesura/>
-                         asmiñchāstre pañcamahābhūtaśarīrisamavāyaḥ puruṣa ity ucyate |
-                        tasmin kriyā, so 'dhiṣṭhānaṃ; kasmāt? lokasya dvaividhyāta ; loko
-                        hi dvividhaḥ sthāvaro jaṅgamaśca; dvividhātmaka evāgneyaḥ,
-                        saumyaśca, tadbhūyastvāt ; pañcātmako vā; tatra caturvidho
-                        bhūtagrāmaḥ saṃsvedajajarāyujāṇḍajodbhijjasañjñaḥ ; tatra puruṣaḥ
-                        pradhānaṃ, tasyopakaraṇamanyat; tasmāt puruṣo 'dhiṣṭhānam ||22|| </l>
+                         asmiñchāstre pañcamahābhūtaśarīrisamavāyaḥ puruṣa ity ucyate | tasmin
+                        kriyā, so 'dhiṣṭhānaṃ; kasmāt? lokasya dvaividhyāta ; loko hi dvividhaḥ
+                        sthāvaro jaṅgamaśca; dvividhātmaka evāgneyaḥ, saumyaśca, tadbhūyastvāt ;
+                        pañcātmako vā; tatra caturvidho bhūtagrāmaḥ
+                        saṃsvedajajarāyujāṇḍajodbhijjasañjñaḥ ; tatra puruṣaḥ pradhānaṃ,
+                        tasyopakaraṇamanyat; tasmāt puruṣo 'dhiṣṭhānam ||22|| </l>
 
                     <l xml:id="SS.1.1.23">
                         <label>1938 ed. 1.1.23</label>
@@ -335,8 +312,7 @@
                     <l xml:id="SS.1.1.24">
                         <label>1938 ed. 1.1.24</label>
                         <caesura/>
-                         te caturvidhāḥ- āgantavaḥ, śārīrāḥ, mānasāḥ, svābhāvikāśceti
-                        ||24|| </l>
+                         te caturvidhāḥ- āgantavaḥ, śārīrāḥ, mānasāḥ, svābhāvikāśceti ||24|| </l>
 
                     <l xml:id="SS.1.1.25.1">
                         <label>1938 ed. 1.1.25.1</label>
@@ -346,8 +322,7 @@
                     <l xml:id="SS.1.1.25.2">
                         <label>1938 ed. 1.1.25.1</label>
                         <caesura/>
-                         śārīrās tv annapānamūlā
-                        vātapittakaphaśoṇitasannipātavaiṣamyanimittāḥ</l>
+                         śārīrās tv annapānamūlā vātapittakaphaśoṇitasannipātavaiṣamyanimittāḥ</l>
 
                     <l xml:id="SS.1.1.25.3">
                         <label>1938 ed. 1.1.25.3</label>
@@ -369,38 +344,35 @@
                     <l xml:id="SS.1.1.27">
                         <label>1938 ed. 1.1.27</label>
                         <caesura/>
-                         teṣāṃ saṃśodhanasaṃśamanāhārācārāḥ samyak prayuktā nigrahahetavaḥ
-                        ||27|| </l>
+                         teṣāṃ saṃśodhanasaṃśamanāhārācārāḥ samyak prayuktā nigrahahetavaḥ ||27|| </l>
 
                     <l xml:id="SS.1.1.28">
                         <label>1938 ed. 1.1.28</label>
                         <caesura/>
-                         prāṇināṃ punar mūlam āhāro balavarṇaujasāṃ ca | sa ṣaṭsu raseṣv
-                        āyattaḥ; rasāḥ punar dravyāśrayāḥ; dravyāṇi punar oṣadhayaḥ | tās
-                        tu dvividhāḥ- sthāvarā jaṅgamāś ca ||28|| </l>
+                         prāṇināṃ punar mūlam āhāro balavarṇaujasāṃ ca | sa ṣaṭsu raseṣv āyattaḥ;
+                        rasāḥ punar dravyāśrayāḥ; dravyāṇi punar oṣadhayaḥ | tās tu dvividhāḥ-
+                        sthāvarā jaṅgamāś ca ||28|| </l>
 
                     <l xml:id="SS.1.1.29">
                         <label>1938 ed. 1.1.29</label>
                         <caesura/>
-                         tāsāṃ sthāvarāś caturvidhāḥ- vanaspatayo, vṛkṣā, vīrudha,
-                        oṣadhaya iti | tāsu, apuṣpāḥ phalavanto vanaspatayaḥ,
-                        puṣpaphalavanto vṛkṣāḥ, pratānavatyaḥ stambinyaś ca vīrudhaḥ,
-                        phalapākaniṣṭhā oṣadhaya iti ||29|| </l>
+                         tāsāṃ sthāvarāś caturvidhāḥ- vanaspatayo, vṛkṣā, vīrudha, oṣadhaya iti |
+                        tāsu, apuṣpāḥ phalavanto vanaspatayaḥ, puṣpaphalavanto vṛkṣāḥ, pratānavatyaḥ
+                        stambinyaś ca vīrudhaḥ, phalapākaniṣṭhā oṣadhaya iti ||29|| </l>
 
                     <l xml:id="SS.1.1.30">
                         <label>1938 ed. 1.1.30</label>
                         <caesura/>
-                         jaṅgamā khalv api caturvidhāḥ jarāyujāṇḍajasvedajodbhijjāḥ |
-                        tatra paśumanuṣyavyālādayo jarāyujāḥ, khagasarpasarīsṛpaprabhṛtayo
-                        'ṇḍajāḥ, kṛmikīṭapipīlikāprabhṛtayaḥ svedajāḥ,
-                        indragopamaṇḍūkaprabhṛtaya udbhijjāḥ ||30|| </l>
+                         jaṅgamā khalv api caturvidhāḥ jarāyujāṇḍajasvedajodbhijjāḥ | tatra
+                        paśumanuṣyavyālādayo jarāyujāḥ, khagasarpasarīsṛpaprabhṛtayo 'ṇḍajāḥ,
+                        kṛmikīṭapipīlikāprabhṛtayaḥ svedajāḥ, indragopamaṇḍūkaprabhṛtaya udbhijjāḥ
+                        ||30|| </l>
 
                     <l xml:id="SS.1.1.31">
                         <label>1938 ed. 1.1.31</label>
                         <caesura/>
-                         tatra sthāvarebhyas
-                        tvakpatrapuṣpaphalamūlakandaniryāsasvarasādayaḥ prayojanavantaḥ;
-                        jaṅgamebhyaś carmanakharomarudhirādayaḥ ||31|| </l>
+                         tatra sthāvarebhyas tvakpatrapuṣpaphalamūlakandaniryāsasvarasādayaḥ
+                        prayojanavantaḥ; jaṅgamebhyaś carmanakharomarudhirādayaḥ ||31|| </l>
 
                     <l xml:id="SS.1.1.32">
                         <label>1938 ed. 1.1.32</label>
@@ -417,8 +389,8 @@
                     <l xml:id="SS.1.1.34">
                         <label>1938 ed. 1.1.34</label>
                         <caesura/>
-                         ta ete svabhāvata eva doṣāṇāṃ
-                        sañcayaprakopapraśamapratīkārahetavaḥ prayojanavantaś ca ||34|| </l>
+                         ta ete svabhāvata eva doṣāṇāṃ sañcayaprakopapraśamapratīkārahetavaḥ
+                        prayojanavantaś ca ||34|| </l>
 
                     <l xml:id="SS.1.1.35">
                         <label>1938 ed. 1.1.35</label>
@@ -446,14 +418,13 @@
                     <l xml:id="SS.1.1.38">
                         <label>1938 ed. 1.1.38</label>
                         <caesura/>
-                         evam etat puruṣo vyādhir auṣadhaṃ kriyā kāla iti catuṣṭayaṃ
-                        samāsena vyākhyātam | tatra puruṣagrahaṇāt tatsambhavadravyasamūho
-                        bhūtādir uktas tadaṅgapratyaṅgavikalpāś ca
-                        tvaṅmāṃsāsthisirāsnāyuprabhṛtayaḥ, vyādhigrahaṇād
-                        vātapittakaphaśoṇitasannipātavaiṣamyanimittāḥ sarva eva vyādhayo
-                        vyākhyātāḥ, auṣadhagrahaṇāddravyarasaguṇavīryavipākānāmādeśaḥ,
-                        kriyāgrahaṇāt snehādīni cchedyādīni ca karmāṇi vyākhyātāni,
-                        kālagrahaṇāt sarvakriyākālānāmādeśaḥ ||38|| </l>
+                         evam etat puruṣo vyādhir auṣadhaṃ kriyā kāla iti catuṣṭayaṃ samāsena
+                        vyākhyātam | tatra puruṣagrahaṇāt tatsambhavadravyasamūho bhūtādir uktas
+                        tadaṅgapratyaṅgavikalpāś ca tvaṅmāṃsāsthisirāsnāyuprabhṛtayaḥ,
+                        vyādhigrahaṇād vātapittakaphaśoṇitasannipātavaiṣamyanimittāḥ sarva eva
+                        vyādhayo vyākhyātāḥ, auṣadhagrahaṇāddravyarasaguṇavīryavipākānāmādeśaḥ,
+                        kriyāgrahaṇāt snehādīni cchedyādīni ca karmāṇi vyākhyātāni, kālagrahaṇāt
+                        sarvakriyākālānāmādeśaḥ ||38|| </l>
 
                     <l xml:id="SS.1.1.39">
                         <label>1938 ed. 1.1.39</label>
@@ -468,8 +439,8 @@
                         <label>1938 ed. 1.1.40</label>
                         <caesura/>
                          tac ca saviṃśam adhyāyaśataṃ pañcasu sthāneṣu | tatra
-                        sūtranidānaśārīracikitsitakalpeṣv arthavaśāt saṃvibhajyottare
-                        tantre śeṣān arthān vakṣyāmaḥ ||40|| </l>
+                        sūtranidānaśārīracikitsitakalpeṣv arthavaśāt saṃvibhajyottare tantre śeṣān
+                        arthān vakṣyāmaḥ ||40|| </l>
 
                     <l xml:id="SS.1.1.41">
                         <label>1938 ed. 1.1.41</label>
@@ -485,8 +456,8 @@
                          asukṣaye śakrasalokatāṃ vrajet ||41|| </l>
 
 
-                    <l xml:id="SS.1.1.trailer"> iti suśrutasaṃhitāyāṃ sūtrasthāne
-                        vedotpattir nāma prathamo 'dhyāyaḥ ||1|| </l>
+                    <l xml:id="SS.1.1.trailer"> iti suśrutasaṃhitāyāṃ sūtrasthāne vedotpattir nāma
+                        prathamo 'dhyāyaḥ ||1|| </l>
                 </div>
 
 
@@ -509,56 +480,54 @@
                         <caesura/>
                          brāhmaṇakṣatriyavaiśyānām
                         anyatamamanvayavayaḥśīlaśauryaśaucācāravinayaśaktibalamedhādhṛtismṛtimatipratipattiyuktaṃ
-                        tanujihvauṣṭhadantāgramṛjuvaktrākṣināsaṃ prasannacittavākceṣṭaṃ
-                        kleśasahaṃ ca bhiṣak śiṣyam upanayet | ato viparītaguṇaṃ nopanayet
-                        ||3|| </l>
+                        tanujihvauṣṭhadantāgramṛjuvaktrākṣināsaṃ prasannacittavākceṣṭaṃ kleśasahaṃ
+                        ca bhiṣak śiṣyam upanayet | ato viparītaguṇaṃ nopanayet ||3|| </l>
 
                     <l xml:id="SS.1.2.4">
                         <label>1938 ed. 1.2.4</label>
                         <caesura/>
                          upanayanīyaṃ tu brāhmaṇaṃ praśasteṣu tithikaraṇamuhūrtanakṣatreṣu
-                        praśastāyāṃ diśi śucau same deśe caturhastaṃ caturasraṃ sthaṇḍilam
-                        upalipya gomayena, darbhaiḥ saṃstīrya ratnapuṣpalājabhaktair
-                        devatāḥ pūjayitvā viprān bhiṣajaś ca, tatrollikhyābhyukṣya ca
-                        dakṣiṇato brahmāṇaṃ sthāpayitvā'gnim upasamādhāya,
-                        khadirapalāśadevadārubilvānāṃ samidbhiścaturṇāṃ vā kṣīrivṛkṣāṇāṃ
-                        (nyagrodhodumbarāśvatthamadhūkānāṃ) dadhimadhughṛtāktābhir
-                        dārvīhaumikena vidhinā sapraṇavābhir mahāvyāhṛtibhiḥ
-                        sruveṇājyāhutīr juhuyāt, tataḥ pratidaivatamṛṣīṃś ca svāhākāraṃ
-                        kuryāt , śiṣyam api kārayet ||4|| </l>
+                        praśastāyāṃ diśi śucau same deśe caturhastaṃ caturasraṃ sthaṇḍilam upalipya
+                        gomayena, darbhaiḥ saṃstīrya ratnapuṣpalājabhaktair devatāḥ pūjayitvā viprān
+                        bhiṣajaś ca, tatrollikhyābhyukṣya ca dakṣiṇato brahmāṇaṃ sthāpayitvā'gnim
+                        upasamādhāya, khadirapalāśadevadārubilvānāṃ samidbhiścaturṇāṃ vā
+                        kṣīrivṛkṣāṇāṃ (nyagrodhodumbarāśvatthamadhūkānāṃ) dadhimadhughṛtāktābhir
+                        dārvīhaumikena vidhinā sapraṇavābhir mahāvyāhṛtibhiḥ sruveṇājyāhutīr
+                        juhuyāt, tataḥ pratidaivatamṛṣīṃś ca svāhākāraṃ kuryāt , śiṣyam api kārayet
+                        ||4|| </l>
 
                     <l xml:id="SS.1.2.5">
                         <label>1938 ed. 1.2.5</label>
                         <caesura/>
-                         brāhmaṇas trayāṇāṃ varṇānām upanayanaṃ kartumarhati, (rājanyo
-                        dvayasya, vaiśyo vaiśyasyaiveti;) śūdramapi kulaguṇasampannaṃ
+                         brāhmaṇas trayāṇāṃ varṇānām upanayanaṃ kartumarhati, (rājanyo dvayasya,
+                        vaiśyo vaiśyasyaiveti;) śūdramapi kulaguṇasampannaṃ
                         mantravarjamanupanītamadhyāpayed ity eke ||5|| </l>
 
                     <l xml:id="SS.1.2.6">
                         <label>1938 ed. 1.2.6</label>
                         <caesura/>
                          tato 'gniṃ triḥ pariṇīyāgnisākṣikaṃ śiṣyaṃ brūyāt-
-                        kāmakrodhalobhamohamānāhaṅkārerṣyāpāruṣyapaiśunyānṛtālasyāyaśasyāni
-                        hitvā, nīcanakharomṇā śucinā kaṣāyavāsasā
+                        kāmakrodhalobhamohamānāhaṅkārerṣyāpāruṣyapaiśunyānṛtālasyāyaśasyāni hitvā,
+                        nīcanakharomṇā śucinā kaṣāyavāsasā
                         satyavratabrahmacaryābhivādanatatpareṇāvaśyaṃ bhavitavyaṃ,
-                        madanumatasthānagamanaśayanāsanabhojanādhyayanapareṇa bhūtvā
-                        matpriyahiteṣu vartitavyam; ato 'nyathā te vartamānasyādharmo
-                        bhavati, aphalā ca vidyā, na ca prākāśyaṃ prāpnoti ||6|| </l>
+                        madanumatasthānagamanaśayanāsanabhojanādhyayanapareṇa bhūtvā matpriyahiteṣu
+                        vartitavyam; ato 'nyathā te vartamānasyādharmo bhavati, aphalā ca vidyā, na
+                        ca prākāśyaṃ prāpnoti ||6|| </l>
 
                     <l xml:id="SS.1.2.7">
                         <label>1938 ed. 1.2.7</label>
                         <caesura/>
-                         ahaṃ vā tvayi samyagvartamāne yady anyathādarśī syām enobhāg
-                        bhaveyam aphalavidyaś ca ||7|| </l>
+                         ahaṃ vā tvayi samyagvartamāne yady anyathādarśī syām enobhāg bhaveyam
+                        aphalavidyaś ca ||7|| </l>
 
                     <l xml:id="SS.1.2.8">
                         <label>1938 ed. 1.2.8</label>
                         <caesura/>
                          dvijagurudaridramitrapravrajitopanatasādhvanāthābhyupagatānāṃ
-                        cātmabāndhavānām iva svabhaiṣajaiḥ pratikartavyam, evaṃ sādhu
-                        bhavati; vyādhaśākunikapatitapāpakāriṇāṃ ca na pratikartavyam;
-                        evaṃ vidyā prakāśate mitra<pc> </pc>yaśo<pc
-                            > </pc>dharmārtha<pc> </pc>kāmāṃś ca prāpnoti ||8|| </l>
+                        cātmabāndhavānām iva svabhaiṣajaiḥ pratikartavyam, evaṃ sādhu bhavati;
+                        vyādhaśākunikapatitapāpakāriṇāṃ ca na pratikartavyam; evaṃ vidyā prakāśate
+                            mitra<pc> </pc>yaśo<pc> </pc>dharmārtha<pc> </pc>kāmāṃś ca prāpnoti
+                        ||8|| </l>
 
                     <l xml:id="SS.1.2.9">
                         <label>1938 ed. 1.2.9</label>
@@ -584,8 +553,8 @@
                         <caesura/>
                          nādhīyate nāśucinā ca nityam ||10|| </l>
 
-                    <l xml:id="SS1.2.trailer"> iti suśrutasaṃhitāyāṃ sūtrasthāne
-                        śiṣyopanayanīyo nāma dvitīyo 'dhyāyaḥ ||2|| </l>
+                    <l xml:id="SS1.2.trailer"> iti suśrutasaṃhitāyāṃ sūtrasthāne śiṣyopanayanīyo
+                        nāma dvitīyo 'dhyāyaḥ ||2|| </l>
 
                 </div>
                 <div n="3" type="adhyāya">
@@ -605,9 +574,8 @@
                         <label>1938 ed. 1.3.3</label>
                         <caesura/>
                          prāgabhihitaṃ saviṃśam adhyāyaśataṃ pañcasu sthāneṣu | tatra
-                        sūtrasthānamadhyāyāḥ ṣaṭcatvāriṃśat, ṣoḍaśa nidānāni, daśa
-                        śārīrāṇi, catvāriṃśaccikitsitāni, aṣṭau kalpāḥ, taduttaraṃ
-                        ṣaṭṣaṣṭiḥ ||3|| </l>
+                        sūtrasthānamadhyāyāḥ ṣaṭcatvāriṃśat, ṣoḍaśa nidānāni, daśa śārīrāṇi,
+                        catvāriṃśaccikitsitāni, aṣṭau kalpāḥ, taduttaraṃ ṣaṭṣaṣṭiḥ ||3|| </l>
 
                     <l xml:id="SS.1.3.4">
                         <label>1938 ed. 1.3.4</label>
@@ -913,8 +881,8 @@
                     <l xml:id="SS.1.3.47">
                         <label>1938 ed. 1.3.47</label>
                         <caesura/>
-                         etad dhy avaśyam adhyeyam, adhītya ca karmāpy avaśyam
-                        upāsitavyam, ubhayajño hi bhiṣag rājārho bhavati ||47|| </l>
+                         etad dhy avaśyam adhyeyam, adhītya ca karmāpy avaśyam upāsitavyam,
+                        ubhayajño hi bhiṣag rājārho bhavati ||47|| </l>
 
                     <l xml:id="SS.1.3.48">
                         <label>1938 ed. 1.3.48</label>
@@ -963,15 +931,13 @@
                     <l xml:id="SS.1.3.54">
                         <label>1938 ed. 1.3.54</label>
                         <caesura/>
-                         atha vatsa! tad etad adhyeyaṃ yathā tathopadhāraya mayā
-                        procyamānaṃ atha śucaye
-                        kṛtottarāsaṅgāyāvyākulāyopasthitāyādhyayanakāle śiṣyāya yathāśakti
+                         atha vatsa! tad etad adhyeyaṃ yathā tathopadhāraya mayā procyamānaṃ atha
+                        śucaye kṛtottarāsaṅgāyāvyākulāyopasthitāyādhyayanakāle śiṣyāya yathāśakti
                         gururupadiśet padaṃ pādaṃ ślokaṃ vā; te ca padapādaślokā bhūyaḥ
-                        krameṇānusandheyāḥ, evam ekaikaśo ghaṭayed ātmanā cānupaṭhet;
-                        adrutam avilambitam aviśaṅkitam ananunāsikaṃ suvyaktākṣaram
-                        apīḍitavarṇam akṣibhruvauṣṭhahastair anabhinītaṃ susaṃskṛtaṃ
-                        nātyuccair nātinīcaiś ca svaraiḥ paṭhet | na cāntareṇa kaścid
-                        vrajet tayor adhīyānayoḥ ||54|| </l>
+                        krameṇānusandheyāḥ, evam ekaikaśo ghaṭayed ātmanā cānupaṭhet; adrutam
+                        avilambitam aviśaṅkitam ananunāsikaṃ suvyaktākṣaram apīḍitavarṇam
+                        akṣibhruvauṣṭhahastair anabhinītaṃ susaṃskṛtaṃ nātyuccair nātinīcaiś ca
+                        svaraiḥ paṭhet | na cāntareṇa kaścid vrajet tayor adhīyānayoḥ ||54|| </l>
 
                     <l xml:id="SS.1.3.55">
                         <label>1938 ed. 1.3.55</label>
@@ -992,8 +958,8 @@
                     <l xml:id="SS.1.3.trailer">
                         <label>1938 ed. 1.3.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne 'dhyayanasampradānīyo nāma
-                        tṛtīyo 'dhyāyaḥ ||3|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne 'dhyayanasampradānīyo nāma tṛtīyo
+                        'dhyāyaḥ ||3|| </l>
                 </div>
                 <div n="4" type="adhyāya">
 
@@ -1010,8 +976,8 @@
                     <l xml:id="SS.1.4.3">
                         <label>1938 ed. 1.4.3</label>
                         <caesura/>
-                         adhigatam apy adhyayanam aprabhāṣitam arthataḥ kharasya
-                        candanabhāra iva kevalaṃ pariśramakaraṃ bhavati ||3|| </l>
+                         adhigatam apy adhyayanam aprabhāṣitam arthataḥ kharasya candanabhāra iva
+                        kevalaṃ pariśramakaraṃ bhavati ||3|| </l>
 
                     <l xml:id="SS.1.4.4">
                         <label>1938 ed. 1.4.4</label>
@@ -1032,18 +998,17 @@
                          tasmāt saviṃśama dhyāyaśatam anupadapādaślokam anuvarṇayitavyam
                         anuśrotavyaṃ ca; kasmāt? sūkṣmā hi
                         dravyarasaguṇavīryavipākadoṣadhātumalāśayamarmasirāsnāyusandhyasthigarbhasambhavadravyasamūhavibhāgāstathā
-                        pranaṣṭaśalyoddharaṇavraṇaviniścayabhagnavikalpāḥ
-                        sādhyayāpyapratyākhyeyatā ca vikārāṇāmevamādayaś cānye viśeṣāḥ
-                        sahasraśo ye vicintyamānā vimalavipulabuddherapi
-                        buddhimākulīkuryuḥ kiṃ punaralpabuddheḥ, tasmād
+                        pranaṣṭaśalyoddharaṇavraṇaviniścayabhagnavikalpāḥ sādhyayāpyapratyākhyeyatā
+                        ca vikārāṇāmevamādayaś cānye viśeṣāḥ sahasraśo ye vicintyamānā
+                        vimalavipulabuddherapi buddhimākulīkuryuḥ kiṃ punaralpabuddheḥ, tasmād
                         avaśyamanupadapādaślokamanuvarṇayitavyamanuśrotavyaṃ ca ||5|| </l>
 
                     <l xml:id="SS.1.4.6">
                         <label>1938 ed. 1.4.6</label>
                         <caesura/>
-                         anyaśāstropapannānāṃ cārthānāmihopanītānāmarthavaśātteṣāṃ
-                        tadvidyebhya eva vyākhyānamanuśrotavyaṃ, kasmāt? na hyekasmin
-                        śāstre śakyaḥ sarvaśāstrāṇāmavarodhaḥ kartum ||6|| </l>
+                         anyaśāstropapannānāṃ cārthānāmihopanītānāmarthavaśātteṣāṃ tadvidyebhya eva
+                        vyākhyānamanuśrotavyaṃ, kasmāt? na hyekasmin śāstre śakyaḥ
+                        sarvaśāstrāṇāmavarodhaḥ kartum ||6|| </l>
 
                     <l xml:id="SS.1.4.7">
                         <label>1938 ed. 1.4.7</label>
@@ -1071,8 +1036,7 @@
                     <l xml:id="SS.1.4.trailer">
                         <label>1938 ed. 1.4.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne prabhāṣaṇīyo nāma caturtho
-                        'dhyāyaḥ ||4|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne prabhāṣaṇīyo nāma caturtho 'dhyāyaḥ ||4|| </l>
 
                 </div>
                 <div n="5" type="adhyāya">
@@ -1090,41 +1054,40 @@
                     <l xml:id="SS.1.5.3">
                         <label>1938 ed. 1.5.3</label>
                         <caesura/>
-                         trividhaṃ karma- pūrvakarma, pradhānakarma, paścātkarmeti;
-                        tadvyādhiṃ pratyupadekṣyāmaḥ ||3|| </l>
+                         trividhaṃ karma- pūrvakarma, pradhānakarma, paścātkarmeti; tadvyādhiṃ
+                        pratyupadekṣyāmaḥ ||3|| </l>
 
                     <l xml:id="SS.1.5.4">
                         <label>1938 ed. 1.5.4</label>
                         <caesura/>
-                         asya tu śāstrasya śastrakarmaprādhānyācchastrakarmaiva tāvat
-                        pūrvam upadekṣyāmastatsambhārāṃś ca ||4|| </l>
+                         asya tu śāstrasya śastrakarmaprādhānyācchastrakarmaiva tāvat pūrvam
+                        upadekṣyāmastatsambhārāṃś ca ||4|| </l>
 
                     <l xml:id="SS.1.5.5">
                         <label>1938 ed. 1.5.5</label>
                         <caesura/>
-                         tac ca śastrakarmā'ṣṭavidhaṃ; tad yathā- chedyaṃ, bhedyaṃ,
-                        lekhyaṃ, vedhyam, eṣyam, āhāryaṃ, visrāvyaṃ, sīvyamiti ||5|| </l>
+                         tac ca śastrakarmā'ṣṭavidhaṃ; tad yathā- chedyaṃ, bhedyaṃ, lekhyaṃ,
+                        vedhyam, eṣyam, āhāryaṃ, visrāvyaṃ, sīvyamiti ||5|| </l>
 
                     <l xml:id="SS.1.5.6">
                         <label>1938 ed. 1.5.6</label>
                         <caesura/>
-                         ato 'nyatamaṃ karma cikīrṣatā vaidyena pūrvamevopakalpayitavyāni
-                        bhavanti, tad yathā-
+                         ato 'nyatamaṃ karma cikīrṣatā vaidyena pūrvamevopakalpayitavyāni bhavanti,
+                        tad yathā-
                         yantraśastrakṣārāgniśalākāśṛṅgajalaukālābūjāmbavauṣṭhapicuprotasūtrapatrapaṭṭamadhughṛtavasāpayastaila-
-                        tarpaṇakaṣāyālepanakalkavyajanaśītoṣṇodakakaṭāhādīni, parikarmiṇaś
-                        ca snigdhāḥ sthirā balavantaḥ ||6|| </l>
+                        tarpaṇakaṣāyālepanakalkavyajanaśītoṣṇodakakaṭāhādīni, parikarmiṇaś ca
+                        snigdhāḥ sthirā balavantaḥ ||6|| </l>
 
                     <l xml:id="SS.1.5.7">
                         <label>1938 ed. 1.5.7</label>
                         <caesura/>
                          tataḥ praśasteṣu tithikaraṇamuhūrtanakṣatreṣu
                         dadhyakṣatānnapānaratnairagniṃ viprān bhiṣajaś cārcayitvā,
-                        kṛtabalimaṅgalasvastivācanaṃ laghubhuktavantaṃ prāṅmukhamāturam
-                        upaveśya , yantrayitvā , pratyaṅmukho vaidyo
-                        marmasirāsnāyusandhyasthidhamanīḥ pariharan, anulomaṃ śastraṃ
-                        nidadhyādāpūyadarśanāt , sakṛdevāpaharecchastramāśu ca; mahatsvapi
-                        ca pākeṣu dvyaṅgulāntaraṃ tryaṅgulāntaraṃ vā śastrapadam uktam
-                        ||7|| </l>
+                        kṛtabalimaṅgalasvastivācanaṃ laghubhuktavantaṃ prāṅmukhamāturam upaveśya ,
+                        yantrayitvā , pratyaṅmukho vaidyo marmasirāsnāyusandhyasthidhamanīḥ
+                        pariharan, anulomaṃ śastraṃ nidadhyādāpūyadarśanāt ,
+                        sakṛdevāpaharecchastramāśu ca; mahatsvapi ca pākeṣu dvyaṅgulāntaraṃ
+                        tryaṅgulāntaraṃ vā śastrapadam uktam ||7|| </l>
 
                     <l xml:id="SS.1.5.8">
                         <label>1938 ed. 1.5.8</label>
@@ -1150,8 +1113,8 @@
                     <l xml:id="SS.1.5.11">
                         <label>1938 ed. 1.5.11</label>
                         <caesura/>
-                         ekena vā vraṇenāśudhyamāne nā'ntarā buddhyā'vekṣyāparān vraṇān
-                        kuryāt ||11|| </l>
+                         ekena vā vraṇenāśudhyamāne nā'ntarā buddhyā'vekṣyāparān vraṇān kuryāt
+                        ||11|| </l>
 
                     <l xml:id="SS.1.5.12">
                         <label>1938 ed. 1.5.12</label>
@@ -1165,8 +1128,7 @@
                     <l xml:id="SS.1.5.13">
                         <label>1938 ed. 1.5.13</label>
                         <caesura/>
-                         tatra
-                        bhrūgaṇḍaśaṅkhalalāṭākṣipuṭauṣṭhadantaveṣṭakakṣākukṣivaṅkṣaṇeṣu
+                         tatra bhrūgaṇḍaśaṅkhalalāṭākṣipuṭauṣṭhadantaveṣṭakakṣākukṣivaṅkṣaṇeṣu
                         tiryak cheda uktaḥ ||13|| </l>
 
                     <l xml:id="SS.1.5.14">
@@ -1179,24 +1141,23 @@
                     <l xml:id="SS.1.5.15">
                         <label>1938 ed. 1.5.15</label>
                         <caesura/>
-                         anyathā tu sirāsnāyucchedanam, atimātraṃ vedanā,
-                        cirādvraṇasaṃroho, māṃsakandīprādurbhāvaśceti ||15|| </l>
+                         anyathā tu sirāsnāyucchedanam, atimātraṃ vedanā, cirādvraṇasaṃroho,
+                        māṃsakandīprādurbhāvaśceti ||15|| </l>
 
                     <l xml:id="SS.1.5.16">
                         <label>1938 ed. 1.5.16</label>
                         <caesura/>
-                         mūḍhagarbhodarārśo 'śmarībhagandaramukharogeṣv abhuktavataḥ karma
-                        kurvīta ||16|| </l>
+                         mūḍhagarbhodarārśo 'śmarībhagandaramukharogeṣv abhuktavataḥ karma kurvīta
+                        ||16|| </l>
 
                     <l xml:id="SS.1.5.17">
                         <label>1938 ed. 1.5.17</label>
                         <caesura/>
                          tataḥ śastramavacārya,śītābhir adbhir āturamāśvāsya, samantāt
-                        paripīḍyāṅgulyā, vraṇamabhimṛdya(jya), prakṣālya kaṣāyeṇa
-                        protenodakamādāya , tilakalkamadhusarpiḥpragāḍhāmauṣadhayuktāṃ
-                        nātisnigdhāṃ nātirūkṣāṃ vartiṃ praṇidadhyāt; tataḥ kalkenācchādya,
-                        ghanāṃ kavalikāṃ dattvā, vastrapaṭṭena badhnīyāt;
-                        vedanārakṣoghnairdhūpairdhūpayet, rakṣoghnaiś ca mantrai rakṣāṃ
+                        paripīḍyāṅgulyā, vraṇamabhimṛdya(jya), prakṣālya kaṣāyeṇa protenodakamādāya
+                        , tilakalkamadhusarpiḥpragāḍhāmauṣadhayuktāṃ nātisnigdhāṃ nātirūkṣāṃ vartiṃ
+                        praṇidadhyāt; tataḥ kalkenācchādya, ghanāṃ kavalikāṃ dattvā, vastrapaṭṭena
+                        badhnīyāt; vedanārakṣoghnairdhūpairdhūpayet, rakṣoghnaiś ca mantrai rakṣāṃ
                         kurvīta ||17|| </l>
 
                     <l xml:id="SS.1.5.18">
@@ -1209,8 +1170,7 @@
                     <l xml:id="SS.1.5.19">
                         <label>1938 ed. 1.5.19</label>
                         <caesura/>
-                         udakumbhāccāpo gṛhītvā prokṣayan rakṣākarma kuryāt ;
-                        tadvakṣyāmaḥ- ||19|| </l>
+                         udakumbhāccāpo gṛhītvā prokṣayan rakṣākarma kuryāt ; tadvakṣyāmaḥ- ||19|| </l>
 
                     <l xml:id="SS.1.5.20">
                         <label>1938 ed. 1.5.20</label>
@@ -1264,8 +1224,8 @@
                     <l xml:id="SS.1.5.27">
                         <label>1938 ed. 1.5.27</label>
                         <caesura/>
-                         cakṣuḥ sūryo diśaḥ śrotre candramāḥ pātu te manaḥ | nakṣatrāṇi
-                        sadā rūpaṃ chāyāṃ pāntu niśāstava ||27|| </l>
+                         cakṣuḥ sūryo diśaḥ śrotre candramāḥ pātu te manaḥ | nakṣatrāṇi sadā rūpaṃ
+                        chāyāṃ pāntu niśāstava ||27|| </l>
 
                     <l xml:id="SS.1.5.28">
                         <label>1938 ed. 1.5.28</label>
@@ -1321,27 +1281,26 @@
                     <l xml:id="SS.1.5.35">
                         <label>1938 ed. 1.5.35</label>
                         <caesura/>
-                         tatastṛtīye 'hani vimucyaivam eva badhnīyād vastrapaṭṭena; na
-                        cainaṃ tvaramāṇo 'paredyur mokṣayet ||35|| </l>
+                         tatastṛtīye 'hani vimucyaivam eva badhnīyād vastrapaṭṭena; na cainaṃ
+                        tvaramāṇo 'paredyur mokṣayet ||35|| </l>
 
                     <l xml:id="SS.1.5.36">
                         <label>1938 ed. 1.5.36</label>
                         <caesura/>
-                         dvitīyadivasaparimokṣaṇād vigrathito vraṇaś cirād upasaṃrohati,
-                        tīvrarujaś ca bhavati ||36|| </l>
+                         dvitīyadivasaparimokṣaṇād vigrathito vraṇaś cirād upasaṃrohati, tīvrarujaś
+                        ca bhavati ||36|| </l>
 
                     <l xml:id="SS.1.5.37">
                         <label>1938 ed. 1.5.37</label>
                         <caesura/>
-                         ata ūrdhvaṃ doṣakālabalādīn avekṣya kaṣāyālepanabandhāhārācārān
-                        vidadhyāt ||37|| </l>
+                         ata ūrdhvaṃ doṣakālabalādīn avekṣya kaṣāyālepanabandhāhārācārān vidadhyāt
+                        ||37|| </l>
 
                     <l xml:id="SS.1.5.38">
                         <label>1938 ed. 1.5.38</label>
                         <caesura/>
-                         na cainaṃ tvaramāṇaḥ sāntardoṣaṃ ropayet; sa hy
-                        alpenāpyapacāreṇābhyantaram utsaṅgaṃ kṛtvā bhūyo 'pi vikaroti
-                        ||38|| </l>
+                         na cainaṃ tvaramāṇaḥ sāntardoṣaṃ ropayet; sa hy alpenāpyapacāreṇābhyantaram
+                        utsaṅgaṃ kṛtvā bhūyo 'pi vikaroti ||38|| </l>
 
                     <l xml:id="SS.1.5.39abcd">
                         <label>1938 ed. 1.5.39abcd</label>
@@ -1378,8 +1337,8 @@
                         <caesura/>
                          dhṛtena sā śāntim upaiti siktā koṣṇena yaṣṭīmadhukānvitenā ||42|| </l>
 
-                    <p ana="trailer">iti suśrutasaṃhitāyāṃ sūtrasthāne 'gropaharaṇīyo nāma
-                        pañcamo 'dhyāyaḥ ||5|| </p>
+                    <p ana="trailer">iti suśrutasaṃhitāyāṃ sūtrasthāne 'gropaharaṇīyo nāma pañcamo
+                        'dhyāyaḥ ||5|| </p>
                 </div>
                 <div n="6" type="adhyāya">
                     <head>śaṣṭho 'dhyāyaḥ |</head>
@@ -1397,9 +1356,8 @@
                         <label>1938 ed. 1.6.3</label>
                         <caesura/>
                          kālo hi nāma (bhagavān ) svayambhur anādimadhyanidhanaḥ | atra
-                        rasavyāpatsampattī jīvitamaraṇe ca manuṣyāṇāmāyatte | sa sūkṣmām
-                        api kalāṃ na līyata iti kālaḥ, saṅkalayati kālayati vā bhūtānīti
-                        kālaḥ ||3|| </l>
+                        rasavyāpatsampattī jīvitamaraṇe ca manuṣyāṇāmāyatte | sa sūkṣmām api kalāṃ
+                        na līyata iti kālaḥ, saṅkalayati kālayati vā bhūtānīti kālaḥ ||3|| </l>
 
                     <l xml:id="SS.1.6.4">
                         <label>1938 ed. 1.6.4</label>
@@ -1411,31 +1369,28 @@
                     <l xml:id="SS.1.6.5">
                         <label>1938 ed. 1.6.5</label>
                         <caesura/>
-                         tatra laghvakṣaroccāraṇamātro 'kṣinimeṣaḥ, pañcadaśā'kṣinimeṣāḥ
-                        kāṣṭhā, triṃśatkāṣṭhāḥ kalā, viṃśatikalo muhūrtaḥ
-                        kalādaśabhāgaśca, triṃśanmuhūrtamahorātraṃ, pañcadaśāhorātrāṇi
-                        pakṣaḥ, sa ca dvividhaḥ- śuklaḥ kṛṣṇaśca, tau māsaḥ ||5|| </l>
+                         tatra laghvakṣaroccāraṇamātro 'kṣinimeṣaḥ, pañcadaśā'kṣinimeṣāḥ kāṣṭhā,
+                        triṃśatkāṣṭhāḥ kalā, viṃśatikalo muhūrtaḥ kalādaśabhāgaśca,
+                        triṃśanmuhūrtamahorātraṃ, pañcadaśāhorātrāṇi pakṣaḥ, sa ca dvividhaḥ- śuklaḥ
+                        kṛṣṇaśca, tau māsaḥ ||5|| </l>
 
                     <l xml:id="SS.1.6.6">
                         <label>1938 ed. 1.6.6</label>
                         <caesura/>
-                         tatra māghādayo dvādaśa māsāḥ, dvimāsikamṛtuṃ kṛtvā ṣaḍṛtavo
-                        bhavanti; te śiśiravasantagrīṣmavarṣāśaraddhemantāḥ | teṣāṃ
-                        tapastapasyau śiśiraḥ, madhumādhavau vasantaḥ, śuciśukrau grīṣmaḥ,
-                        nabhonabhasyau varṣāḥ, iṣorjau śarat, sahaḥsahasyau hemanta iti
-                        ||6|| </l>
+                         tatra māghādayo dvādaśa māsāḥ, dvimāsikamṛtuṃ kṛtvā ṣaḍṛtavo bhavanti; te
+                        śiśiravasantagrīṣmavarṣāśaraddhemantāḥ | teṣāṃ tapastapasyau śiśiraḥ,
+                        madhumādhavau vasantaḥ, śuciśukrau grīṣmaḥ, nabhonabhasyau varṣāḥ, iṣorjau
+                        śarat, sahaḥsahasyau hemanta iti ||6|| </l>
 
                     <l xml:id="SS.1.6.7">
                         <label>1938 ed. 1.6.7</label>
                         <caesura/>
-                         ta ete śītoṣṇavarṣalakṣaṇāś candrād ity ayoḥ kālavibhāgakaratvād
-                        ayane dve bhavato dakṣiṇam uttaraṃ ca | tayor dakṣiṇaṃ
-                        varṣāśaraddhemantāḥ; teṣu bhagavān āpyāyate somaḥ,
-                        amlalavaṇamadhurāś ca rasā balavanto bhavanti, uttarottaraṃ ca
-                        sarvaprāṇināṃ balam abhivardhate | uttaraṃ ca
-                        śiśiravasantagrīṣmāḥ, teṣu bhagavān āpyāyate 'rkaḥ,
-                        tiktakaṣāyakaṭukāś ca rasā balavanto bhavanti, uttarottaraṃ ca
-                        sarvaprāṇināṃ balam upahīyate ||7|| </l>
+                         ta ete śītoṣṇavarṣalakṣaṇāś candrād ity ayoḥ kālavibhāgakaratvād ayane dve
+                        bhavato dakṣiṇam uttaraṃ ca | tayor dakṣiṇaṃ varṣāśaraddhemantāḥ; teṣu
+                        bhagavān āpyāyate somaḥ, amlalavaṇamadhurāś ca rasā balavanto bhavanti,
+                        uttarottaraṃ ca sarvaprāṇināṃ balam abhivardhate | uttaraṃ ca
+                        śiśiravasantagrīṣmāḥ, teṣu bhagavān āpyāyate 'rkaḥ, tiktakaṣāyakaṭukāś ca
+                        rasā balavanto bhavanti, uttarottaraṃ ca sarvaprāṇināṃ balam upahīyate ||7|| </l>
 
                     <l xml:id="SS.1.6.8">
                         <label>1938 ed. 1.6.8</label>
@@ -1449,63 +1404,58 @@
                     <l xml:id="SS.1.6.9">
                         <label>1938 ed. 1.6.9</label>
                         <caesura/>
-                         atha khalv ayane dve yugapat saṃvatsaro bhavati | te tu pañca
-                        yugam iti sañjñāṃ labhante | sa eṣa nimeṣādir yugaparyantaḥ kālaś
-                        cakravat parivartamānaḥ kālacakram ity ucyata ity eke ||9|| </l>
+                         atha khalv ayane dve yugapat saṃvatsaro bhavati | te tu pañca yugam iti
+                        sañjñāṃ labhante | sa eṣa nimeṣādir yugaparyantaḥ kālaś cakravat
+                        parivartamānaḥ kālacakram ity ucyata ity eke ||9|| </l>
 
                     <l xml:id="SS.1.6.10">
                         <label>1938 ed. 1.6.10</label>
                         <caesura/>
                          iha tu varṣāśaraddhemantavasantagrīṣmaprāvṛṣaḥ ṣaḍṛtavo bhavanti,
                         doṣopacayaprakopopaśamanimittaṃ; te tu bhādrapadādyena dvimāsikena
-                        vyākhyātāḥ; tad yathā- bhādrapadāśvayujau varṣāḥ,
-                        kārtikamārgaśīrṣau śarat, pauṣamāghau hemantaḥ, phālgunacaitrau
-                        vasantaḥ, vaiśākhajyeṣṭhau grīṣmaḥ; āṣāḍhaśrāvaṇau prāvṛḍiti
-                        ||10|| </l>
+                        vyākhyātāḥ; tad yathā- bhādrapadāśvayujau varṣāḥ, kārtikamārgaśīrṣau śarat,
+                        pauṣamāghau hemantaḥ, phālgunacaitrau vasantaḥ, vaiśākhajyeṣṭhau grīṣmaḥ;
+                        āṣāḍhaśrāvaṇau prāvṛḍiti ||10|| </l>
 
                     <l xml:id="SS.1.6.11">
                         <label>1938 ed. 1.6.11</label>
                         <caesura/>
-                         tatra, varṣāsvoṣadhayastaruṇyo 'lpavīryā āpaś cāpraśāntāḥ
-                        kṣitimalaprāyāḥ, tā upayujyamānā nabhasi meghāvatate
-                        jalapraklinnāyāṃ bhūmau klinnadehānāṃ prāṇināṃ
-                        śītavātaviṣṭambhitāgnīnāṃ vidahyante, vidāhāt
-                        pittasañcayamāpādayanti; sa sañcayaḥ śaradi praviralameghe viyaty
-                        upaśuṣyati paṅke 'rkakiraṇapravilāyitaḥ paittikān vyādhīñjanayati
-                        | tā evauṣadhayaḥ kālapariṇāmāt pariṇatavīryā balavatyo hemante
-                        bhavantyāpaś ca praśāntāḥ snigdhā atyarthaṃ gurvyāśca, tā
-                        upayujyamānā mandakiraṇatvād bhānoḥ
-                        satuṣārapavanopastambhitadehānāṃ dehināmavidagdhāḥ snehācchaityād
-                        gauravād upalepāc ca śleṣmasañcayamāpādayanti; sa sañcayo vasante
-                        'rkaraśmipravilāyita īṣatstabdhadehānāṃ dehināṃ ślaiṣmikān
-                        vyādhīñjanayati | tā evauṣadhayo nidāghe niḥsārā rūkṣā atimātraṃ
-                        laghvyo bhavantyāpaśca, tā upayujyamānāḥ
-                        sūryapratāpopaśoṣitadehānāṃ dehināṃ raukṣyāllaghutvāc ca vāyoḥ
-                        sañcayamāpādayanti; sa sañcayaḥ prāvṛṣi cātyarthaṃ jalopaklinnāyāṃ
-                        bhūmau klinnadehānāṃ dehināṃ śītavātavarṣerito vātikān
-                        vyādhīñjanayati | evam eṣa doṣāṇāṃ sañcayaprakopahetur uktaḥ
-                        ||11|| </l>
+                         tatra, varṣāsvoṣadhayastaruṇyo 'lpavīryā āpaś cāpraśāntāḥ kṣitimalaprāyāḥ,
+                        tā upayujyamānā nabhasi meghāvatate jalapraklinnāyāṃ bhūmau klinnadehānāṃ
+                        prāṇināṃ śītavātaviṣṭambhitāgnīnāṃ vidahyante, vidāhāt
+                        pittasañcayamāpādayanti; sa sañcayaḥ śaradi praviralameghe viyaty upaśuṣyati
+                        paṅke 'rkakiraṇapravilāyitaḥ paittikān vyādhīñjanayati | tā evauṣadhayaḥ
+                        kālapariṇāmāt pariṇatavīryā balavatyo hemante bhavantyāpaś ca praśāntāḥ
+                        snigdhā atyarthaṃ gurvyāśca, tā upayujyamānā mandakiraṇatvād bhānoḥ
+                        satuṣārapavanopastambhitadehānāṃ dehināmavidagdhāḥ snehācchaityād gauravād
+                        upalepāc ca śleṣmasañcayamāpādayanti; sa sañcayo vasante
+                        'rkaraśmipravilāyita īṣatstabdhadehānāṃ dehināṃ ślaiṣmikān vyādhīñjanayati |
+                        tā evauṣadhayo nidāghe niḥsārā rūkṣā atimātraṃ laghvyo bhavantyāpaśca, tā
+                        upayujyamānāḥ sūryapratāpopaśoṣitadehānāṃ dehināṃ raukṣyāllaghutvāc ca vāyoḥ
+                        sañcayamāpādayanti; sa sañcayaḥ prāvṛṣi cātyarthaṃ jalopaklinnāyāṃ bhūmau
+                        klinnadehānāṃ dehināṃ śītavātavarṣerito vātikān vyādhīñjanayati | evam eṣa
+                        doṣāṇāṃ sañcayaprakopahetur uktaḥ ||11|| </l>
 
                     <l xml:id="SS.1.6.12">
                         <label>1938 ed. 1.6.12</label>
                         <caesura/>
-                         tatra varṣāhemantagrīṣmeṣu sañcitānāṃ doṣāṇāṃ
-                        śaradvasantaprāvṛṭsu ca prakupitānāṃ nirharaṇaṃ kartavyam ||12|| </l>
+                         tatra varṣāhemantagrīṣmeṣu sañcitānāṃ doṣāṇāṃ śaradvasantaprāvṛṭsu ca
+                        prakupitānāṃ nirharaṇaṃ kartavyam ||12|| </l>
 
                     <l xml:id="SS.1.6.13">
                         <label>1938 ed. 1.6.13</label>
                         <caesura/>
-                         tatra paittikānāṃ vyādhīnām upaśamo hemante, ślaiṣmikāṇāṃ
-                        nidāghe, vātikānāṃ śaradi , svabhāvata eva; ta ete
-                        sañcayaprakopopaśamā vyākhyātāḥ ||13|| </l>
+                         tatra paittikānāṃ vyādhīnām upaśamo hemante, ślaiṣmikāṇāṃ nidāghe,
+                        vātikānāṃ śaradi , svabhāvata eva; ta ete sañcayaprakopopaśamā vyākhyātāḥ
+                        ||13|| </l>
 
                     <l xml:id="SS.1.6.14">
                         <label>1938 ed. 1.6.14</label>
                         <caesura/>
-                         tatra, pūrvāhṇe vasantasya liṅgaṃ, madhyāhne grīṣmasya, aparāhṇe
-                        prāvṛṣaḥ , pradoṣe vārṣikaṃ, śāradam ardharātre, pratyuṣasi
-                        haimantam upalakṣayet; evam ahorātram api varṣam iva
-                        śītoṣṇavarṣalakṣaṇaṃ doṣopacayaprakopopaśamair jānīyāt ||14|| </l>
+                         tatra, pūrvāhṇe vasantasya liṅgaṃ, madhyāhne grīṣmasya, aparāhṇe prāvṛṣaḥ ,
+                        pradoṣe vārṣikaṃ, śāradam ardharātre, pratyuṣasi haimantam upalakṣayet; evam
+                        ahorātram api varṣam iva śītoṣṇavarṣalakṣaṇaṃ doṣopacayaprakopopaśamair
+                        jānīyāt ||14|| </l>
 
                     <l xml:id="SS.1.6.15">
                         <label>1938 ed. 1.6.15</label>
@@ -1533,10 +1483,9 @@
                         <label>1938 ed. 1.6.19</label>
                         <caesura/>
                          kadācid avyāpanneṣv api ṛtuṣu kṛtyābhiśāparakṣaḥkrodhādharmair
-                        upadhvasyante janapadāḥ, viṣauṣadhipuṣpagandhena vā
-                        vāyunopanītenākramyate yo deśas tatra doṣaprakṛtyaviśeṣeṇa
-                        kāsaśvāsavamathupratiśyāyaśirorugjvarair upatapyante,
-                        grahanakṣatracaritair vā,
+                        upadhvasyante janapadāḥ, viṣauṣadhipuṣpagandhena vā vāyunopanītenākramyate
+                        yo deśas tatra doṣaprakṛtyaviśeṣeṇa kāsaśvāsavamathupratiśyāyaśirorugjvarair
+                        upatapyante, grahanakṣatracaritair vā,
                         gṛhadāraśayanāsanayānavāhanamaṇiratnopakaraṇagarhitalakṣaṇanimittaprādurbhāvair
                         vā ||19|| </l>
 
@@ -1545,8 +1494,8 @@
                         <caesura/>
                          tatra,
                         sthānaparityāgaśāntikarmaprāyaścittamaṅgalajapahomopahārejyāñjalinamaskārataponiyama-
-                        dayādānadīkṣābhyupagamadevatābrāhmaṇaguruparairbhavitavyam, evaṃ
-                        sādhu bhavati ||20|| </l>
+                        dayādānadīkṣābhyupagamadevatābrāhmaṇaguruparairbhavitavyam, evaṃ sādhu
+                        bhavati ||20|| </l>
 
                     <l xml:id="SS.1.6.21">
                         <label>1938 ed. 1.6.21</label>
@@ -1675,8 +1624,7 @@
                     <l xml:id="SS.1.6.trailer">
                         <label>1938 ed. 1.6.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne ṛtucaryā nāma ṣaṣṭho 'dhyāyaḥ
-                        ||6|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne ṛtucaryā nāma ṣaṣṭho 'dhyāyaḥ ||6|| </l>
                 </div>
 
                 <div n="7" type="adhyāya">
@@ -1696,15 +1644,14 @@
                     <l xml:id="SS.1.7.3">
                         <label>1938 ed. 1.7.3</label>
                         <caesura/>
-                         yantraśatam ekottaram; atra hastameva pradhānatamaṃ yantrāṇām
-                        avagaccha, (kiṃ kāraṇaṃ ? yasmādd hastād ṛte yantrāṇām
-                        apravṛttireva) tadadhīnatvād yantrakarmaṇām ||3|| </l>
+                         yantraśatam ekottaram; atra hastameva pradhānatamaṃ yantrāṇām avagaccha,
+                        (kiṃ kāraṇaṃ ? yasmādd hastād ṛte yantrāṇām apravṛttireva) tadadhīnatvād
+                        yantrakarmaṇām ||3|| </l>
 
                     <l xml:id="SS.1.7.4">
                         <label>1938 ed. 1.7.4</label>
                         <caesura/>
-                         tatra, manaḥśarīrābādhakarāṇi śalyāni; teṣāṃ āharaṇopāyo yantrāṇi
-                        ||4|| </l>
+                         tatra, manaḥśarīrābādhakarāṇi śalyāni; teṣāṃ āharaṇopāyo yantrāṇi ||4|| </l>
 
                     <l xml:id="SS.1.7.5">
                         <label>1938 ed. 1.7.5</label>
@@ -1715,23 +1662,21 @@
                     <l xml:id="SS.1.7.6">
                         <label>1938 ed. 1.7.6</label>
                         <caesura/>
-                         tatra caturviṃśatiḥ svastikayantrāṇi , dve sandaṃśayantre, dve
-                        eva tālayantre, viṃśatirnāḍyaḥ, aṣṭāviṃśatiḥ śalākāḥ,
-                        pañcaviṃśatirupayantrāṇi ||6|| </l>
+                         tatra caturviṃśatiḥ svastikayantrāṇi , dve sandaṃśayantre, dve eva
+                        tālayantre, viṃśatirnāḍyaḥ, aṣṭāviṃśatiḥ śalākāḥ, pañcaviṃśatirupayantrāṇi
+                        ||6|| </l>
 
                     <l xml:id="SS.1.7.7">
                         <label>1938 ed. 1.7.7</label>
                         <caesura/>
-                         tāni prāyaśo lauhāni bhavanti; tatpratirūpakāṇi vā tadalābhe
-                        ||7|| </l>
+                         tāni prāyaśo lauhāni bhavanti; tatpratirūpakāṇi vā tadalābhe ||7|| </l>
 
                     <l xml:id="SS.1.7.8">
                         <label>1938 ed. 1.7.8</label>
                         <caesura/>
-                         tatra, nānāprakārāṇāṃ vyālānāṃ mṛgapakṣiṇāṃ mukhair mukhāni
-                        yantrāṇāṃ prāyaśaḥ sadṛśāni; tasmāt
-                        tatsārūpyādāgamādupadeśādanyayantradarśanādyuktitaś ca kārayet
-                        ||8|| </l>
+                         tatra, nānāprakārāṇāṃ vyālānāṃ mṛgapakṣiṇāṃ mukhair mukhāni yantrāṇāṃ
+                        prāyaśaḥ sadṛśāni; tasmāt
+                        tatsārūpyādāgamādupadeśādanyayantradarśanādyuktitaś ca kārayet ||8|| </l>
 
                     <l xml:id="SS.1.7.9">
                         <label>1938 ed. 1.7.9</label>
@@ -1747,8 +1692,8 @@
                         siṃhavyāghravṛkatarakṣvṛkṣadvīpimārjāraśṛgālamṛgair
                         vārukakākakaṅkakuraracāsabhāsaśaśaghātyulūkacilliśyena-
                         gṛdhrakrauñcabhṛṅgarājāñjalikarṇāvabhañjananandīmukhamukhāni ,
-                        masūrākṛtibhiḥ kīlair avabaddhāni , mūle 'ṅkuśavadāvṛttavāraṅgāṇi
-                        , asthividaṣṭaśalyoddharaṇārtham upadiśyante ||10|| </l>
+                        masūrākṛtibhiḥ kīlair avabaddhāni , mūle 'ṅkuśavadāvṛttavāraṅgāṇi ,
+                        asthividaṣṭaśalyoddharaṇārtham upadiśyante ||10|| </l>
 
                     <l xml:id="SS.1.7.11">
                         <label>1938 ed. 1.7.11</label>
@@ -1775,17 +1720,15 @@
                     <l xml:id="SS.1.7.14">
                         <label>1938 ed. 1.7.14</label>
                         <caesura/>
-                         śalākāyantrāṇyapi nānāprakārāṇi, nānāprayojanāni,
-                        yathāyogapariṇāhadīrghāṇi ca; teṣāṃ
-                        gaṇḍūpadasarpaphaṇaśarapuṅkhabaḍiśamukhe dve dve,
-                        eṣaṇavyūhanacālanāharaṇārtham upadiśyete ; masūradalamātramukhe
-                        dve kiñcidānatāgre srotogataśalyoddharaṇārthaṃ; ṣaṭ
-                        kārpāsakṛtoṣṇīṣāṇi , pramārjanakriyāsu; trīṇi darvyākṛtīni
-                        khallamukhāni, kṣārauṣadhapraṇidhānārthaṃ ; trīṇyanyāni
-                        jāmbavavadanāni, trīṇyaṅkuśavadanāni, ṣaḍevāgnikarmasvabhipretāni;
-                        nāsārbudaharaṇārthamekaṃ kolāsthidalamātramukhaṃ
-                        khallatīkṣṇauṣṭhaṃ ; añjanārthamekaṃ kalāyaparimaṇḍalamubhayato
-                        mukulāgraṃ; mūtramārgaviśodhanārthamekaṃ
+                         śalākāyantrāṇyapi nānāprakārāṇi, nānāprayojanāni, yathāyogapariṇāhadīrghāṇi
+                        ca; teṣāṃ gaṇḍūpadasarpaphaṇaśarapuṅkhabaḍiśamukhe dve dve,
+                        eṣaṇavyūhanacālanāharaṇārtham upadiśyete ; masūradalamātramukhe dve
+                        kiñcidānatāgre srotogataśalyoddharaṇārthaṃ; ṣaṭ kārpāsakṛtoṣṇīṣāṇi ,
+                        pramārjanakriyāsu; trīṇi darvyākṛtīni khallamukhāni,
+                        kṣārauṣadhapraṇidhānārthaṃ ; trīṇyanyāni jāmbavavadanāni,
+                        trīṇyaṅkuśavadanāni, ṣaḍevāgnikarmasvabhipretāni; nāsārbudaharaṇārthamekaṃ
+                        kolāsthidalamātramukhaṃ khallatīkṣṇauṣṭhaṃ ; añjanārthamekaṃ
+                        kalāyaparimaṇḍalamubhayato mukulāgraṃ; mūtramārgaviśodhanārthamekaṃ
                         mālatīpuṣpavṛntāgrapramāṇaparimaṇḍalam iti ||14|| </l>
 
                     <l xml:id="SS.1.7.15">
@@ -1821,9 +1764,9 @@
                     <l xml:id="SS.1.7.19">
                         <label>1938 ed. 1.7.19</label>
                         <caesura/>
-                         tatra, atisthūlam, asāram, atidīrgham, atihrasvam, agrāhi,
-                        viṣamagrāhi, vakraṃ, śithilam, atyunnatam, mṛdukīlaṃ, mṛdumukhaṃ,
-                        mṛdupāśam, iti dvādaśa yantradoṣāḥ ||19|| </l>
+                         tatra, atisthūlam, asāram, atidīrgham, atihrasvam, agrāhi, viṣamagrāhi,
+                        vakraṃ, śithilam, atyunnatam, mṛdukīlaṃ, mṛdumukhaṃ, mṛdupāśam, iti dvādaśa
+                        yantradoṣāḥ ||19|| </l>
 
                     <l xml:id="SS.1.7.20">
                         <label>1938 ed. 1.7.20</label>
@@ -1842,14 +1785,13 @@
                     <l xml:id="SS.1.7.22">
                         <label>1938 ed. 1.7.22</label>
                         <caesura/>
-                         ni(vi)vartate sādhvavagāhate ca śalyaṃ nigṛhyoddharate ca yasmāt
-                        |
+                         ni(vi)vartate sādhvavagāhate ca śalyaṃ nigṛhyoddharate ca yasmāt |
                         <caesura/>
-                         yantreṣv ataḥ kaṅkamukhaṃ pradhānaṃ sthāneṣu sarveṣv adhi(vi)kāri
-                        caiva ||22|| </l>
+                         yantreṣv ataḥ kaṅkamukhaṃ pradhānaṃ sthāneṣu sarveṣv adhi(vi)kāri caiva
+                        ||22|| </l>
 
-                    <l xml:id="SS.1.7.trailer"> iti suśrutasaṃhitāyāṃ sūtrasthāne
-                        yantravidhirnāma saptamo 'dhyāyaḥ ||7|| </l>
+                    <l xml:id="SS.1.7.trailer"> iti suśrutasaṃhitāyāṃ sūtrasthāne yantravidhirnāma
+                        saptamo 'dhyāyaḥ ||7|| </l>
 
                 </div>
 
@@ -1877,26 +1819,23 @@
                         <label>1938 ed. 1.8.4</label>
                         <caesura/>
                          tatra maṇḍalāgrakarapatre syātāṃ chedane lekhane ca,
-                        vṛddhipatranakhaśastramudrikotpalapatrakārdhadhārāṇi chedane
-                        bhedane ca,
-                        sūcīkuśapatrāṭī(ṭā)mukhaśarārimukhāntarmukhatrikūrcakāni
-                        visrāvaṇe, kuṭhārikāvrīhimukhārāvetasapatrakāṇi vyadhane sūcī ca,
-                        baḍiśaṃ dantaśaṅkuś cāharaṇe, eṣaṇyeṣaṇe ānulomye ca, sūcyaḥ
-                        sīvane; ity aṣṭavidhe karmaṇyupayogaḥ śastrāṇāṃ vyākhyātaḥ ||4|| </l>
+                        vṛddhipatranakhaśastramudrikotpalapatrakārdhadhārāṇi chedane bhedane ca,
+                        sūcīkuśapatrāṭī(ṭā)mukhaśarārimukhāntarmukhatrikūrcakāni visrāvaṇe,
+                        kuṭhārikāvrīhimukhārāvetasapatrakāṇi vyadhane sūcī ca, baḍiśaṃ dantaśaṅkuś
+                        cāharaṇe, eṣaṇyeṣaṇe ānulomye ca, sūcyaḥ sīvane; ity aṣṭavidhe
+                        karmaṇyupayogaḥ śastrāṇāṃ vyākhyātaḥ ||4|| </l>
 
                     <l xml:id="SS.1.8.5">
                         <label>1938 ed. 1.8.5</label>
                         <caesura/>
                          teṣāṃ atha yathāyogaṃ grahaṇasamāsopāyaḥ karmasu vakṣyate- tatra
-                        vṛddhipatraṃ vṛntaphalasādhāraṇe bhāge gṛhṇīyāt, bhedanānyevaṃ
-                        sarvāṇi, vṛddhipatraṃ maṇḍalāgraṃ ca kiñciduttānena pāṇinā lekhane
-                        bahuśo 'vacāryaṃ, vṛntāgre visrāvaṇāni, viśeṣeṇa tu
-                        bālavṛddhasukumārabhīrunārīṇāṃ rājñāṃ rājamā(pu)trāṇāṃ ca
-                        trikūrcakena visrāvayet,
-                        talapracchāditavṛntamaṅguṣṭhapradeśinībhyāṃ vrīhimukhaṃ,
-                        kuṭhārikāṃ
-                        vāmahastanyastāmitarahastamadhyamāṅgulyā'ṅguṣṭhaviṣṭabdhayā'bhihanyāt
-                        , ārākarapatraiṣaṇyo mūle, śeṣāṇi tu yathāyogaṃ gṛhṇīyāt ||5|| </l>
+                        vṛddhipatraṃ vṛntaphalasādhāraṇe bhāge gṛhṇīyāt, bhedanānyevaṃ sarvāṇi,
+                        vṛddhipatraṃ maṇḍalāgraṃ ca kiñciduttānena pāṇinā lekhane bahuśo 'vacāryaṃ,
+                        vṛntāgre visrāvaṇāni, viśeṣeṇa tu bālavṛddhasukumārabhīrunārīṇāṃ rājñāṃ
+                        rājamā(pu)trāṇāṃ ca trikūrcakena visrāvayet,
+                        talapracchāditavṛntamaṅguṣṭhapradeśinībhyāṃ vrīhimukhaṃ, kuṭhārikāṃ
+                        vāmahastanyastāmitarahastamadhyamāṅgulyā'ṅguṣṭhaviṣṭabdhayā'bhihanyāt ,
+                        ārākarapatraiṣaṇyo mūle, śeṣāṇi tu yathāyogaṃ gṛhṇīyāt ||5|| </l>
 
                     <l xml:id="SS.1.8.6">
                         <label>1938 ed. 1.8.6</label>
@@ -1907,41 +1846,37 @@
                         <label>1938 ed. 1.8.7</label>
                         <caesura/>
                          tatra nakhaśastraiṣaṇyāvaṣṭāṅgule , sūcyo vakṣyante,
-                        (pradeśinyagraparvapradeśapramāṇā mudrikā, daśāṅgulā śarārimukhī
-                        sā ca (yā sā) kartarīti kathyate) | śeṣāṇi tu ṣaḍaṅgulāni ||7||
-                        tāni sugrahāṇi, sulohāni, sudhārāṇi, surūpāṇi,
-                        susamāhitamukhāgrāṇi, akarālāni, ceti śastrasampat ||8|| </l>
+                        (pradeśinyagraparvapradeśapramāṇā mudrikā, daśāṅgulā śarārimukhī sā ca (yā
+                        sā) kartarīti kathyate) | śeṣāṇi tu ṣaḍaṅgulāni ||7|| tāni sugrahāṇi,
+                        sulohāni, sudhārāṇi, surūpāṇi, susamāhitamukhāgrāṇi, akarālāni, ceti
+                        śastrasampat ||8|| </l>
 
 
                     <l xml:id="SS.1.8.9">
                         <label>1938 ed. 1.8.9</label>
                         <caesura/>
-                         tatra vakraṃ, kuṇṭhaṃ, khaṇḍaṃ, kharadhāram, atisthūlam,
-                        atyalpam, atidīrgham, atihrasvam, ity aṣṭau śastradoṣāḥ | ato
-                        viparītaguṇam ādadīta, anyatra karapatrāt; tad dhi kharadhāram
-                        asthicchedanārtham ||9|| </l>
+                         tatra vakraṃ, kuṇṭhaṃ, khaṇḍaṃ, kharadhāram, atisthūlam, atyalpam,
+                        atidīrgham, atihrasvam, ity aṣṭau śastradoṣāḥ | ato viparītaguṇam ādadīta,
+                        anyatra karapatrāt; tad dhi kharadhāram asthicchedanārtham ||9|| </l>
 
                     <l xml:id="SS.1.8.10">
                         <label>1938 ed. 1.8.10</label>
                         <caesura/>
-                         tatra dhārā bhedanānāṃ māsūrī, lekhanānām ardhamāsūrī,
-                        vyadhanānāṃ visrāvaṇānāṃ ca kaiśikī, chedanānām ardhakaiśikīti
-                        ||10|| </l>
+                         tatra dhārā bhedanānāṃ māsūrī, lekhanānām ardhamāsūrī, vyadhanānāṃ
+                        visrāvaṇānāṃ ca kaiśikī, chedanānām ardhakaiśikīti ||10|| </l>
 
                     <l xml:id="SS.1.8.11">
                         <label>1938 ed. 1.8.11</label>
                         <caesura/>
-                         baḍiśaṃ dantaśaṅkuś cānatāgre |
-                        tīkṣṇakaṇṭakaprathamayavapatramukhyeṣaṇī (gaṇḍūpadākāramukhī ca)
-                        ||11|| </l>
+                         baḍiśaṃ dantaśaṅkuś cānatāgre | tīkṣṇakaṇṭakaprathamayavapatramukhyeṣaṇī
+                        (gaṇḍūpadākāramukhī ca) ||11|| </l>
 
                     <l xml:id="SS.1.8.12">
                         <label>1938 ed. 1.8.12</label>
                         <caesura/>
                          teṣāṃ pāyanā trividhā kṣārodakataileṣu | tatra kṣārapāyitaṃ
-                        śaraśalyāsthicchedaneṣu, udakapāyitaṃ
-                        māṃsacchedanabhedanapāṭaneṣu, tailapāyitaṃ
-                        sirāvyadhanasnāyucchedaneṣu ||12|| </l>
+                        śaraśalyāsthicchedaneṣu, udakapāyitaṃ māṃsacchedanabhedanapāṭaneṣu,
+                        tailapāyitaṃ sirāvyadhanasnāyucchedaneṣu ||12|| </l>
 
                     <l xml:id="SS.1.8.13">
                         <label>1938 ed. 1.8.13</label>
@@ -2005,8 +1940,8 @@
                     <l xml:id="SS.1.8.trailer">
                         <label>1938 ed. 1.8.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne śastrāvacāraṇīyo nāmāṣṭamo
-                        'dhyāyaḥ ||8|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne śastrāvacāraṇīyo nāmāṣṭamo 'dhyāyaḥ ||8||
+                    </l>
                 </div>
                 <div n="9" type="adhyāya">
 
@@ -2023,26 +1958,23 @@
                     <l xml:id="SS.1.9.3">
                         <label>1938 ed. 1.9.3</label>
                         <caesura/>
-                         adhigatasarvaśāstrārtham api śiṣyaṃ yogyāṃ kārayet | snehādiṣu
-                        chedyādiṣu ca karmapatham upadiśet | subahuśruto 'pyakṛtayogyaḥ
-                        karmasvayogyo bhavati ||3|| </l>
+                         adhigatasarvaśāstrārtham api śiṣyaṃ yogyāṃ kārayet | snehādiṣu chedyādiṣu
+                        ca karmapatham upadiśet | subahuśruto 'pyakṛtayogyaḥ karmasvayogyo bhavati
+                        ||3|| </l>
 
                     <l xml:id="SS.1.9.4">
                         <label>1938 ed. 1.9.4</label>
                         <caesura/>
-                         tatra,
-                        puṣpaphalālābūkālindakatrapusai(so)rvārukarkārukaprabhṛtiṣu
+                         tatra, puṣpaphalālābūkālindakatrapusai(so)rvārukarkārukaprabhṛtiṣu
                         chedyaviśeṣān darśayet, utkartanāpakartanāni copadiśet;
                         dṛtibastiprasevakaprabhṛtiṣūdakapaṅkapūrṇeṣu bhedyayogyāṃ; saromṇi
                         carmaṇyātate lekhyasya; mṛtapaśusirāsūtpalanāleṣu ca vedhyasya;
                         ghuṇopahatakāṣṭhaveṇunalanālīśuṣkālābūmukheṣveṣyasya;
-                        panasabimbībilvaphalamajjamṛtapaśudanteṣvāhāryasya;
-                        madhūcchiṣṭopalipte śālmalīphalake visrāvyasya;
-                        sūkṣmaghanavastrāntayor mṛducarmāntayoś ca sīvyasya;
-                        pustamayapuruṣāṅgapratyaṅgaviśeṣeṣu bandhanayogyāṃ; mṛduṣu
+                        panasabimbībilvaphalamajjamṛtapaśudanteṣvāhāryasya; madhūcchiṣṭopalipte
+                        śālmalīphalake visrāvyasya; sūkṣmaghanavastrāntayor mṛducarmāntayoś ca
+                        sīvyasya; pustamayapuruṣāṅgapratyaṅgaviśeṣeṣu bandhanayogyāṃ; mṛduṣu
                         māṃsakhaṇḍeṣv agnikṣārayogyāṃ; mṛducarmamāṃsapeśīṣūtpalanāleṣu ca
-                        karṇasandhibandhayogyām;
-                        udakapūrṇaghaṭapārśvasrotasyalābūmukhādiṣu ca
+                        karṇasandhibandhayogyām; udakapūrṇaghaṭapārśvasrotasyalābūmukhādiṣu ca
                         netrapraṇidhānabastivraṇabastipīḍanayogyām iti ||4|| </l>
 
                     <l xml:id="SS.1.9.5ab">
@@ -2070,8 +2002,8 @@
                     <l xml:id="SS.1.9.trailer">
                         <label>1938 ed. 1.9.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne yogyāsūtrīyo nāma navamo
-                        'dhyāyaḥ ||9|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne yogyāsūtrīyo nāma navamo 'dhyāyaḥ ||9||
+                    </l>
                 </div>
                 <div n="10" type="adhyāya">
 
@@ -2088,48 +2020,44 @@
                     <l xml:id="SS.1.10.3">
                         <label>1938 ed. 1.10.3</label>
                         <caesura/>
-                         adhigatatantreṇopāsitatantrārthena dṛṣṭakarmaṇā kṛtayogyena
-                        śāstraṃ nigadatā rājānujñātena nīcanakharomṇā śucinā
-                        śuklavastraparihitena chatravatā daṇḍahastena
-                        sopānatkenānuddhataveśena sumanasā kalyāṇābhivyāhāreṇākuhakena
-                        bandhubhūtena bhūtānāṃ susahāyavatā vaidyena viśikhā'nupraveṣṭavyā
-                        ||3|| </l>
+                         adhigatatantreṇopāsitatantrārthena dṛṣṭakarmaṇā kṛtayogyena śāstraṃ
+                        nigadatā rājānujñātena nīcanakharomṇā śucinā śuklavastraparihitena
+                        chatravatā daṇḍahastena sopānatkenānuddhataveśena sumanasā
+                        kalyāṇābhivyāhāreṇākuhakena bandhubhūtena bhūtānāṃ susahāyavatā vaidyena
+                        viśikhā'nupraveṣṭavyā ||3|| </l>
 
                     <l xml:id="SS.1.10.4.1">
                         <label>1938 ed. 1.10.4.1</label>
                         <caesura/>
-                         tato dūtanimittaśakunamaṅgalānulomyenāturagṛhamabhigamya,
-                        upaviśya, āturamabhipaśyet spṛśet pṛcchec ca | tribhir
-                        etairvijñānopāyai rogāḥ prāyaśo veditavyā </l>
+                         tato dūtanimittaśakunamaṅgalānulomyenāturagṛhamabhigamya, upaviśya,
+                        āturamabhipaśyet spṛśet pṛcchec ca | tribhir etairvijñānopāyai rogāḥ prāyaśo
+                        veditavyā </l>
 
                     <l xml:id="SS.1.10.4.2">
                         <label>1938 ed. 1.10.4.2</label>
                         <caesura/>
-                         ity eke; tat tu na samyak, ṣaḍvidho hi rogāṇāṃ vijñānopāyaḥ, tad
-                        yathā- pañcabhiḥ śrotrādibhiḥ praśnena ceti ||4|| </l>
+                         ity eke; tat tu na samyak, ṣaḍvidho hi rogāṇāṃ vijñānopāyaḥ, tad yathā-
+                        pañcabhiḥ śrotrādibhiḥ praśnena ceti ||4|| </l>
 
                     <l xml:id="SS.1.10.5">
                         <label>1938 ed. 1.10.5</label>
                         <caesura/>
-                         tatra śrotrendriyavijñeyā viśeṣā rogeṣu vraṇāsrāvavijñānīyādiṣu
-                        vakṣyante- ‘tatra saphenaṃ raktamīrayannanilaḥ saśabdo
-                        nirgacchati’(sū. a.26) ity evamādayaḥ, sparśanendriyavijñeyāḥ
-                        śītoṣṇaślakṣṇakarkaśamṛdukaṭhinatvād ayaḥ (sparśaviśeṣā )
-                        jvaraśophādiṣu, cakṣurindriyavijñeyāḥ
-                        śarīropacayāpacayāyurlakṣaṇabalavarṇavikārādayaḥ,
-                        rasanendriyavijñeyāḥ pramehādiṣu rasaviśeṣāḥ, ghrāṇendriyavijñeyā
-                        ariṣṭaliṅgādiṣu vraṇānāmavraṇānāṃ ca gandhaviśeṣāḥ, praśnena ca
-                        vijānīyāddeśaṃ kālaṃ jātiṃ sātmyamātaṅkasamutpattiṃ
-                        vedanāsamucchrāyaṃ balamantaragniṃ vātamūtrapurīṣāṇāṃ
-                        pravṛttimapravṛttiṃ kālaprakarṣādīṃś ca viśeṣān | ātmasadṛśeṣu
-                        vijñānābhyupāyeṣu tatsthānīyair jānīyāt ||5|| </l>
+                         tatra śrotrendriyavijñeyā viśeṣā rogeṣu vraṇāsrāvavijñānīyādiṣu vakṣyante-
+                        ‘tatra saphenaṃ raktamīrayannanilaḥ saśabdo nirgacchati’(sū. a.26) ity
+                        evamādayaḥ, sparśanendriyavijñeyāḥ śītoṣṇaślakṣṇakarkaśamṛdukaṭhinatvād ayaḥ
+                        (sparśaviśeṣā ) jvaraśophādiṣu, cakṣurindriyavijñeyāḥ
+                        śarīropacayāpacayāyurlakṣaṇabalavarṇavikārādayaḥ, rasanendriyavijñeyāḥ
+                        pramehādiṣu rasaviśeṣāḥ, ghrāṇendriyavijñeyā ariṣṭaliṅgādiṣu
+                        vraṇānāmavraṇānāṃ ca gandhaviśeṣāḥ, praśnena ca vijānīyāddeśaṃ kālaṃ jātiṃ
+                        sātmyamātaṅkasamutpattiṃ vedanāsamucchrāyaṃ balamantaragniṃ
+                        vātamūtrapurīṣāṇāṃ pravṛttimapravṛttiṃ kālaprakarṣādīṃś ca viśeṣān |
+                        ātmasadṛśeṣu vijñānābhyupāyeṣu tatsthānīyair jānīyāt ||5|| </l>
 
                     <l xml:id="SS.1.10.6">
                         <label>1938 ed. 1.10.6</label>
                         <caesura/>
-                         evam abhisamīkṣya sādhyān sādhayet, yāpyān yāpayet,
-                        asādhyānnaivopakrameta, parisaṃvatsarotthitāṃś ca vikārān prāyaśo
-                        varjayet ||6|| </l>
+                         evam abhisamīkṣya sādhyān sādhayet, yāpyān yāpayet, asādhyānnaivopakrameta,
+                        parisaṃvatsarotthitāṃś ca vikārān prāyaśo varjayet ||6|| </l>
 
 
                     <l xml:id="SS.1.10.7">
@@ -2148,8 +2076,7 @@
                         <caesura/>
                          tad yathā-
                         śrotriyanṛpatistrībālavṛddhabhīrurājasevakakitavadurbalavaidyavidagdhavyādhigopakadaridrakṛpaṇakrodhanānāmanātmavatāmanāthānāṃ
-                        ca; evaṃ nirūpya cikitsāṃ kurvan dharmārthakāmayaśāṃsi prāpnoti
-                        ||8|| </l>
+                        ca; evaṃ nirūpya cikitsāṃ kurvan dharmārthakāmayaśāṃsi prāpnoti ||8|| </l>
 
                     <l xml:id="SS.1.10.9">
                         <label>1938 ed. 1.10.9</label>
@@ -2163,8 +2090,8 @@
                     <l xml:id="SS.1.10.trailer">
                         <label>1938 ed. 1.10.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne viśikhānupraveśanīyo nāma
-                        daśamo 'dhyāyaḥ ||10|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne viśikhānupraveśanīyo nāma daśamo 'dhyāyaḥ
+                        ||10|| </l>
                 </div>
 
                 <div n="11" type="adhyāya">
@@ -2174,9 +2101,8 @@
                     <l xml:id="SS.1.11.3">
                         <label>1938 ed. 1.11.3</label>
                         <caesura/>
-                         śastrānuśastrebhyaḥ kṣāraḥ pradhānatamaḥ,
-                        chedyabhedyalekhyakaraṇāt tridoṣaghnatvād viśeṣakriyāvacāraṇācca
-                        ||3|| </l>
+                         śastrānuśastrebhyaḥ kṣāraḥ pradhānatamaḥ, chedyabhedyalekhyakaraṇāt
+                        tridoṣaghnatvād viśeṣakriyāvacāraṇācca ||3|| </l>
 
                     <l xml:id="SS.1.11.4">
                         <label>1938 ed. 1.11.4</label>
@@ -2186,12 +2112,10 @@
                     <l xml:id="SS.1.11.5">
                         <label>1938 ed. 1.11.5</label>
                         <caesura/>
-                         nānauṣadhisamavāyāttridoṣaghnaḥ , śuklatvāt saumyaḥ; tasya
-                        saumyasyāpi sato dahanapacanadāraṇādiśaktiraviruddhā,
-                        āgneyauṣadhiguṇabhūyiṣṭhatvāt kaṭuka uṣṇastīkṣṇaḥ pācano vilayanaḥ
-                        śodhano ropaṇaḥ śoṣaṇaḥ stambhano lekhanaḥ
-                        kṛmyāmakaphakuṣṭhaviṣamedasām upahantā puṃstvasya cātisevitaḥ
-                        ||5|| </l>
+                         nānauṣadhisamavāyāttridoṣaghnaḥ , śuklatvāt saumyaḥ; tasya saumyasyāpi sato
+                        dahanapacanadāraṇādiśaktiraviruddhā, āgneyauṣadhiguṇabhūyiṣṭhatvāt kaṭuka
+                        uṣṇastīkṣṇaḥ pācano vilayanaḥ śodhano ropaṇaḥ śoṣaṇaḥ stambhano lekhanaḥ
+                        kṛmyāmakaphakuṣṭhaviṣamedasām upahantā puṃstvasya cātisevitaḥ ||5|| </l>
 
                     <l xml:id="SS.1.11.6">
                         <label>1938 ed. 1.11.6</label>
@@ -2203,9 +2127,9 @@
                         <caesura/>
                          tatra pratisāraṇīyaḥ
                         kuṣṭhakiṭibhadadrumaṇḍalakilāsabhagandarārbudārśoduṣṭavraṇanāḍīcarmakīla-
-                        tilakālakanyacchavyaṅgamaśakabāhyavidradhikṛmiviṣādiṣūpadiśyate ,
-                        saptasu ca mukharogeṣūpajihvādhijihvopakuśadantavaidarbheṣu tisṛṣu
-                        ca rohiṇīṣu, eteṣvevānuśastrapraṇidhānamuktam ||7|| </l>
+                        tilakālakanyacchavyaṅgamaśakabāhyavidradhikṛmiviṣādiṣūpadiśyate , saptasu ca
+                        mukharogeṣūpajihvādhijihvopakuśadantavaidarbheṣu tisṛṣu ca rohiṇīṣu,
+                        eteṣvevānuśastrapraṇidhānamuktam ||7|| </l>
 
                     <l xml:id="SS.1.11.8">
                         <label>1938 ed. 1.11.8</label>
@@ -2222,33 +2146,29 @@
                     <l xml:id="SS.1.11.10">
                         <label>1938 ed. 1.11.10</label>
                         <caesura/>
-                         taṃ cetarakṣāravaddagdhvā parisrāvayet; tasya vistaro 'nyatra
-                        ||10|| </l>
+                         taṃ cetarakṣāravaddagdhvā parisrāvayet; tasya vistaro 'nyatra ||10|| </l>
 
                     <l xml:id="SS.1.11.11">
                         <label>1938 ed. 1.11.11</label>
                         <caesura/>
-                         athetarastrividho mṛdurmadhyastīkṣṇaś ca | taṃ cikīrṣuḥ śaradi
-                        girisānujaṃ śucirupoṣya praśaste 'hani praśastadeśajātamanupahataṃ
-                        madhyamavayasaṃ mahāntamasitamuṣkakamadhivāsyāparedyuḥ pāṭayitvā
-                        khaṇḍaśaḥ prakalpyāvapāṭya nivāte deśe nicitiṃ kṛtvā
-                        sudhāśarkarāśca prakṣipya tilanālairādīpayet | athopaśānte 'gnau
-                        tadbhasma pṛthaggṛhṇīyādbhasmaśarkarāś ca | athānenaiva vidhānena
+                         athetarastrividho mṛdurmadhyastīkṣṇaś ca | taṃ cikīrṣuḥ śaradi girisānujaṃ
+                        śucirupoṣya praśaste 'hani praśastadeśajātamanupahataṃ madhyamavayasaṃ
+                        mahāntamasitamuṣkakamadhivāsyāparedyuḥ pāṭayitvā khaṇḍaśaḥ prakalpyāvapāṭya
+                        nivāte deśe nicitiṃ kṛtvā sudhāśarkarāśca prakṣipya tilanālairādīpayet |
+                        athopaśānte 'gnau tadbhasma pṛthaggṛhṇīyādbhasmaśarkarāś ca | athānenaiva
+                        vidhānena
                         kuṭajapalāśāśvakarṇapāribhadrakabibhītakāragvadhatilvakārkasnuhyapāmārgapāṭalānaktamālavṛṣakadalī-
                         citrakapūtīkendravṛkṣāsphotāśvamārakasaptacchadāgnimanthaguñjāścatasraśca
-                        kośātakīḥ samūlaphalapatraśākhā dahet | tataḥ
-                        kṣāradroṇamudakadroṇaiḥ ṣaḍbhir āloḍya mūtrair vā
-                        yathoktairekaviṃśatikṛtvaḥ parisrāvya, mahati kaṭāhe
-                        śanairdarvyā'vaghaṭṭayan vipacet | sa yadā bhavatyaccho
-                        raktastīkṣṇaḥ picchilaś ca tamādāya mahati vastre parisrāvyetaraṃ
-                        vibhajya punaragnāvadhiśrayet | tata eva kṣārodakāt
-                        kuḍavamadhyardhaṃ vā'panayet | tataḥ
-                        kaṭaśarkarābhasmaśarkarākṣīrapākaśaṅkhanābhīragnivarṇāḥ
-                        kṛtvā''yase pātre tasminn eva kṣārodake niṣicya piṣṭvā tenaiva
-                        dvidroṇe 'ṣṭapalasammitaṃ śaṅkhanābhyādīnāṃ pramāṇaṃ prativāpya ,
-                        satatam apramattaś cainam avaghaṭṭayan vipacet | sa yathā
-                        nātisāndro nātidravaś ca bhavati tathā prayateta |
-                        athainamāgatapākamavatāryānuguptamāyase kumbhe saṃvṛtamukhe
+                        kośātakīḥ samūlaphalapatraśākhā dahet | tataḥ kṣāradroṇamudakadroṇaiḥ
+                        ṣaḍbhir āloḍya mūtrair vā yathoktairekaviṃśatikṛtvaḥ parisrāvya, mahati
+                        kaṭāhe śanairdarvyā'vaghaṭṭayan vipacet | sa yadā bhavatyaccho raktastīkṣṇaḥ
+                        picchilaś ca tamādāya mahati vastre parisrāvyetaraṃ vibhajya
+                        punaragnāvadhiśrayet | tata eva kṣārodakāt kuḍavamadhyardhaṃ vā'panayet |
+                        tataḥ kaṭaśarkarābhasmaśarkarākṣīrapākaśaṅkhanābhīragnivarṇāḥ kṛtvā''yase
+                        pātre tasminn eva kṣārodake niṣicya piṣṭvā tenaiva dvidroṇe 'ṣṭapalasammitaṃ
+                        śaṅkhanābhyādīnāṃ pramāṇaṃ prativāpya , satatam apramattaś cainam
+                        avaghaṭṭayan vipacet | sa yathā nātisāndro nātidravaś ca bhavati tathā
+                        prayateta | athainamāgatapākamavatāryānuguptamāyase kumbhe saṃvṛtamukhe
                         nidadhyādeṣa madhyamaḥ ||11|| </l>
 
                     <l xml:id="SS.1.11.12">
@@ -2261,8 +2181,8 @@
                         <caesura/>
                          pratīvāpe yathālābhaṃ
                         dantīdravantīcitrakalāṅgalīpūtikapravālatālapatrīviḍasuvarcikākanakakṣīrīhiṅguvacātiviṣāḥ
-                        samāḥ ślakṣṇacūrṇāḥ śuktipramāṇāḥ pratīvāpaḥ | sa eva sapratīvāpaḥ
-                        pakvaḥ pākyastīkṣṇaḥ ||13|| </l>
+                        samāḥ ślakṣṇacūrṇāḥ śuktipramāṇāḥ pratīvāpaḥ | sa eva sapratīvāpaḥ pakvaḥ
+                        pākyastīkṣṇaḥ ||13|| </l>
 
                     <l xml:id="SS.1.11.14">
                         <label>1938 ed. 1.11.14</label>
@@ -2277,9 +2197,8 @@
                     <l xml:id="SS.1.11.16">
                         <label>1938 ed. 1.11.16</label>
                         <caesura/>
-                         bhavataś cātra - naivātitīkṣṇo na mṛduḥ śuklaḥ ślakṣṇo 'tha
-                        picchilaḥ | aviṣyandī śivaḥ śīghraḥ kṣāro hy aṣṭaguṇaḥ smṛtaḥ
-                        ||16|| </l>
+                         bhavataś cātra - naivātitīkṣṇo na mṛduḥ śuklaḥ ślakṣṇo 'tha picchilaḥ |
+                        aviṣyandī śivaḥ śīghraḥ kṣāro hy aṣṭaguṇaḥ smṛtaḥ ||16|| </l>
 
                     <l xml:id="SS.1.11.17">
                         <label>1938 ed. 1.11.17</label>
@@ -2291,10 +2210,10 @@
                     <l xml:id="SS.1.11.18">
                         <label>1938 ed. 1.11.18</label>
                         <caesura/>
-                         tatra kṣārasādhyavyādhivyādhitam upaveśya nivātātape deśe
-                        'sambādhe 'gropaharaṇīyoktena vidhānenopasambhṛtasambhāraṃ, tato
-                        'sya tamavakāśaṃ nirīkṣyāvaghṛṣyāvalikhya pracchayitvā , śalākayā
-                        kṣāraṃ pratisārayet, dattvā vākśatamātramupekṣeta ||18|| </l>
+                         tatra kṣārasādhyavyādhivyādhitam upaveśya nivātātape deśe 'sambādhe
+                        'gropaharaṇīyoktena vidhānenopasambhṛtasambhāraṃ, tato 'sya tamavakāśaṃ
+                        nirīkṣyāvaghṛṣyāvalikhya pracchayitvā , śalākayā kṣāraṃ pratisārayet, dattvā
+                        vākśatamātramupekṣeta ||18|| </l>
 
                     <l xml:id="SS.1.11.19">
                         <label>1938 ed. 1.11.19</label>
@@ -2306,8 +2225,8 @@
                     <l xml:id="SS.1.11.20">
                         <label>1938 ed. 1.11.20</label>
                         <caesura/>
-                         atha cet sthiramūlatvāt kṣāradagdhaṃ na śīryate | idamālepanaṃ
-                        tatra samagramavacārayet ||20|| </l>
+                         atha cet sthiramūlatvāt kṣāradagdhaṃ na śīryate | idamālepanaṃ tatra
+                        samagramavacārayet ||20|| </l>
 
                     <l xml:id="SS.1.11.21">
                         <label>1938 ed. 1.11.21</label>
@@ -2325,15 +2244,14 @@
                     <l xml:id="SS.1.11.23">
                         <label>1938 ed. 1.11.23</label>
                         <caesura/>
-                         āgneyenāgninā tulyaḥ kathaṃ kṣāraḥ praśāmyati | evaṃ cenmanyase
-                        vatsa! procyamānaṃ nibodha me ||23||</l>
+                         āgneyenāgninā tulyaḥ kathaṃ kṣāraḥ praśāmyati | evaṃ cenmanyase vatsa!
+                        procyamānaṃ nibodha me ||23||</l>
 
                     <l xml:id="SS.1.11.24">
                         <label>1938 ed. 1.11.24</label>
                         <caesura/>
-                         amlavarjān rasān kṣāre sarvāneva vibhāvayet | kaṭukas tatra
-                        bhūyiṣṭho lavaṇo 'nurasas tathā | amlena saha saṃyuktaḥ sa
-                        tīkṣṇalavaṇo rase ||24|| </l>
+                         amlavarjān rasān kṣāre sarvāneva vibhāvayet | kaṭukas tatra bhūyiṣṭho
+                        lavaṇo 'nurasas tathā | amlena saha saṃyuktaḥ sa tīkṣṇalavaṇo rase ||24|| </l>
 
                     <l xml:id="SS.1.11.25">
                         <label>1938 ed. 1.11.25</label>
@@ -2345,11 +2263,11 @@
                     <l xml:id="SS.1.11.26">
                         <label>1938 ed. 1.11.26</label>
                         <caesura/>
-                         tatra samyagdagdhe vikāropaśamo lāghavamanāsrāvaś ca |26|
-                        hīnadagdhe todakaṇḍujāḍyāni vyādhivṛddhiś ca
+                         tatra samyagdagdhe vikāropaśamo lāghavamanāsrāvaś ca |26| hīnadagdhe
+                        todakaṇḍujāḍyāni vyādhivṛddhiś ca
                         <caesura/>
-                         atidagdhe dāhapākarāgasrāvāṅgamardaklamapipāsāmūrcchāḥ syur
-                        maraṇaṃ vā ||26|| </l>
+                         atidagdhe dāhapākarāgasrāvāṅgamardaklamapipāsāmūrcchāḥ syur maraṇaṃ vā
+                        ||26|| </l>
 
                     <l xml:id="SS.1.11.27">
                         <label>1938 ed. 1.11.27</label>
@@ -2373,79 +2291,311 @@
                     <l xml:id="SS.1.11.30">
                         <label>1938 ed. 1.11.30</label>
                         <caesura/>
-                         tatra kṣārasādhyeṣv api vyādhiṣu
-                        śūnagātramasthiśūlinamannadveṣiṇaṃ hṛdayasandhipīḍopadrutaṃ ca
-                        kṣāro na sādhayati (durbalabālasthavirādīn pratisāraṇīya iti)
-                        ||30|| </l>
+                         tatra kṣārasādhyeṣv api vyādhiṣu śūnagātramasthiśūlinamannadveṣiṇaṃ
+                        hṛdayasandhipīḍopadrutaṃ ca kṣāro na sādhayati (durbalabālasthavirādīn
+                        pratisāraṇīya iti) ||30|| </l>
 
                     <l xml:id="SS.1.11.31">
                         <label>1938 ed. 1.11.31</label>
                         <caesura/>
-                         bhavati cātra - viṣāgniśastrāśanimṛtyukalpaḥ kṣāro
-                        bhavatyalpamatiprayuktaḥ | sa dhīmatā samyaganuprayukto
-                        rogānnihanyādacireṇa ghorān ||31|| </l>
+                         bhavati cātra - viṣāgniśastrāśanimṛtyukalpaḥ kṣāro bhavatyalpamatiprayuktaḥ
+                        | sa dhīmatā samyaganuprayukto rogānnihanyādacireṇa ghorān ||31|| </l>
 
                     <l xml:id="SS.1.11.trailer">
                         <label>1938 ed. 1.11.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne kṣārapākavidhirnāmaikādaśo
-                        'dhyāyaḥ ||11|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne kṣārapākavidhirnāmaikādaśo 'dhyāyaḥ
+                        ||11|| </l>
                 </div>
 
                 <div n="12" type="adhyāya">
 
-                    <l xml:id="SS.1.12.3">
-                        <label>1938 ed. 1.12.3</label>
-                        <caesura/>
-                         kṣārādagnirgarīyān kriyāsu vyākhyātaḥ, taddagdhānāṃ
-                        rogāṇāmapunarbhāvādbheṣajaśastrakṣārairasādhyānāṃ tatsādhyatvāc ca
-                        ||3|| </l>
 
-                    <l xml:id="SS.1.12.4">
-                        <label>1938 ed. 1.12.4</label>
+                    <!--                    -->
+
+                    <l xml:id="SS.1.12.1">
+                        <label>1938 ed. 1.12.1</label>
+                        <caesura/>
+                         || athāto 'gnikarmavidhim adhyāyaṃ vyākhyāsyāmaḥ ||1||</l>
+
+
+                    <l xml:id="SS.1.12.2"><label>1938 ed. 1.12.2</label>
+                        <caesura/>
+                         yathovāca bhagavān dhanvantariḥ ||2||</l>
+
+
+                    <p xml:id="NS.1.12.1" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.1</label>
+                        <caesura/>
+                         athāta ityādi | agninā kṛtvā yat karma, agneḥ saṃbandhi vā yat karma, tad
+                        agnikarma; tasya vidhir vidhānaṃ, tad yasminn adhyāye vidyate taṃ
+                        vyākhyāsyāmaḥ | ‘agnikarmīyam’ ity anye paṭhanti, “agnikarmādhikṛtya kṛto
+                        'gnikarmīyaḥ” iti vyākhyānayanti ca ||1||2|| </p>
+
+
+                    <!--                    -->
+
+
+                    <l xml:id="SS.1.12.3a1">
+                        <label>1938 ed. 1.12.3a</label>
+                        <caesura/>
+                         kṣārādagnirgarīyān kriyāsu vyākhyātaḥ, </l>
+
+                    <l xml:id="SS.1.12.3b">
+                        <label>1938 ed. 1.12.3b</label>
+                        <caesura/>
+                         taddagdhānāṃ rogāṇāmapunarbhāvādbheṣajaśastrakṣārairasādhyānāṃ
+                        tatsādhyatvāc ca ||3|| </l>
+
+
+                    <p xml:id="NS.1.12.3a1" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.3a</label>
+                        <caesura/>
+                         agnikarmamāhātmyam āha,— kṣārād ityādi |— </p>
+
+
+                    <p xml:id="NS.1.12.3a2" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.3a</label>
+                        <caesura/>
+                         kṣārād guroḥ sakāśād agnir garīyān gurutaraḥ | kutra punaḥ kṣārād agnir
+                        garīyān ity āha — kriyāsu karmasu, na tu guṇeṣu; guṇeṣu punas
+                        tridoṣaghnacchedyabhedyalekhyakaraṇādiṣu kṣāra eva pradhānaḥ; etena sve sve
+                        kṛtye dvayor api prādhānyam ity uktaṃ; yathā — dṛḍhaprahāritvenārjunāt
+                        karṇaḥ, karṇād dūrāpātitvenārjunaḥ pradhānam iti | vyākhyāta iti kathita ity
+                        arthaḥ |</p>
+
+
+                    <p xml:id="NS.1.12.3b1" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.3b</label>
+                        <caesura/>
+                         pratijñātasya garīyas tv asya sādhakaṃ hetum āha —</p>
+
+                    <p xml:id="NS.1.12.3b2" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.3b</label>
+                        <caesura/>
+                         tad dagdhānām iti | — agnidagdhānām; apunarbhāvād iti apunarbhāvas tu
+                        sādhyānāṃ samyag dagdhānāṃ , etad viparyaye tv agnidagdhasyāpi punar
+                        udbhavaḥ anye tv anyā samādadhati — arbudādayo 'gninā samūlam unmūlitā
+                        mithyāhārādibhiḥ punardoṣaprakopāt tat sthāna evānye jāyamānās tadvad
+                        upālabhyante | hetvantaraṃ samuccinvan āha, — bheṣajetyādi | tatsādhyatvāt_
+                        agnisādhyatvād ity arthaḥ | anye tu ‘svedaśastrakṣāraiḥ’ iti paṭhanti,
+                        tatrāyam arthaḥ — bhagandarārśasādayaḥ pūrvaṃ svidyante, paścāt teṣu śastram
+                        avacāryate; athavā svedagrahaṇaṃ bheṣajopalakṣaṇaṃ, bheṣajāśaktau
+                        śastrāvacāraṇaṃ, śastrāśaktāv aśeṣavyādhiśamanāya kṣāraḥ, kṣārāśakye
+                        'vagāḍhamūle vyādhāv agnir iti ||3||</p>
+
+
+                    <l xml:id="SS.1.12.4a">
+                        <label>1938 ed. 1.12.4a</label>
                         <caesura/>
                          athemāni dahanopakaraṇāni bhavanti- tad yathā-
-                        pippalyajāśakṛdgodantaśaraśalākājāmbavauṣṭhetaralauhāḥ
-                        kṣaudraguḍasnehāś ca | tatra,
-                        pippalyajāśakṛdgodantaśaraśalākāstvaggatānāṃ,
-                        jāmbavauṣṭhetaralauhā māṃsagatānāṃ, kṣaudraguḍasnehāḥ
-                        sirāsnāyusandhyasthigatānām ||4|| </l>
+                        pippalyajāśakṛdgodantaśaraśalākājāmbavauṣṭhetaralauhāḥ kṣaudraguḍasnehāś ca
+                        |</l>
+
+                    <l xml:id="SS.1.12.4b">
+                        <label>1938 ed. 1.12.4b</label>
+                        <caesura/>
+                         tatra, pippalyajāśakṛdgodantaśaraśalākāstvaggatānāṃ, </l>
+
+                    <l xml:id="SS.1.12.4c">
+                        <label>1938 ed. 1.12.4c</label>
+                        <caesura/>
+                         jāmbavauṣṭhetaralauhā māṃsagatānāṃ, </l>
+
+                    <l xml:id="SS.1.12.4d">
+                        <label>1938 ed. 1.12.4d</label>
+                        <caesura/>
+                         kṣaudraguḍasnehāḥ sirāsnāyusandhyasthigatānām ||4|| </l>
+
+
+                    <p xml:id="NS.1.12.4a1" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.4a</label>
+                        <caesura/>
+                         aganyavacāraṇopakaraṇāni nidarśayann āha, — athemānītyādi |</p>
+
+
+                    <p xml:id="NS.1.12.4a2" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.4a</label>
+                        <caesura/>
+                         ajāśakṛt chāgapurīṣaṃ; jāmbavauṣṭhaṃ jambūphalasadṛśamukhāgrā
+                        kṛṣṇapāṣāṇaracitāvarttiḥ; itaralohās tāmrarajatādayaḥ, teṣāṃ vikārā lauhāḥ;
+                        kṣaudraguḍasnehāś ceti cakārāt sarjarasamadhūcchiṣṭādayaḥ |</p>
+
+
+                    <p xml:id="NS.1.12.4b1" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.4b</label>
+                        <caesura/>
+                         agnyupakaraṇarāśitrayasya pratyekaṃ viṣayaṃ darśayann āha — tatretyādi
+                        |</p>
+
+                    <p xml:id="NS.1.12.4b2" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.4b</label>
+                        <caesura/>
+                         tvaggatānām iti vātakaphakṛtānāṃ suptyādivikārāṇāṃ |</p>
+
+
+                    <p xml:id="NS.1.12.4c" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.4c</label>
+                        <caesura/>
+                         māṃsagatānāṃ vātakaphajavikārāṇām | </p>
+
+                    <p xml:id="NS.1.12.4d" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.4d</label>
+                        <caesura/>
+                         kṣaudraguḍasnehāḥ ity atrāpi vātakaphasambhūtānām iti bodhavyam | nanu,
+                        kāśyapena muninā sirādiṣv agnikarma pratiṣiddhaṃ; tathā ca tad vacanaṃ, —
+                        “na sirāsnāyusandhyasthimarmasv api kathaṃcana | daṃśasyotkarttanaṃ kāryaṃ
+                        dāho vā bhiṣajāgninā” — iti; iha tu sirādiṣv api agnikarmoktam , itthaṃ ca
+                        śāstrāntaravirodhaḥ; tan na, atrāpi sirā snāyusandhyasthichedād
+                        raktātipravṛttau vyāpatpratīkāyāgnikarmoktaṃ, na punaḥ
+                        sirādigatarogochedanāya, yato māṃsadāhād eva sirādigatarogocchedo jāyata
+                        eva; tathā ca bhadraśaunakaḥ, — “tvaṅmāṃsasaṃśrito vāyus tvagdāhenaiva
+                        śāmyati | māṃse dagdhe hi śāmyanti sirāsnāyvasthisandhijāḥ” — iti ||4||
+                        tasya kālaṃ sāpavādaṃ nirddiśann āha |</p>
+
 
                     <l xml:id="SS.1.12.5">
                         <label>1938 ed. 1.12.5</label>
                         <caesura/>
-                         tatrāgnikarma sarvartuṣu kuryād anyatra śaradgrīṣmābhyāṃ;
-                        tatrāpyātyayike 'gnikarmasādhye vyādhau tatpratyanīkaṃ vidhiṃ
-                        kṛtvā ||5|| </l>
+                         tatrāgnikarma sarvartuṣu kuryād anyatra śaradgrīṣmābhyāṃ; tatrāpyātyayike
+                        'gnikarmasādhye vyādhau tatpratyanīkaṃ vidhiṃ kṛtvā ||5|| </l>
 
-                    <l xml:id="SS.1.12.6">
-                        <label>1938 ed. 1.12.6</label>
+
+                    <p xml:id="NS.1.12.5a" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.5</label>
                         <caesura/>
-                         sarvavyādhiṣvṛtuṣu ca picchilamannaṃ bhuktavataḥ;
-                        mūḍhagarbhāśmarībhagandarodarārśomukharogeṣv abhuktavataḥ karma
-                        kurvīta ||6|| </l>
+                         tasya kālaṃ sāpavādaṃ nirddiśann āha, — tatrāgnītyādi | tatrāgnikarma
+                        sarvartuṣu kuryād ity utsargaḥ, anyatra śaradgrīṣmābhyām ity apavādaḥ |
+                        śaradgrīṣmayor apy avasthāyāṃ pravṛttim āha, — tatrāpītyādi | </p>
+
+                    <p xml:id="NS.1.12.5b" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.5</label>
+                        <caesura/>
+                         trāpīti śaradgrīṣamyor api, ātyayike āśuprāṇavināśake,
+                            tatpratyanīka<pc> </pc>vidhiṃ kṛtveti tasyāgnisamānasya
+                        śaradgrīṣmābhidhānasyartoḥ, pratyanīkavidhiṃ viparitavidhānaṃ
+                        śītācchādanabhojanapradehādikaṃ kṛtvā ‘agnikarma kuryāt’ ity anuvarttate |
+                        atra pāṭhe kecid vidhiśabdaṃ na paṭhanti ||5|| </p>
+
+
+                    <l xml:id="SS.1.12.6a">
+                        <label>1938 ed. 1.12.6a</label>
+                        <caesura/>
+                         sarvavyādhiṣvṛtuṣu ca picchilamannaṃ bhuktavataḥ;</l>
+
+                    <l xml:id="SS.1.12.6b">
+                        <label>1938 ed. 1.12.6b</label>
+                        <caesura/>
+                         mūḍhagarbhāśmarībhagandarodarārśomukharogeṣv abhuktavataḥ karma kurvīta
+                        ||6|| </l>
+
+                    <p xml:id="NS.1.12.6a1" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.6a</label>
+                        <caesura/>
+                         sarvā'gnikarmāṃgavidhim āha, — sarvavyādhiṣv ityādi |</p>
+
+
+                    <p xml:id="NS.1.12.6a2" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.6a</label>
+                        <caesura/>
+                         atrāpi ‘agnikarma kuryāt’ iti pratyekaṃ saṃbadhyate picchilam annaṃ
+                        picchilavīryam annaṃ; śītamṛdupicchilānāṃ vīryāṇāṃ pittaghnatvāt |</p>
+
+
+                    <p xml:id="NS.1.12.6b1" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.6b</label>
+                        <caesura/>
+                         tatra pradeśeṣu bhojanasya pratiṣedham āha —</p>
+
+                    <p xml:id="NS.1.12.6b2" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.6b</label>
+                        <caesura/>
+                         mūḍhagarbhāśmarītyādi | eṣu bhojane kṛte ūrdhvādhovegābhyāṃ karmavighātaḥ
+                        syāt kvacid udarānavakāśatvāt | kecid atra ‘mūḍhagarbhāśmarī’ ityādipāṭhaṃ
+                        na paṭhanti ||6|| </p>
+
+
+
+                    <!--                    -->
 
                     <l xml:id="SS.1.12.7">
                         <label>1938 ed. 1.12.7</label>
                         <caesura/>
-                         tatra dvividhamagnikarmāhureke- tvagdagdhaṃ, māṃsadagdhaṃ ca; iha
-                        tu sirāsnāyusandhyasthiṣv api na pratiṣiddho 'gniḥ ||7|| </l>
+                         tatra dvividhamagnikarmāhureke- tvagdagdhaṃ, māṃsadagdhaṃ ca; iha tu
+                        sirāsnāyusandhyasthiṣv api na pratiṣiddho 'gniḥ ||7|| </l>
+
+                    <p xml:id="NS.1.12.7a" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.7</label>
+                        <caesura/>
+                         agnikarmaṇy ekīyamataṃ darśayann āya, — tatra dvividam ityādi |</p>
+
+                    <p xml:id="NS.1.12.7b" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.7</label>
+                        <caesura/>
+                         svatantrasiddhāntaṃ darśayann āha — iha tu siretyādi | sirādiṣv apy
+                        agnikarma kartavyam ity arthaḥ pūrvaṃ vyākhyātaḥ; “sirādiṣv api
+                        agnikarmavidhir ātyayike vyādhāv eva, nānyatra” ity anye vyākhyānayanti
+                        ||7||</p>
+
+
+                    <!--                    -->
 
                     <l xml:id="SS.1.12.8">
                         <label>1938 ed. 1.12.8</label>
                         <caesura/>
                          tatra, śabdaprādurbhāvo durgandhatā tvaksaṅkocaś ca tvagdagdhe,
-                        kapotavarṇatā'lpaśvayathuvedanā śuṣkasaṅkucitavraṇatā ca
-                        māṃsadagdhe; kṛṣṇonnatavraṇatā srāvasannirodhaś ca
-                        sirāsnāyudagdhe, rūkṣāruṇatā karkaśasthiravraṇatā ca
-                        sandhyasthidagdhe ||8|| </l>
+                        kapotavarṇatā'lpaśvayathuvedanā śuṣkasaṅkucitavraṇatā ca māṃsadagdhe;
+                        kṛṣṇonnatavraṇatā srāvasannirodhaś ca sirāsnāyudagdhe, rūkṣāruṇatā
+                        karkaśasthiravraṇatā ca sandhyasthidagdhe ||8|| </l>
 
-                    <l xml:id="SS.1.12.9">
-                        <label>1938 ed. 1.12.9</label>
+                    <p xml:id="NS.1.12.8a" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.8a</label>
                         <caesura/>
-                         tatra śirorogādhimanthayor bhrūlalāṭaśaṅkhapradeśeṣu dahet,
-                        vartmarogeṣvārdrālaktakapraticchannāṃ dṛṣṭiṃ kṛtvā vartmaromakūpān
-                        ||9|| </l>
+                         tvagādiṣu karmaṇi kṛte prativiṣayaṃ bhedalakṣaṇaṃ darśayann āha, — tatra
+                        śabdetyādi |</p>
+
+                    <p xml:id="NS.1.12.8b" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.8b</label>
+                        <caesura/>
+                         sthiravraṇatā kaṭhinavraṇatā ||8||</p>
+
+
+                    <!--                    -->
+
+
+
+                    <l xml:id="SS.1.12.9a">
+                        <label>1938 ed. 1.12.9a</label>
+                        <caesura/>
+                         tatra śirorogādhimanthayor bhrūlalāṭaśaṅkhapradeśeṣu dahet,</l>
+
+                    <l xml:id="SS.1.12.9b">
+                        <label>1938 ed. 1.12.9b</label>
+                        <caesura/>
+                         vartmarogeṣvārdrālaktakapraticchannāṃ dṛṣṭiṃ kṛtvā vartmaromakūpān ||9|| </l>
+
+                    <p xml:id="NS.1.12.9a1" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.9a</label>
+                        <caesura/>
+                         rogabhedāc charīrāvayavaviśeṣeṣv agnyavacāraṇaṃ darśayann āha, — tatra
+                        śirorogetyādi |</p>
+
+                    <p xml:id="NS.1.12.9a2" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.9a</label>
+                        <caesura/>
+                         adhimanthaḥ akṣirogo 'bhiṣyandapūrvakaḥ | bhruvau akṣikūṭopari romarājī,
+                        śaṅkhau bhrūkarṇayor madhyam | vartmadeśe yathā 'gnyavacāraṇaṃ tathā
+                        darśayann āha, — vartmarogeṣv ityādi |</p>
+
+                    <p xml:id="NS.1.12.9b" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.9b</label>
+                        <caesura/>
+                         ‘dahet’ ity anuvartate | vartma netracchādanam | ārdrālaktaka ārdrakarpaṭaḥ
+                        ||9||</p>
+
+
+                    <!--                    -->
+
 
                     <l xml:id="SS.1.12.10">
                         <label>1938 ed. 1.12.10</label>
@@ -2455,6 +2605,20 @@
                         'rbudabhagandarāpacīślīpadacarmakīlatilakālakāntravṛddhisandhisirācchedanādiṣu
                         nāḍīśoṇitātipravṛttiṣu cāgnikarma kuryāt ||10|| </l>
 
+                    <p xml:id="NS.1.12.10a" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.10</label>
+                        <caesura/>
+                         śeṣaviṣayam avasthābhedena darśayann āha, — tvaṅmāṃsetyādi |</p>
+
+                    <p xml:id="NS.1.12.10b" style="stream1">
+                        <label>Ḍalhaṇa on 1.12.10</label>
+                        <caesura/>
+                         atyugraruje vāyau iti ugraśūle vāyau | ucchritakaṭhinasuptamāṃse iti
+                        ucchritam utsedhavat, suptam acetanam | nāḍīti vraṇaviśeṣaḥ | </p>
+
+                    <!--                    -->
+
+
                     <l xml:id="SS.1.12.11">
                         <label>1938 ed. 1.12.11</label>
                         <caesura/>
@@ -2463,9 +2627,9 @@
                     <l xml:id="SS.1.12.12">
                         <label>1938 ed. 1.12.12</label>
                         <caesura/>
-                         bhavati cātra - rogasya saṃsthānamavekṣya samyaṅnarasya marmāṇi
-                        balābalaṃ ca | vyādhiṃ tathartuṃ ca samīkṣya samyak tato
-                        'vyavasyedbhiṣagagnikarma ||12|| </l>
+                         bhavati cātra - rogasya saṃsthānamavekṣya samyaṅnarasya marmāṇi balābalaṃ
+                        ca | vyādhiṃ tathartuṃ ca samīkṣya samyak tato 'vyavasyedbhiṣagagnikarma
+                        ||12|| </l>
 
                     <l xml:id="SS.1.12.13">
                         <label>1938 ed. 1.12.13</label>
@@ -2482,26 +2646,23 @@
                     <l xml:id="SS.1.12.15">
                         <label>1938 ed. 1.12.15</label>
                         <caesura/>
-                         ata ūrdhvamitarathādagdhalakṣaṇaṃ vakṣyāmaḥ | tatra, snigdhaṃ
-                        rūkṣaṃ vā''(cā)śrity a dravyamagnirdahati; agnisantapto hi snehaḥ
-                        sūkṣmasirānusāritvāt tvagādīnanupraviśyāśu dahati; tasmāt
-                        snehadagdhe 'dhikā rujo bhavanti ||15|| </l>
+                         ata ūrdhvamitarathādagdhalakṣaṇaṃ vakṣyāmaḥ | tatra, snigdhaṃ rūkṣaṃ
+                        vā''(cā)śrity a dravyamagnirdahati; agnisantapto hi snehaḥ
+                        sūkṣmasirānusāritvāt tvagādīnanupraviśyāśu dahati; tasmāt snehadagdhe 'dhikā
+                        rujo bhavanti ||15|| </l>
 
                     <l xml:id="SS.1.12.16">
                         <label>1938 ed. 1.12.16</label>
                         <caesura/>
                          tatra pluṣṭaṃ durdagdhaṃ samyagdagdhamatidagdhaṃ ceti
-                        caturvidhamagnidagdham | tatra yadvivarṇaṃ pluṣyate 'timātraṃ tat
-                        pluṣṭaṃ; yatrottiṣṭhanti
-                        sphoṭāstīvrāścoṣadāharāgapākavedanāścirāccopaśāmyanti
+                        caturvidhamagnidagdham | tatra yadvivarṇaṃ pluṣyate 'timātraṃ tat pluṣṭaṃ;
+                        yatrottiṣṭhanti sphoṭāstīvrāścoṣadāharāgapākavedanāścirāccopaśāmyanti
                         taddurdagdhaṃ; samyagdagdhamanavagāḍhaṃ tālavarṇaṃ susaṃsthitaṃ
                         pūrvalakṣaṇayuktaṃ ca; atidagdhe māṃsāvalambanaṃ gātraviśleṣaḥ
-                        sirāsnāyusandhyasthivyāpādanamatimātraṃ
-                        jvaradāhapipāsāmūrcchāścopadravā bhavanti, vraṇaś cāsya cireṇa
-                        rohati, rūḍhaś ca vivarṇo bhavati |
+                        sirāsnāyusandhyasthivyāpādanamatimātraṃ jvaradāhapipāsāmūrcchāścopadravā
+                        bhavanti, vraṇaś cāsya cireṇa rohati, rūḍhaś ca vivarṇo bhavati |
                         <caesura/>
-                         tadetaccaturvidhamagnidagdhalakṣaṇamātmakarmaprasādhakaṃ bhavati
-                        ||16|| </l>
+                         tadetaccaturvidhamagnidagdhalakṣaṇamātmakarmaprasādhakaṃ bhavati ||16|| </l>
 
                     <l xml:id="SS.1.12.17">
                         <label>1938 ed. 1.12.17</label>
@@ -2513,26 +2674,26 @@
                     <l xml:id="SS.1.12.18">
                         <label>1938 ed. 1.12.18</label>
                         <caesura/>
-                         tulyavīrye ubhe hyete rasato dravyatas tathā | tenāsya
-                        vedanāstīvrāḥ prakṛtyā ca vidahyate ||18||</l>
+                         tulyavīrye ubhe hyete rasato dravyatas tathā | tenāsya vedanāstīvrāḥ
+                        prakṛtyā ca vidahyate ||18||</l>
 
                     <l xml:id="SS.1.12.19">
                         <label>1938 ed. 1.12.19</label>
                         <caesura/>
-                         sphoṭāḥ śīghraṃ prajāyante jvarastṛṣṇā ca bādhate ||
-                        dagdhasyopaśamārthāya cikitsā sampravakṣyate ||19|| </l>
+                         sphoṭāḥ śīghraṃ prajāyante jvarastṛṣṇā ca bādhate || dagdhasyopaśamārthāya
+                        cikitsā sampravakṣyate ||19|| </l>
 
                     <l xml:id="SS.1.12.20">
                         <label>1938 ed. 1.12.20</label>
                         <caesura/>
-                         pluṣṭasyāgnipratapanaṃ kāryamuṣṇaṃ tathauṣadham | śarīre
-                        svinnabhūyiṣṭhe svinnaṃ bhavati śoṇitam ||20||</l>
+                         pluṣṭasyāgnipratapanaṃ kāryamuṣṇaṃ tathauṣadham | śarīre svinnabhūyiṣṭhe
+                        svinnaṃ bhavati śoṇitam ||20||</l>
 
                     <l xml:id="SS.1.12.21">
                         <label>1938 ed. 1.12.21</label>
                         <caesura/>
-                         prakṛtyā hyudakaṃ śītaṃ skandayatyatiśoṇitam | tasmāt sukhayati
-                        hyuṣṇaṃ nanu śītaṃ kathañcana ||21|| </l>
+                         prakṛtyā hyudakaṃ śītaṃ skandayatyatiśoṇitam | tasmāt sukhayati hyuṣṇaṃ
+                        nanu śītaṃ kathañcana ||21|| </l>
 
                     <l xml:id="SS.1.12.22">
                         <label>1938 ed. 1.12.22</label>
@@ -2557,14 +2718,14 @@
                     <l xml:id="SS.1.12.25">
                         <label>1938 ed. 1.12.25</label>
                         <caesura/>
-                         atidagdhe viśīrṇāni māṃsānyuddhṛtya śītalām | kriyāṃ kuryād
-                        bhiṣak paś cācchālitaṇḍulakaṇḍanaiḥ ||25|| </l>
+                         atidagdhe viśīrṇāni māṃsānyuddhṛtya śītalām | kriyāṃ kuryād bhiṣak paś
+                        cācchālitaṇḍulakaṇḍanaiḥ ||25|| </l>
 
                     <l xml:id="SS.1.12.26">
                         <label>1938 ed. 1.12.26</label>
                         <caesura/>
-                         tindukītvakkapālair vā ghṛtamiśraiḥ pralepayet | vraṇaṃ
-                        guḍūcīpatrair vā chādayed athavaudakaiḥ ||26||</l>
+                         tindukītvakkapālair vā ghṛtamiśraiḥ pralepayet | vraṇaṃ guḍūcīpatrair vā
+                        chādayed athavaudakaiḥ ||26||</l>
 
                     <l xml:id="SS.1.12.27">
                         <label>1938 ed. 1.12.27</label>
@@ -2589,50 +2750,50 @@
                     <l xml:id="SS.1.12.30">
                         <label>1938 ed. 1.12.30</label>
                         <caesura/>
-                         śvasiti kṣauti cātyarthamapyādhamati kāsate | cakṣuṣoḥ paridāhaś
-                        ca rāgaścaivopajāyate ||30||</l>
+                         śvasiti kṣauti cātyarthamapyādhamati kāsate | cakṣuṣoḥ paridāhaś ca
+                        rāgaścaivopajāyate ||30||</l>
 
                     <l xml:id="SS.1.12.31">
                         <label>1938 ed. 1.12.31</label>
                         <caesura/>
-                         sadhūmakaṃ niśvasiti ghreyamanyanna vetti ca | tathaiva ca rasān
-                        sarvān śrutiś cāsyopahanyate ||31||</l>
+                         sadhūmakaṃ niśvasiti ghreyamanyanna vetti ca | tathaiva ca rasān sarvān
+                        śrutiś cāsyopahanyate ||31||</l>
 
                     <l xml:id="SS.1.12.32">
                         <label>1938 ed. 1.12.32</label>
                         <caesura/>
-                         tṛṣṇādāhajvarayutaḥ sīdatyatha ca mūrcchati | dhūmopahata ity
-                        eṣaḥ śṛṇu tasya cikitsitam ||32|| </l>
+                         tṛṣṇādāhajvarayutaḥ sīdatyatha ca mūrcchati | dhūmopahata ity eṣaḥ śṛṇu
+                        tasya cikitsitam ||32|| </l>
 
                     <l xml:id="SS.1.12.33">
                         <label>1938 ed. 1.12.33</label>
                         <caesura/>
-                         sarpirikṣurasaṃ drākṣāṃ payo vā śarkarāmbu vā | madhurāmlau rasau
-                        vā'pi vamanāya pradāpayet ||33||</l>
+                         sarpirikṣurasaṃ drākṣāṃ payo vā śarkarāmbu vā | madhurāmlau rasau vā'pi
+                        vamanāya pradāpayet ||33||</l>
 
                     <l xml:id="SS.1.12.34">
                         <label>1938 ed. 1.12.34</label>
                         <caesura/>
-                         vamataḥ koṣṭhaśuddhiḥ syāddhūmagandhaśca naśyati | vidhinā'nena
-                        śāmyanti sadanakṣavathujvarāḥ ||34|| </l>
+                         vamataḥ koṣṭhaśuddhiḥ syāddhūmagandhaśca naśyati | vidhinā'nena śāmyanti
+                        sadanakṣavathujvarāḥ ||34|| </l>
 
                     <l xml:id="SS.1.12.35">
                         <label>1938 ed. 1.12.35</label>
                         <caesura/>
-                         dāhamūrcchātṛḍādhmānaśvāsakāsāś ca dāruṇāḥ | madhurairlavaṇāmlaiś
-                        ca kaṭukaiḥ kavalagrahaiḥ ||35||</l>
+                         dāhamūrcchātṛḍādhmānaśvāsakāsāś ca dāruṇāḥ | madhurairlavaṇāmlaiś ca
+                        kaṭukaiḥ kavalagrahaiḥ ||35||</l>
 
                     <l xml:id="SS.1.12.36">
                         <label>1938 ed. 1.12.36</label>
                         <caesura/>
-                         samyaggṛhṇātīndriyārthān manaś cāsya prasīdati | śirovirecanaṃ
-                        cāsmai dadyādyogena śāstravit ||36|| </l>
+                         samyaggṛhṇātīndriyārthān manaś cāsya prasīdati | śirovirecanaṃ cāsmai
+                        dadyādyogena śāstravit ||36|| </l>
 
                     <l xml:id="SS.1.12.37">
                         <label>1938 ed. 1.12.37</label>
                         <caesura/>
-                         dṛṣṭirviśudhyate cāsya śirogrīvaṃ ca dehinaḥ | avidāhi laghu
-                        snigdhamāhāraṃ cāsya kalpayet ||37|| </l>
+                         dṛṣṭirviśudhyate cāsya śirogrīvaṃ ca dehinaḥ | avidāhi laghu snigdhamāhāraṃ
+                        cāsya kalpayet ||37|| </l>
 
                     <l xml:id="SS.1.12.38">
                         <label>1938 ed. 1.12.38</label>
@@ -2653,8 +2814,8 @@
                     <l xml:id="SS.1.12.trailer">
                         <label>1938 ed. 1.12.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne 'gnikarmavidhirnāma dvādaśo
-                        'dhyāyaḥ ||12|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne 'gnikarmavidhirnāma dvādaśo 'dhyāyaḥ
+                        ||12|| </l>
                 </div>
 
                 <div n="13" type="adhyāya">
@@ -2664,33 +2825,30 @@
 
 
                     <l xml:id="SS.1.13.1">
-                        <label>1938 ed. 1.13.1</label>
-                         athāto jalaukāvacāraṇīyam adhyāyaṃ vyākhyāsyāmaḥ || </l>
+                        <label>1938 ed. 1.13.1</label> athāto jalaukāvacāraṇīyam adhyāyaṃ
+                        vyākhyāsyāmaḥ || </l>
 
 
                     <l xml:id="SS.1.13.2">
-                        <label>1938 ed. 1.13.2</label>
-                         yathovāca bhagavān dhanvantariḥ || </l>
+                        <label>1938 ed. 1.13.2</label> yathovāca bhagavān dhanvantariḥ || </l>
 
 
                     <l xml:id="SS.1.13.3">
-                        <label>1938 ed. 1.13.3</label>
-                         nṛpāḍhya<pc> </pc>bāla<pc> </pc>sthavira<pc> </pc>bhīru<pc> </pc>durbala<pc> </pc>nārī<pc> </pc>sukumārāṇām
-                        anugrahārthaṃ paramasukumāro 'yaṃ śoṇitāvasecanopāyo 'bhihito
-                        jalaukasaḥ || </l>
+                        <label>1938 ed. 1.13.3</label> nṛpāḍhya<pc> </pc>bāla<pc
+                            > </pc>sthavira<pc> </pc>bhīru<pc> </pc>durbala<pc> </pc>nārī<pc
+                        > </pc>sukumārāṇām anugrahārthaṃ paramasukumāro 'yaṃ śoṇitāvasecanopāyo
+                        'bhihito jalaukasaḥ || </l>
 
 
                     <l xml:id="SS.1.13.4">
-                        <label>1938 ed. 1.13.4</label>
-                         tatra vātapittakaphaduṣṭaśoṇitaṃ yathāsaṃkhyaṃ
-                        śṛṅgajalaukālābubhir avasecayet sarvāṇi sarvair vā (viśeṣas tu
+                        <label>1938 ed. 1.13.4</label> tatra vātapittakaphaduṣṭaśoṇitaṃ
+                        yathāsaṃkhyaṃ śṛṅgajalaukālābubhir avasecayet sarvāṇi sarvair vā (viśeṣas tu
                         visrāvyaṃ śṛṅgajalaukālābubhir gṛhṇīyāt) || </l>
 
 
 
                     <l xml:id="SS.1.13.5">
-                        <label>1938 ed. 1.13.5ab</label>
-                         bhavanti cātra ślokāḥ |
+                        <label>1938 ed. 1.13.5ab</label> bhavanti cātra ślokāḥ |
                         <caesura/>
                          uṣṇaṃ samadhuraṃ snigdhaṃ gavāṃ śṛṅgaṃ prakīrtitam |
                         <caesura/>
@@ -2700,83 +2858,73 @@
 
 
                     <l xml:id="SS.1.13.6">
-                        <label>1938 ed. 1.13.6</label>
-                         śītādhivāsā madhurā jalaukā vārisaṃbhavā |
+                        <label>1938 ed. 1.13.6</label> śītādhivāsā madhurā jalaukā vārisaṃbhavā |
                         <caesura/>
                          tasmāt pittopasṛṣṭe tu hitā sā tv avasecane || </l>
 
 
                     <l xml:id="SS.1.13.7">
-                        <label>1938 ed. 1.13.7</label>
-                         alābu kaṭukaṃ rūkṣaṃ tīkṣṇaṃ ca parikīrtitam |
+                        <label>1938 ed. 1.13.7</label> alābu kaṭukaṃ rūkṣaṃ tīkṣṇaṃ ca parikīrtitam
+                        |
                         <caesura/>
                          tasmāc chleṣmopasṛṣṭe tu hitaṃ tad avasecane || </l>
 
 
                     <l xml:id="SS.1.13.8">
-                        <label>1938 ed. 1.13.8</label>
-                         tatra pracchite tanu<pc> </pc>basti<pc> </pc>paṭalāvanaddhena
-                        śṛṅgeṇa śoṇitam avasecayed ācūṣaṇāt sāntardīpayā 'lābvā |
-                        (jalāyukā vakṣyante) || </l>
+                        <label>1938 ed. 1.13.8</label> tatra pracchite tanu<pc> </pc>basti<pc
+                        > </pc>paṭalāvanaddhena śṛṅgeṇa śoṇitam avasecayed ācūṣaṇāt sāntardīpayā
+                        'lābvā | (jalāyukā vakṣyante) || </l>
 
 
                     <l xml:id="SS.1.13.9">
-                        <label>1938 ed. 1.13.9</label>
-                         jalam āsām āyur iti jalāyukāḥ jalam āsām oka iti jalaukasaḥ || </l>
+                        <label>1938 ed. 1.13.9</label> jalam āsām āyur iti jalāyukāḥ jalam āsām oka
+                        iti jalaukasaḥ || </l>
 
 
                     <l xml:id="SS.1.13.10">
-                        <label>1938 ed. 1.13.10</label>
-                         tā dvādaśa tāsāṃ saviṣāḥ ṣaṭ tāvatya eva nirviṣāḥ || </l>
+                        <label>1938 ed. 1.13.10</label> tā dvādaśa tāsāṃ saviṣāḥ ṣaṭ tāvatya eva
+                        nirviṣāḥ || </l>
 
 
                     <l xml:id="SS.1.13.11">
-                        <label>1938 ed. 1.13.11</label>
-                         tatra saviṣāḥ kṛṣṇā karburā alagardā indrāyudhā sāmudrikā
-                        gocandanā ceti | tāsu añjanacūrṇavarṇā pṛthuśirāḥ kṛṣṇā
-                        varmimatsyavad āyatā chinnonnatakukṣiḥ karburā romaśā mahāpārśvā
-                        kṛṣṇamukhī alagardā indrāyudhavad ūrdhvarājibhiś citritā
-                        indrāyudhā īṣadasitapītikā vicitrapuṣpākṛticitrā sāmudrikāḥ
-                        govṛṣaṇavad adhobhāge dvidhābhūtākṛtir aṇumukhī gocandaneti |
-                        tābhir daṣṭe puruṣe daṃśe śvayathur atimātraṃ kaṇḍūrmūrcchā jvaro
-                        dāhaś chardir madaḥ sadanam iti liṅgāni bhavanti | tatra mahāgadaḥ
-                        pānālepananasya karmādiṣūpayojyaḥ | indrāyudhādaṣṭam asādhyam |
+                        <label>1938 ed. 1.13.11</label> tatra saviṣāḥ kṛṣṇā karburā alagardā
+                        indrāyudhā sāmudrikā gocandanā ceti | tāsu añjanacūrṇavarṇā pṛthuśirāḥ kṛṣṇā
+                        varmimatsyavad āyatā chinnonnatakukṣiḥ karburā romaśā mahāpārśvā kṛṣṇamukhī
+                        alagardā indrāyudhavad ūrdhvarājibhiś citritā indrāyudhā īṣadasitapītikā
+                        vicitrapuṣpākṛticitrā sāmudrikāḥ govṛṣaṇavad adhobhāge dvidhābhūtākṛtir
+                        aṇumukhī gocandaneti | tābhir daṣṭe puruṣe daṃśe śvayathur atimātraṃ
+                        kaṇḍūrmūrcchā jvaro dāhaś chardir madaḥ sadanam iti liṅgāni bhavanti | tatra
+                        mahāgadaḥ pānālepananasya karmādiṣūpayojyaḥ | indrāyudhādaṣṭam asādhyam |
                         ity etāḥ saviṣāḥ sacikitsitā vyākhyātāḥ || </l>
 
 
                     <l xml:id="SS.1.13.12">
-                        <label>1938 ed. 1.13.12</label>
-                         atha nirviṣāḥ kapilā piṅgalā śaṅkumukhī mūṣikā puṇḍarīkamukhī
-                        sāvarikā ceti | tatra manaḥśilārañjitābhyām iva pārśvābhyāṃ pṛṣṭhe
-                        snigdhā mudgavarṇā kapilā kiṃcidraktā vṛttakāyā piṅgalā ''śugā ca
-                        piṅgalā yakṛdvarṇā śīghrapāyinī dīrghatīkṣṇamukhī śaṅkumukhīḥ
-                        mūṣikākṛtivarṇā 'niṣṭagandhā ca mūṣikā mudgavarṇā
-                        puṇḍarīkatulyavaktrā puṇḍarīkamukhī snigdhā padmapatravarṇā
-                        'ṣṭādaśāṅgulapramāṇā sāvarikā sā ca paśvarthe ity etā aviṣā
-                        vyākhyātāḥ || </l>
+                        <label>1938 ed. 1.13.12</label> atha nirviṣāḥ kapilā piṅgalā śaṅkumukhī
+                        mūṣikā puṇḍarīkamukhī sāvarikā ceti | tatra manaḥśilārañjitābhyām iva
+                        pārśvābhyāṃ pṛṣṭhe snigdhā mudgavarṇā kapilā kiṃcidraktā vṛttakāyā piṅgalā
+                        ''śugā ca piṅgalā yakṛdvarṇā śīghrapāyinī dīrghatīkṣṇamukhī śaṅkumukhīḥ
+                        mūṣikākṛtivarṇā 'niṣṭagandhā ca mūṣikā mudgavarṇā puṇḍarīkatulyavaktrā
+                        puṇḍarīkamukhī snigdhā padmapatravarṇā 'ṣṭādaśāṅgulapramāṇā sāvarikā sā ca
+                        paśvarthe ity etā aviṣā vyākhyātāḥ || </l>
 
 
                     <l xml:id="SS.1.13.13">
-                        <label>1938 ed. 1.13.13</label>
-                         tāsāṃ yavanapāṇḍyasahya<pc> </pc>pautanādīni kṣetrāṇi teṣu
-                        mahāśarīrā balavatyaḥ śīghrapāyinyo mahāśanā nirviṣāś ca viśeṣeṇa
-                        bhavanti |</l>
+                        <label>1938 ed. 1.13.13</label> tāsāṃ yavanapāṇḍyasahya<pc> </pc>pautanādīni
+                        kṣetrāṇi teṣu mahāśarīrā balavatyaḥ śīghrapāyinyo mahāśanā nirviṣāś ca
+                        viśeṣeṇa bhavanti |</l>
 
 
                     <l xml:id="SS.1.13.14">
-                        <label>1938 ed. 1.13.14</label>
-                         tatra saviṣa<pc> </pc>matsya<pc> </pc>kīṭa<pc
-                            > </pc>dardura<pc> </pc>mūtra<pc> </pc>purīṣa<pc
-                        > </pc>kothajātāḥ kaluṣeṣv ambhaḥsu ca saviṣāḥ
-                            padmotpala<pc> </pc>nalina<pc> </pc>kumuda<pc
-                            > </pc>saugandhika<pc> </pc>kuvalaya<pc
-                            > </pc>puṇḍarīka<pc> </pc>śaivala<pc> </pc>kotha<pc> </pc>jātā
-                        vimaleṣv ambhaḥsu ca nirviṣāḥ || </l>
+                        <label>1938 ed. 1.13.14</label> tatra saviṣa<pc> </pc>matsya<pc
+                            > </pc>kīṭa<pc> </pc>dardura<pc> </pc>mūtra<pc> </pc>purīṣa<pc
+                        > </pc>kothajātāḥ kaluṣeṣv ambhaḥsu ca saviṣāḥ padmotpala<pc
+                            > </pc>nalina<pc> </pc>kumuda<pc> </pc>saugandhika<pc
+                            > </pc>kuvalaya<pc> </pc>puṇḍarīka<pc> </pc>śaivala<pc
+                            > </pc>kotha<pc> </pc>jātā vimaleṣv ambhaḥsu ca nirviṣāḥ || </l>
 
 
                     <l xml:id="SS.1.13.15">
-                        <label>1938 ed. 1.13.15</label>
-                         bhavati cātra |
+                        <label>1938 ed. 1.13.15</label> bhavati cātra |
                         <caesura/>
                          kṣetreṣu vicaranty etāḥ salilāḍhyasugandhiṣu |
                         <caesura/>
@@ -2784,22 +2932,20 @@
 
 
                     <l xml:id="SS.1.13.16">
-                        <label>1938 ed. 1.13.16</label>
-                         tāsāṃ grahaṇam ārdracarmaṇā, anyair vā prayogair gṛhṇīyāt || </l>
+                        <label>1938 ed. 1.13.16</label> tāsāṃ grahaṇam ārdracarmaṇā, anyair vā
+                        prayogair gṛhṇīyāt || </l>
 
 
                     <l xml:id="SS.1.13.17">
-                        <label>1938 ed. 1.13.17</label>
-                         athaināṃ nave mahati ghaṭe sarastaḍāgodakapaṅkam āvāpya nidadhyāt
-                        bhakṣyārthe cāsām upaharec chaivalaṃ vallūram audakāṃś ca kandāṃś
-                        cūrṇīkṛtya śayyārthaṃ tṛṇam audakāni ca patrāṇi tryahāt tryahāc
-                        cābhyo 'nyaj jalaṃ bhakṣyaṃ ca dadyāt saptarātrāt saptarātrāc ca
-                        ghaṭam anyaṃ saṃkrāmayet || </l>
+                        <label>1938 ed. 1.13.17</label> athaināṃ nave mahati ghaṭe
+                        sarastaḍāgodakapaṅkam āvāpya nidadhyāt bhakṣyārthe cāsām upaharec chaivalaṃ
+                        vallūram audakāṃś ca kandāṃś cūrṇīkṛtya śayyārthaṃ tṛṇam audakāni ca patrāṇi
+                        tryahāt tryahāc cābhyo 'nyaj jalaṃ bhakṣyaṃ ca dadyāt saptarātrāt
+                        saptarātrāc ca ghaṭam anyaṃ saṃkrāmayet || </l>
 
 
                     <l xml:id="SS.1.13.18">
-                        <label>1938 ed. 1.13.18</label>
-                         bhavati cātra |
+                        <label>1938 ed. 1.13.18</label> bhavati cātra |
                         <caesura/>
                          sthūlamadhyāḥ parikliṣṭāḥ pṛthvyo mandaviceṣṭitāḥ |
                         <caesura/>
@@ -2807,63 +2953,58 @@
 
 
                     <l xml:id="SS.1.13.19">
-                        <label>1938 ed. 1.13.19</label>
-                         atha jalauko 'vasekasādhyavyādhitam upaveśya saṃveśya vā virūkṣya
-                        cāsya tam avakāśaṃ mṛdgomayacūrṇair yady arujaḥ syāt | gṛhītāś ca
-                        tāḥ sarṣaparajanī<pc> </pc>kalkodaka<pc> </pc>pradigdha<pc
-                        > </pc>gātrīḥ salilasarakamadhye muhūrtasthitā vigataklamā jñātvā
-                        tābhī rogaṃ grāhayet | ślakṣṇaśuklārdrapicuprotāvacchannāṃ kṛtvā
-                        mukham apāvṛṇuyāt agṛhṇantyai kṣīrabinduṃ śoṇitabinduṃ vā dadyāt,
-                        śastrapadāni vā kurvīta yady evam api na gṛhṇīyāt tadā'nyāṃ
-                        grāhayet || </l>
+                        <label>1938 ed. 1.13.19</label> atha jalauko 'vasekasādhyavyādhitam upaveśya
+                        saṃveśya vā virūkṣya cāsya tam avakāśaṃ mṛdgomayacūrṇair yady arujaḥ syāt |
+                        gṛhītāś ca tāḥ sarṣaparajanī<pc> </pc>kalkodaka<pc> </pc>pradigdha<pc
+                        > </pc>gātrīḥ salilasarakamadhye muhūrtasthitā vigataklamā jñātvā tābhī
+                        rogaṃ grāhayet | ślakṣṇaśuklārdrapicuprotāvacchannāṃ kṛtvā mukham apāvṛṇuyāt
+                        agṛhṇantyai kṣīrabinduṃ śoṇitabinduṃ vā dadyāt, śastrapadāni vā kurvīta yady
+                        evam api na gṛhṇīyāt tadā'nyāṃ grāhayet || </l>
 
 
                     <l xml:id="SS.1.13.20">
-                        <label>1938 ed. 1.13.20</label>
-                         yadā ca niviśate 'śvakhuravad ānanaṃ kṛtvonnamya ca skandhaṃ tadā
-                        jānīyād gṛhṇātīti gṛhṇantīṃ cārdravastrāvacchannāṃ kṛtvā dhārayet
-                        || </l>
+                        <label>1938 ed. 1.13.20</label> yadā ca niviśate 'śvakhuravad ānanaṃ
+                        kṛtvonnamya ca skandhaṃ tadā jānīyād gṛhṇātīti gṛhṇantīṃ
+                        cārdravastrāvacchannāṃ kṛtvā dhārayet || </l>
 
 
                     <l xml:id="SS.1.13.21">
-                        <label>1938 ed. 1.13.21</label>
-                         daṃśe toda<pc> </pc>kaṇḍu<pc> </pc>prādur<pc> </pc>bhāvair
-                        jānīyāc chuddham iyam ādatta iti śuddham ādadānām apanayet atha
-                        śoṇitagandhena na muñcen mukham asyāḥ saindhavacūrṇenāvakiret || </l>
+                        <label>1938 ed. 1.13.21</label> daṃśe toda<pc> </pc>kaṇḍu<pc
+                            > </pc>prādur<pc> </pc>bhāvair jānīyāc chuddham iyam ādatta iti śuddham
+                        ādadānām apanayet atha śoṇitagandhena na muñcen mukham asyāḥ
+                        saindhavacūrṇenāvakiret || </l>
 
 
                     <l xml:id="SS.1.13.22">
-                        <label>1938 ed. 1.13.22</label>
-                         atha patitāṃ taṇḍula<pc> </pc>kaṇḍana<pc> </pc>pradigdhagātrīṃ
-                        tailalavaṇābhyaktamukhīṃ vāmahastāṅguṣṭhāṅgulībhyāṃ gṛhītapucchāṃ
-                        dakṣiṇahastāṅguṣṭhāṅgulibhyāṃ śanaiḥ śanair anulomam anumārjayed ā
-                        mukhāt vāmayet tāvad yāvat samyagvāntaliṅgānīti | samyagvāntā
-                            salilasarake<pc> </pc>nyastā bhoktukāmā satī caret | yā sīdatī
-                        na ceṣṭate sā durvāntā tāṃ punaḥ samyag vāmayet | durvāntāyā
-                        vyādhir asādhya indramado nāma bhavati | atha suvāntāṃ pūrvavat
+                        <label>1938 ed. 1.13.22</label> atha patitāṃ taṇḍula<pc
+                            > </pc>kaṇḍana<pc> </pc>pradigdhagātrīṃ tailalavaṇābhyaktamukhīṃ
+                        vāmahastāṅguṣṭhāṅgulībhyāṃ gṛhītapucchāṃ dakṣiṇahastāṅguṣṭhāṅgulibhyāṃ
+                        śanaiḥ śanair anulomam anumārjayed ā mukhāt vāmayet tāvad yāvat
+                        samyagvāntaliṅgānīti | samyagvāntā salilasarake<pc> </pc>nyastā bhoktukāmā
+                        satī caret | yā sīdatī na ceṣṭate sā durvāntā tāṃ punaḥ samyag vāmayet |
+                        durvāntāyā vyādhir asādhya indramado nāma bhavati | atha suvāntāṃ pūrvavat
                         sannidadhyāt || </l>
 
 
 
                     <l xml:id="SS.1.13.23">
-                        <label>1938 ed. 1.13.23</label>
-                         śoṇitasya yogāyogān avekṣya śatadhautaghṛtābhyaṅgas tat
-                        picudhāraṇaṃ vāi jalaukovraṇān madhunā'vaghaṭṭayet śitābhir adbhiś
-                        pariṣecayed badhnīta vā kaṣāyamadhurasnigdhaśītaiś ca pradehaiḥ
-                        pradihyād iti || </l>
+                        <label>1938 ed. 1.13.23</label> śoṇitasya yogāyogān avekṣya
+                        śatadhautaghṛtābhyaṅgas tat picudhāraṇaṃ vāi jalaukovraṇān
+                        madhunā'vaghaṭṭayet śitābhir adbhiś pariṣecayed badhnīta vā
+                        kaṣāyamadhurasnigdhaśītaiś ca pradehaiḥ pradihyād iti || </l>
 
 
 
 
 
                     <l xml:id="SS.1.13.24">
-                        <label>1938 ed. 1.13.24</label>
-                         bhavati cātra | kṣetrāṇi grahaṇaṃ jātīḥ poṣaṇaṃ sāvacāraṇam |
+                        <label>1938 ed. 1.13.24</label> bhavati cātra | kṣetrāṇi grahaṇaṃ jātīḥ
+                        poṣaṇaṃ sāvacāraṇam |
                         <caesura/>
                          jalaukasāṃ ca yo vetti tat sādhyān sa jayed gadān || </l>
 
-                    <p ana="trailer">iti suśrutasaṃhitāyāṃ sūtrasthāne jalaukāvacāraṇīyo
-                        nāma trayodaśo 'dhyāyaḥ || </p>
+                    <p ana="trailer">iti suśrutasaṃhitāyāṃ sūtrasthāne jalaukāvacāraṇīyo nāma
+                        trayodaśo 'dhyāyaḥ || </p>
                 </div>
 
                 <div n="14" type="adhyāya">
@@ -2874,17 +3015,14 @@
                         <caesura/>
                          tatra pāñcabhautikasya caturvidhasya ṣaḍrasasya
                         dvividhavīryasyāṣṭavidhavīryasya vā'nekaguṇasyopayuktasyāhārasya
-                        samyakpariṇatasya yastejobhūtaḥ sāraḥ paramasūkṣmaḥ sa `rasaḥ’ ity
-                        ucyate, tasya hṛdayaṃ sthānaṃ, sa
-                        hṛdayāccaturviṃśatidhamanīranupraviśyor dhvagādaśa
-                        daśādhogāminyaścatasraś ca tiryaggāḥ kṛtsnaṃ
-                        śarīramaharahastarpayati vardhayati dhārayati yāpayati
-                        cādṛṣṭahetukena karmaṇā | tasya śarīramanusarato 'numānād
-                        gatirupalakṣayitavyā kṣayavṛddhivaikṛtaiḥ | tasmin
+                        samyakpariṇatasya yastejobhūtaḥ sāraḥ paramasūkṣmaḥ sa `rasaḥ’ ity ucyate,
+                        tasya hṛdayaṃ sthānaṃ, sa hṛdayāccaturviṃśatidhamanīranupraviśyor dhvagādaśa
+                        daśādhogāminyaścatasraś ca tiryaggāḥ kṛtsnaṃ śarīramaharahastarpayati
+                        vardhayati dhārayati yāpayati cādṛṣṭahetukena karmaṇā | tasya
+                        śarīramanusarato 'numānād gatirupalakṣayitavyā kṣayavṛddhivaikṛtaiḥ | tasmin
                         sarvaśarīrāvayavadoṣadhātumalāśayānusāriṇi rase jijñāsā- kimayaṃ
                         saumyastaijasa? iti | atrocyate- sa khalu dravānusārī
-                        snehanajīvanatarpaṇadhāraṇādibhir viśeṣaiḥ saumya ity avagamyate
-                        ||3|| </l>
+                        snehanajīvanatarpaṇadhāraṇādibhir viśeṣaiḥ saumya ity avagamyate ||3|| </l>
 
                     <l xml:id="SS.1.14.4">
                         <label>1938 ed. 1.14.4</label>
@@ -2894,8 +3032,8 @@
                     <l xml:id="SS.1.14.5">
                         <label>1938 ed. 1.14.5</label>
                         <caesura/>
-                         ślokau cātra bhavataḥ- rañjitāstejasā tvāpaḥ śarīrasthena dehinām
-                        | avyāpannāḥ prasannena raktam ity abhidhīyate ||5|| </l>
+                         ślokau cātra bhavataḥ- rañjitāstejasā tvāpaḥ śarīrasthena dehinām |
+                        avyāpannāḥ prasannena raktam ity abhidhīyate ||5|| </l>
 
                     <l xml:id="SS.1.14.6">
                         <label>1938 ed. 1.14.6</label>
@@ -2917,14 +3055,14 @@
                     <l xml:id="SS.1.14.9">
                         <label>1938 ed. 1.14.9</label>
                         <caesura/>
-                         visratā dravatā rāgaḥ spandanaṃ laghutā tathā | bhūmyādīnāṃ guṇā
-                        hyete dṛśyante cātra śoṇite ||9|| </l>
+                         visratā dravatā rāgaḥ spandanaṃ laghutā tathā | bhūmyādīnāṃ guṇā hyete
+                        dṛśyante cātra śoṇite ||9|| </l>
 
                     <l xml:id="SS.1.14.10">
                         <label>1938 ed. 1.14.10</label>
                         <caesura/>
-                         rasādraktaṃ tato māṃsaṃ māṃsānmedaḥ prajāyate | medaso 'sthi tato
-                        majjā majjñaḥ śukraṃ tu jāyate ||10|| </l>
+                         rasādraktaṃ tato māṃsaṃ māṃsānmedaḥ prajāyate | medaso 'sthi tato majjā
+                        majjñaḥ śukraṃ tu jāyate ||10|| </l>
 
                     <l xml:id="SS.1.14.11">
                         <label>1938 ed. 1.14.11</label>
@@ -2946,8 +3084,7 @@
                         <label>1938 ed. 1.14.14</label>
                         <caesura/>
                          sa khalu trīṇi trīṇi kalāsahasrāṇi pañcadaśa ca kalā ekaikasmin
-                        dhātāvavatiṣṭhate; evaṃ māsena rasaḥ śukraṃ strīṇāṃ cārtavaṃ
-                        bhavati ||14|| </l>
+                        dhātāvavatiṣṭhate; evaṃ māsena rasaḥ śukraṃ strīṇāṃ cārtavaṃ bhavati ||14|| </l>
 
                     <l xml:id="SS.1.14.15">
                         <label>1938 ed. 1.14.15</label>
@@ -2959,30 +3096,28 @@
                     <l xml:id="SS.1.14.16">
                         <label>1938 ed. 1.14.16</label>
                         <caesura/>
-                         sa śabdārcirjalasantānavadaṇunā viśeṣeṇānudhāvaty evaṃ śarīraṃ
-                        kevalam ||16|| </l>
+                         sa śabdārcirjalasantānavadaṇunā viśeṣeṇānudhāvaty evaṃ śarīraṃ kevalam
+                        ||16|| </l>
 
                     <l xml:id="SS.1.14.17">
                         <label>1938 ed. 1.14.17</label>
                         <caesura/>
-                         vājīkaraṇyastvoṣadhayaḥ svabalaguṇotkarṣādvirecanavadupayuktāḥ
-                        śukraṃ śīghraṃ virecayanti ||17|| </l>
+                         vājīkaraṇyastvoṣadhayaḥ svabalaguṇotkarṣādvirecanavadupayuktāḥ śukraṃ
+                        śīghraṃ virecayanti ||17|| </l>
 
                     <l xml:id="SS.1.14.18">
                         <label>1938 ed. 1.14.18</label>
                         <caesura/>
-                         yathā hi puṣpamukulastho gandho na śakyamihāstīti vaktuṃ, naiva
-                        nāstīti; atha cāsti, satāṃ bhāvānāmabhivyaktiriti jñātvā , kevalaṃ
-                        saukṣmyānnābhivyajyate; sa eva vivṛtapatrakeśare puṣpe
-                        kālāntareṇābhivyaktiṃ gacchati; evaṃ bālānām api
-                        vayaḥpariṇāmācchukraprādurbhāvo bhavati, romarājyādayaś ca viśeṣā
-                        nārīṇām ||18|| </l>
+                         yathā hi puṣpamukulastho gandho na śakyamihāstīti vaktuṃ, naiva nāstīti;
+                        atha cāsti, satāṃ bhāvānāmabhivyaktiriti jñātvā , kevalaṃ
+                        saukṣmyānnābhivyajyate; sa eva vivṛtapatrakeśare puṣpe kālāntareṇābhivyaktiṃ
+                        gacchati; evaṃ bālānām api vayaḥpariṇāmācchukraprādurbhāvo bhavati,
+                        romarājyādayaś ca viśeṣā nārīṇām ||18|| </l>
 
                     <l xml:id="SS.1.14.19">
                         <label>1938 ed. 1.14.19</label>
                         <caesura/>
-                         sa evānnaraso vṛddhānāṃ (jarā) paripakvaśarīratvād aprīṇano
-                        bhavati ||19|| </l>
+                         sa evānnaraso vṛddhānāṃ (jarā) paripakvaśarīratvād aprīṇano bhavati ||19|| </l>
 
                     <l xml:id="SS.1.14.20">
                         <label>1938 ed. 1.14.20</label>
@@ -2992,19 +3127,17 @@
                     <l xml:id="SS.1.14.21">
                         <label>1938 ed. 1.14.21</label>
                         <caesura/>
-                         teṣāṃ kṣayavṛddhī śoṇitanimitte, tasmāt tad adhikṛtya vakṣyāmaḥ |
-                        tatra, phenilamaruṇaṃ kṛṣṇaṃ paruṣaṃ tanu śīghragamaskandi ca
-                        vātena duṣṭaṃ; nīlaṃ pītaṃ haritaṃ śyāvaṃ visramaniṣṭaṃ
-                        pipīlikāmakṣikāṇāmaskandi ca pittena duṣṭaṃ; gairikodakapratīkāśaṃ
-                        snigdhaṃ śītalaṃ bahalaṃ picchilaṃ cirasrāvi māṃsapeśīprabhaṃ ca
-                        śleṣmaduṣṭaṃ; sarvalakṣaṇasaṃyuktaṃ kāñjikābhaṃ viśeṣato durgandhi
-                        ca sannipātaduṣṭaṃ; dvidoṣaliṅgaṃ saṃsṛṣṭam ||21|| </l>
+                         teṣāṃ kṣayavṛddhī śoṇitanimitte, tasmāt tad adhikṛtya vakṣyāmaḥ | tatra,
+                        phenilamaruṇaṃ kṛṣṇaṃ paruṣaṃ tanu śīghragamaskandi ca vātena duṣṭaṃ; nīlaṃ
+                        pītaṃ haritaṃ śyāvaṃ visramaniṣṭaṃ pipīlikāmakṣikāṇāmaskandi ca pittena
+                        duṣṭaṃ; gairikodakapratīkāśaṃ snigdhaṃ śītalaṃ bahalaṃ picchilaṃ cirasrāvi
+                        māṃsapeśīprabhaṃ ca śleṣmaduṣṭaṃ; sarvalakṣaṇasaṃyuktaṃ kāñjikābhaṃ viśeṣato
+                        durgandhi ca sannipātaduṣṭaṃ; dvidoṣaliṅgaṃ saṃsṛṣṭam ||21|| </l>
 
                     <l xml:id="SS.1.14.22">
                         <label>1938 ed. 1.14.22</label>
                         <caesura/>
-                         indragopakapratīkāśamasaṃhatamavivarṇaṃ ca prakṛtisthaṃ jānīyāt
-                        ||22|| </l>
+                         indragopakapratīkāśamasaṃhatamavivarṇaṃ ca prakṛtisthaṃ jānīyāt ||22|| </l>
 
                     <l xml:id="SS.1.14.23">
                         <label>1938 ed. 1.14.23</label>
@@ -3025,58 +3158,57 @@
                     <l xml:id="SS.1.14.26">
                         <label>1938 ed. 1.14.26</label>
                         <caesura/>
-                         tatra, ṛjvasaṅkīrṇaṃ sūkṣmaṃ samamanavagāḍhamanuttānamāśu ca
-                        śastraṃ pātayenmarmasirāsnāyusandhīnāṃ cānupaghāti ||26|| </l>
+                         tatra, ṛjvasaṅkīrṇaṃ sūkṣmaṃ samamanavagāḍhamanuttānamāśu ca śastraṃ
+                        pātayenmarmasirāsnāyusandhīnāṃ cānupaghāti ||26|| </l>
 
                     <l xml:id="SS.1.14.27">
                         <label>1938 ed. 1.14.27</label>
                         <caesura/>
-                         tatra, durdine durviddhe śītavātayor asvinne bhuktamātre
-                        skandatvāc choṇitaṃ na sravatyalpaṃ vā sravati ||27|| </l>
+                         tatra, durdine durviddhe śītavātayor asvinne bhuktamātre skandatvāc
+                        choṇitaṃ na sravatyalpaṃ vā sravati ||27|| </l>
 
                     <l xml:id="SS.1.14.28">
                         <label>1938 ed. 1.14.28</label>
                         <caesura/>
-                         madamūrcchāśramārtānāṃ vātaviṇmūtrasaṅginām |
-                        nidrābhibhūtabhītānāṃ nṛṇāṃ nāsṛk pravartate ||28|| </l>
+                         madamūrcchāśramārtānāṃ vātaviṇmūtrasaṅginām | nidrābhibhūtabhītānāṃ nṛṇāṃ
+                        nāsṛk pravartate ||28|| </l>
 
                     <l xml:id="SS.1.14.29">
                         <label>1938 ed. 1.14.29</label>
                         <caesura/>
-                         tad duṣṭaṃ śoṇitamanirhriyamāṇaṃ śophadāharāgapākavedanā janayet
-                        ||29|| </l>
+                         tad duṣṭaṃ śoṇitamanirhriyamāṇaṃ śophadāharāgapākavedanā janayet ||29|| </l>
 
                     <l xml:id="SS.1.14.30">
                         <label>1938 ed. 1.14.30</label>
                         <caesura/>
                          atyuṣṇe 'tisvinne 'tividdhe 'jñairvisrāvitamatipravartate ; tad
                         atipravṛttaṃ śiro 'bhitāpamāndhyamadhimanthatimiraprādurbhāvaṃ
-                        dhātukṣayamākṣepakaṃ dāhaṃ pakṣāghātamekāṅgavikāraṃ hikkāṃ
-                        śvāsakāsau pāṇḍurogaṃ maraṇaṃ cāpādayati ||30|| </l>
+                        dhātukṣayamākṣepakaṃ dāhaṃ pakṣāghātamekāṅgavikāraṃ hikkāṃ śvāsakāsau
+                        pāṇḍurogaṃ maraṇaṃ cāpādayati ||30|| </l>
 
                     <l xml:id="SS.1.14.31">
                         <label>1938 ed. 1.14.31</label>
                         <caesura/>
-                         tasmānna śīte nātyuṣṇe nāsvinne nātitāpite | yavāgūṃ prati
-                        pītasya śoṇitaṃ mokṣayed bhiṣak ||31|| </l>
+                         tasmānna śīte nātyuṣṇe nāsvinne nātitāpite | yavāgūṃ prati pītasya śoṇitaṃ
+                        mokṣayed bhiṣak ||31|| </l>
 
                     <l xml:id="SS.1.14.32">
                         <label>1938 ed. 1.14.32</label>
                         <caesura/>
-                         samyaggatvā yadā raktaṃ svayamevāvatiṣṭhate | śuddhaṃ tadā
-                        vijānīyāt samyagvisrāvitaṃ ca tat ||32|| </l>
+                         samyaggatvā yadā raktaṃ svayamevāvatiṣṭhate | śuddhaṃ tadā vijānīyāt
+                        samyagvisrāvitaṃ ca tat ||32|| </l>
 
                     <l xml:id="SS.1.14.33">
                         <label>1938 ed. 1.14.33</label>
                         <caesura/>
-                         lāghavaṃ vedanāśāntirvyāghervegaparikṣayaḥ | samyagvisrāvite
-                        liṅgaṃ prasādo manasas tathā ||33|| </l>
+                         lāghavaṃ vedanāśāntirvyāghervegaparikṣayaḥ | samyagvisrāvite liṅgaṃ prasādo
+                        manasas tathā ||33|| </l>
 
                     <l xml:id="SS.1.14.34">
                         <label>1938 ed. 1.14.34</label>
                         <caesura/>
-                         tvagdoṣā granthayaḥ śophā rogāḥ śoṇitajāś ca ye |
-                        raktamokṣaṇaśīlānāṃ na bhavanti kadācana ||34|| </l>
+                         tvagdoṣā granthayaḥ śophā rogāḥ śoṇitajāś ca ye | raktamokṣaṇaśīlānāṃ na
+                        bhavanti kadācana ||34|| </l>
 
                     <l xml:id="SS.1.14.35">
                         <label>1938 ed. 1.14.35</label>
@@ -3084,8 +3216,8 @@
                          atha khalvapravartamāne rakte
                         elāśītaśivakuṣṭhatagarapāṭhābhadradāruviḍaṅgacitrakatrikaṭukāgāradhūmaharidrārkāṅkuranaktamālaphalairyathālābhaṃ
                         tribhiścaturbhiḥ samastair vā
-                        cūrṇīkṛtairlavaṇatailapragāḍhairvraṇamukhamavagharṣayet, evaṃ
-                        samyak pravartate ||35|| </l>
+                        cūrṇīkṛtairlavaṇatailapragāḍhairvraṇamukhamavagharṣayet, evaṃ samyak
+                        pravartate ||35|| </l>
 
                     <l xml:id="SS.1.14.36">
                         <label>1938 ed. 1.14.36</label>
@@ -3093,75 +3225,75 @@
                          athātipravṛtte
                         rodhramadhukapriyaṅgupattaṅgupattaṅgagairikasarjarasarasāñjanaśālmalīpuṣpaśaṅkhaśuktimāṣayavagodhūmacūrṇaiḥ
                         śanaiḥ śanairvraṇamukhamavacūrṇyāṅgulyagreṇāvapīḍayet
-                        sālasarjārjunārimedameṣaśṛṅgadhavadhanvanatvagbhi rvā cūrṇitābhiḥ
-                        kṣaumeṇa vā dhmāpitena samudraphenalākṣācūrṇair vā,
-                        yathoktarvraṇabandhanadravyairgāḍhaṃ badhnīyāt,
-                        śītācchādanabhojanāgāraiḥ śītaiḥ pradehapariṣekaiścopacaret,
-                        kṣāreṇāgninā vā dahedyathoktaṃ, vyadhādanantaraṃ tāmevātipravṛttāṃ
-                        sirāṃ vidhyet; kākolyādikvāthaṃ vā śarkarāmadhumadhuraṃ pāyayet,
-                        eṇahariṇorabhraśaśamahiṣavarāhāṇāṃ vā rudhiraṃ; kṣīrayūṣarasaiḥ
-                        susnigdhaiś cāśnīyāt; upadravāṃś ca yathāsvam upacaret ||36|| </l>
+                        sālasarjārjunārimedameṣaśṛṅgadhavadhanvanatvagbhi rvā cūrṇitābhiḥ kṣaumeṇa
+                        vā dhmāpitena samudraphenalākṣācūrṇair vā,
+                        yathoktarvraṇabandhanadravyairgāḍhaṃ badhnīyāt, śītācchādanabhojanāgāraiḥ
+                        śītaiḥ pradehapariṣekaiścopacaret, kṣāreṇāgninā vā dahedyathoktaṃ,
+                        vyadhādanantaraṃ tāmevātipravṛttāṃ sirāṃ vidhyet; kākolyādikvāthaṃ vā
+                        śarkarāmadhumadhuraṃ pāyayet, eṇahariṇorabhraśaśamahiṣavarāhāṇāṃ vā
+                        rudhiraṃ; kṣīrayūṣarasaiḥ susnigdhaiś cāśnīyāt; upadravāṃś ca yathāsvam
+                        upacaret ||36|| </l>
 
                     <l xml:id="SS.1.14.37">
                         <label>1938 ed. 1.14.37</label>
                         <caesura/>
-                         bhavanti cātra - dhātukṣayāt srute rakte mandaḥ sañjāyate 'nalaḥ
-                        | pavanaś ca paraṃ kopaṃ yāti tasmāt prayatnataḥ ||37|| </l>
+                         bhavanti cātra - dhātukṣayāt srute rakte mandaḥ sañjāyate 'nalaḥ | pavanaś
+                        ca paraṃ kopaṃ yāti tasmāt prayatnataḥ ||37|| </l>
 
                     <l xml:id="SS.1.14.38">
                         <label>1938 ed. 1.14.38</label>
                         <caesura/>
-                         taṃ nātiśītairlaghubhiḥ snigdhaiḥ śoṇitavardhanaiḥ |
-                        īṣadamlairanamlair vā bhojanaiḥ samupācaret ||38||</l>
+                         taṃ nātiśītairlaghubhiḥ snigdhaiḥ śoṇitavardhanaiḥ | īṣadamlairanamlair vā
+                        bhojanaiḥ samupācaret ||38||</l>
 
                     <l xml:id="SS.1.14.39">
                         <label>1938 ed. 1.14.39</label>
                         <caesura/>
-                         caturvidhaṃ yadetaddhi rudhirasya nivāraṇam | sandhānaṃ skandanaṃ
-                        caiva pācanaṃ dahanaṃ tathā ||39|| </l>
+                         caturvidhaṃ yadetaddhi rudhirasya nivāraṇam | sandhānaṃ skandanaṃ caiva
+                        pācanaṃ dahanaṃ tathā ||39|| </l>
 
                     <l xml:id="SS.1.14.40">
                         <label>1938 ed. 1.14.40</label>
                         <caesura/>
-                         vraṇaṃ kaṣāyaḥ sandhatte raktaṃ skandayate himam | tathā
-                        sampācayed bhasma dāhaḥ saṅkocayet sirāḥ ||40|| </l>
+                         vraṇaṃ kaṣāyaḥ sandhatte raktaṃ skandayate himam | tathā sampācayed bhasma
+                        dāhaḥ saṅkocayet sirāḥ ||40|| </l>
 
                     <l xml:id="SS.1.14.41">
                         <label>1938 ed. 1.14.41</label>
                         <caesura/>
-                         askandamāne rudhire sandhānāni prayojayet | sandhāne bhraśyamāne
-                        tu pācanaiḥ samupācaret ||41|| </l>
+                         askandamāne rudhire sandhānāni prayojayet | sandhāne bhraśyamāne tu
+                        pācanaiḥ samupācaret ||41|| </l>
 
 
                     <l xml:id="SS.1.14.42">
                         <label>1938 ed. 1.14.42</label>
                         <caesura/>
-                         kalpairetaistribhir vaidyaḥ prayateta yathāvidhi | asiddhimatsu
-                        caiteṣu dāhaḥ parama iṣyate ||42|| </l>
+                         kalpairetaistribhir vaidyaḥ prayateta yathāvidhi | asiddhimatsu caiteṣu
+                        dāhaḥ parama iṣyate ||42|| </l>
 
                     <l xml:id="SS.1.14.43">
                         <label>1938 ed. 1.14.43</label>
                         <caesura/>
-                         śeṣadoṣe yato rakte na vyādhirativartate | sāvaśeṣe tataḥ stheyaṃ
-                        na tu kuryād atikramam ||43|| </l>
+                         śeṣadoṣe yato rakte na vyādhirativartate | sāvaśeṣe tataḥ stheyaṃ na tu
+                        kuryād atikramam ||43|| </l>
 
                     <l xml:id="SS.1.14.44">
                         <label>1938 ed. 1.14.44</label>
                         <caesura/>
-                         dehasya rudhiraṃ mūlaṃ rudhireṇaiva dhāryate | tasmād yatnena
-                        saṃrakṣyaṃ raktaṃ jīva iti sthitiḥ ||44|| </l>
+                         dehasya rudhiraṃ mūlaṃ rudhireṇaiva dhāryate | tasmād yatnena saṃrakṣyaṃ
+                        raktaṃ jīva iti sthitiḥ ||44|| </l>
 
                     <l xml:id="SS.1.14.45">
                         <label>1938 ed. 1.14.45</label>
                         <caesura/>
-                         srutaraktasya sekādyaiḥ śītaiḥ prakupite 'nile | śophaṃ satodaṃ
-                        koṣṇena sarpiṣā pariṣecat ||45|| </l>
+                         srutaraktasya sekādyaiḥ śītaiḥ prakupite 'nile | śophaṃ satodaṃ koṣṇena
+                        sarpiṣā pariṣecat ||45|| </l>
 
                     <l xml:id="SS.1.14.trailer">
                         <label>1938 ed. 1.14.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne śoṇitavarṇanīyo nāma caturdaśo
-                        'dhyāya ||14|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne śoṇitavarṇanīyo nāma caturdaśo 'dhyāya
+                        ||14|| </l>
                 </div>
 
                 <div n="15" type="adhyāya">
@@ -3170,16 +3302,15 @@
                     <l xml:id="SS.1.15.3">
                         <label>1938 ed. 1.15.3</label>
                         <caesura/>
-                         doṣadhātumalamūlaṃ hi śarīraṃ, tasmād eteṣāṃ lakṣaṇamucyamānam
-                        upadhāraya ||3|| </l>
+                         doṣadhātumalamūlaṃ hi śarīraṃ, tasmād eteṣāṃ lakṣaṇamucyamānam upadhāraya
+                        ||3|| </l>
 
                     <l xml:id="SS.1.15.4">
                         <label>1938 ed. 1.15.4</label>
                         <caesura/>
                          tatra praspandanodvahanapūraṇavivekadhāraṇalakṣaṇo vāyuḥ pañcadhā
-                        pravibhaktaḥ śarīraṃ dhārayati (1) |4|
-                        rāgapaktyojastejomedhoṣmakṛt pittaṃ pañcadhā
-                        pravibhaktamagnikarmaṇā'nugrahaṃ karoti; (2) |4|
+                        pravibhaktaḥ śarīraṃ dhārayati (1) |4| rāgapaktyojastejomedhoṣmakṛt pittaṃ
+                        pañcadhā pravibhaktamagnikarmaṇā'nugrahaṃ karoti; (2) |4|
                         sandhisaṃśleṣaṇasnehanaropaṇapūraṇabalasthairyakṛcchleṣmā pañcadhā
                         pravibhakta udakakarmaṇā'nugrahaṃ karoti ||4|| </l>
 
@@ -3187,17 +3318,16 @@
                         <label>1938 ed. 1.15.5</label>
                         <caesura/>
                          rasastuṣṭiṃ prīṇanaṃ raktapuṣṭiṃ ca karoti, raktaṃ varṇaprasādaṃ
-                        māṃsapuṣṭiṃ jīvayati ca, māṃsaṃ śarīrapuṣṭiṃ medasaśca, medaḥ
-                        snehasvedau dṛḍhatvaṃ puṣṭimasthnāṃ ca, asthīni dehadhāraṇaṃ
-                        majjñaḥ puṣṭiṃ ca, majjā snehaṃ balaṃ śukrapuṣṭiṃ pūraṇamasthnāṃ
-                        ca karoti, śukraṃ dhairyaṃ cyavanaṃ prītiṃ dehabalaṃ harṣaṃ
-                        bījārthaṃ ca; (1)
+                        māṃsapuṣṭiṃ jīvayati ca, māṃsaṃ śarīrapuṣṭiṃ medasaśca, medaḥ snehasvedau
+                        dṛḍhatvaṃ puṣṭimasthnāṃ ca, asthīni dehadhāraṇaṃ majjñaḥ puṣṭiṃ ca, majjā
+                        snehaṃ balaṃ śukrapuṣṭiṃ pūraṇamasthnāṃ ca karoti, śukraṃ dhairyaṃ cyavanaṃ
+                        prītiṃ dehabalaṃ harṣaṃ bījārthaṃ ca; (1)
                         <caesura/>
-                         purīṣam upastambhaṃ vāyvagnidhāraṇaṃ ca,
-                        bastipūraṇavikledakṛnmūtraṃ, svedaḥ kledatvaksaukumāryakṛt; (2)
+                         purīṣam upastambhaṃ vāyvagnidhāraṇaṃ ca, bastipūraṇavikledakṛnmūtraṃ,
+                        svedaḥ kledatvaksaukumāryakṛt; (2)
                         <caesura/>
-                         raktalakṣaṇamārtavaṃ garbhakṛcca, garbho garbhalakṣaṇaṃ, stanyaṃ
-                        stanayor āpīnatvajananaṃ jīvanaṃ ceti ||5|| </l>
+                         raktalakṣaṇamārtavaṃ garbhakṛcca, garbho garbhalakṣaṇaṃ, stanyaṃ stanayor
+                        āpīnatvajananaṃ jīvanaṃ ceti ||5|| </l>
 
                     <l xml:id="SS.1.15.6">
                         <label>1938 ed. 1.15.6</label>
@@ -3208,10 +3338,9 @@
                         <label>1938 ed. 1.15.7</label>
                         <caesura/>
                          ata ūrdhvameṣāṃ kṣīṇalakṣaṇaṃ vakṣyāmaḥ | tatra, vātakṣaye
-                        mandaceṣṭatā'lpavāktvamapraharṣo mūḍhasañjñatā ca, pittakṣaye
-                        mandoṣmāgnitā niṣprabhatā ca, śleṣmakṣaye rūkṣatā'ntardāha
-                        āmāśayetaraśleṣmāśayaśūnyatā sandhiśaithilyaṃ (tṛṣṇā daurbalyaṃ
-                        prajāgaraṇaṃ) ca ||7|| </l>
+                        mandaceṣṭatā'lpavāktvamapraharṣo mūḍhasañjñatā ca, pittakṣaye mandoṣmāgnitā
+                        niṣprabhatā ca, śleṣmakṣaye rūkṣatā'ntardāha āmāśayetaraśleṣmāśayaśūnyatā
+                        sandhiśaithilyaṃ (tṛṣṇā daurbalyaṃ prajāgaraṇaṃ) ca ||7|| </l>
 
                     <l xml:id="SS.1.15.8">
                         <label>1938 ed. 1.15.8</label>
@@ -3223,13 +3352,12 @@
                         <caesura/>
                          rasakṣaye hṛtpīḍākampaśūnyatāstṛṣṇā ca, śoṇitakṣaye
                         tvakpāruṣyamamlaśītaprārthanā sirāśaithilyaṃ ca, māṃsakṣaye
-                        sphiggaṇḍauṣṭhopasthoruvakṣaḥkakṣāpiṇḍikodaragrīvāśuṣkatā
-                        raukṣyatodau gātrāṇāṃ sadanaṃ dhamanīśaithilyaṃ ca, medaḥkṣaye
-                        plīhābhivṛddhiḥ sandhiśūnyatā raukṣyaṃ meduramāṃsaprārthanā ca,
-                        asthikṣaye 'sthiśūlaṃ dantanakhabhaṅgo raukṣyaṃ ca, majjakṣaye
-                        'lpaśukratā parvabhedo 'sthinistodo 'sthiśūnyatā ca, śukrakṣaye
-                        meḍhravṛṣaṇavedanā'śaktirmaithune cirād vā prasekaḥ praseke
-                        cālparaktaśukradarśanam ||9|| </l>
+                        sphiggaṇḍauṣṭhopasthoruvakṣaḥkakṣāpiṇḍikodaragrīvāśuṣkatā raukṣyatodau
+                        gātrāṇāṃ sadanaṃ dhamanīśaithilyaṃ ca, medaḥkṣaye plīhābhivṛddhiḥ
+                        sandhiśūnyatā raukṣyaṃ meduramāṃsaprārthanā ca, asthikṣaye 'sthiśūlaṃ
+                        dantanakhabhaṅgo raukṣyaṃ ca, majjakṣaye 'lpaśukratā parvabhedo 'sthinistodo
+                        'sthiśūnyatā ca, śukrakṣaye meḍhravṛṣaṇavedanā'śaktirmaithune cirād vā
+                        prasekaḥ praseke cālparaktaśukradarśanam ||9|| </l>
 
                     <l xml:id="SS.1.15.10">
                         <label>1938 ed. 1.15.10</label>
@@ -3239,63 +3367,57 @@
                     <l xml:id="SS.1.15.11">
                         <label>1938 ed. 1.15.11</label>
                         <caesura/>
-                         purīṣakṣaye hṛdayapārśvapīḍā saśabdasya ca vāyor ūrdhvagamanaṃ
-                        kukṣau sañcaraṇaṃ ca, mūtrakṣaye bastitodo 'lpamūtratā ca; atrāpi
-                        svayonivardhanadravyopayogaḥ | svedakṣaye stabdharomakūpatā
-                        tvakśoṣaḥ sparśavaiguṇyaṃ svedanāśaśca; tatrābhyaṅgaḥ svedopayogaś
-                        ca ||11|| </l>
+                         purīṣakṣaye hṛdayapārśvapīḍā saśabdasya ca vāyor ūrdhvagamanaṃ kukṣau
+                        sañcaraṇaṃ ca, mūtrakṣaye bastitodo 'lpamūtratā ca; atrāpi
+                        svayonivardhanadravyopayogaḥ | svedakṣaye stabdharomakūpatā tvakśoṣaḥ
+                        sparśavaiguṇyaṃ svedanāśaśca; tatrābhyaṅgaḥ svedopayogaś ca ||11|| </l>
 
                     <l xml:id="SS.1.15.12">
                         <label>1938 ed. 1.15.12</label>
                         <caesura/>
                          ārtavakṣaye yathocitakālādarśanamalpatā vā yonivedanā ca; tatra
-                        saṃśodhanamāgneyānāṃ ca dravyāṇāṃ vidhivadupayogaḥ | stanakṣaye
-                        stanayor mlānatā stanyāsambhavo 'lpatā vā; tatra
-                        śleṣmavardhanadravyopayogaḥ | garbhakṣaye
-                        garbhāspandanamanunnatakukṣitā ca; tatra prāptabastikālāyāḥ
+                        saṃśodhanamāgneyānāṃ ca dravyāṇāṃ vidhivadupayogaḥ | stanakṣaye stanayor
+                        mlānatā stanyāsambhavo 'lpatā vā; tatra śleṣmavardhanadravyopayogaḥ |
+                        garbhakṣaye garbhāspandanamanunnatakukṣitā ca; tatra prāptabastikālāyāḥ
                         kṣīrabastiprayogo medyānnopayogaśceti ||12|| </l>
 
                     <l xml:id="SS.1.15.13">
                         <label>1938 ed. 1.15.13</label>
                         <caesura/>
-                         ata ūrdhvamativṛddhānāṃ doṣadhātumalānāṃ lakṣaṇaṃ vakṣyāmaḥ |
-                        vṛddhiḥ punareṣāṃ svayonivardhanātyupasevanādbhavati | tatra,
-                        vātavṛddhau vākpāruṣyaṃ kārśyaṃ kārṣṇyaṃ
-                        gātrasphuraṇamuṣṇakāmi(ma)tā nidrānāśo 'lpabalatvaṃ
-                        gāḍhavarcastvaṃ ca; pittavṛddhau pītāvabhāsatā santāpaḥ
+                         ata ūrdhvamativṛddhānāṃ doṣadhātumalānāṃ lakṣaṇaṃ vakṣyāmaḥ | vṛddhiḥ
+                        punareṣāṃ svayonivardhanātyupasevanādbhavati | tatra, vātavṛddhau
+                        vākpāruṣyaṃ kārśyaṃ kārṣṇyaṃ gātrasphuraṇamuṣṇakāmi(ma)tā nidrānāśo
+                        'lpabalatvaṃ gāḍhavarcastvaṃ ca; pittavṛddhau pītāvabhāsatā santāpaḥ
                         śītakāmitvamalpanidratā mūrcchā balahānirindriyadaurbalyaṃ
-                        pītaviṇmūtranetratvaṃ ca; śleṣmavṛddhau śauklyaṃ śaity aṃ
-                        sthairyaṃ gauravamavasādastandrā nidrā sandhiviśleṣaś ca ||13|| </l>
+                        pītaviṇmūtranetratvaṃ ca; śleṣmavṛddhau śauklyaṃ śaity aṃ sthairyaṃ
+                        gauravamavasādastandrā nidrā sandhiviśleṣaś ca ||13|| </l>
 
                     <l xml:id="SS.1.15.14">
                         <label>1938 ed. 1.15.14</label>
                         <caesura/>
-                         raso 'tivṛddho hṛdayotkledaṃ prasekaṃ cāpādayati; raktaṃ
-                        raktāṅgākṣitāṃ sirāpūrṇatvaṃ ca; māṃsaṃ
-                        sphiggaṇḍauṣṭhopasthorubāhujaṅghāsu vṛddhiṃ gurugātratāṃ ca;
-                        medaḥsnigdhāṅgatāmudarapārśvavṛddhiṃ kāsaśvāsādīn daurgandhyaṃ ca;
-                        asthyadhyasthīnyadhidantāṃśca; majjā sarvāṅganetragauravaṃ ca;
-                        śukraṃ śukrāśmarīmatiprādurbhāvaṃ ca ||14|| </l>
+                         raso 'tivṛddho hṛdayotkledaṃ prasekaṃ cāpādayati; raktaṃ raktāṅgākṣitāṃ
+                        sirāpūrṇatvaṃ ca; māṃsaṃ sphiggaṇḍauṣṭhopasthorubāhujaṅghāsu vṛddhiṃ
+                        gurugātratāṃ ca; medaḥsnigdhāṅgatāmudarapārśvavṛddhiṃ kāsaśvāsādīn
+                        daurgandhyaṃ ca; asthyadhyasthīnyadhidantāṃśca; majjā sarvāṅganetragauravaṃ
+                        ca; śukraṃ śukrāśmarīmatiprādurbhāvaṃ ca ||14|| </l>
 
                     <l xml:id="SS.1.15.15">
                         <label>1938 ed. 1.15.15</label>
                         <caesura/>
-                         purīṣamāṭopaṃ kukṣau śūlaṃ ca; mūtraṃ mūtravṛddhiṃ muhurmuhuḥ
-                        pravṛttiṃ bastitodamādhmānaṃ ca; svedastvaco daurgandhyaṃ kaṇḍūṃ
-                        ca ||15|| </l>
+                         purīṣamāṭopaṃ kukṣau śūlaṃ ca; mūtraṃ mūtravṛddhiṃ muhurmuhuḥ pravṛttiṃ
+                        bastitodamādhmānaṃ ca; svedastvaco daurgandhyaṃ kaṇḍūṃ ca ||15|| </l>
 
                     <l xml:id="SS.1.15.16">
                         <label>1938 ed. 1.15.16</label>
                         <caesura/>
-                         ārtavamaṅgamardamatipravṛttiṃ daurgandhyaṃ ca; stanyaṃ stanayor
-                        āpīnatvaṃ muhurmuhuḥ pravṛttiṃ todaṃ ca; garbho jaṭharābhivṛddhiṃ
-                        svedaṃ ca ||16|| </l>
+                         ārtavamaṅgamardamatipravṛttiṃ daurgandhyaṃ ca; stanyaṃ stanayor āpīnatvaṃ
+                        muhurmuhuḥ pravṛttiṃ todaṃ ca; garbho jaṭharābhivṛddhiṃ svedaṃ ca ||16|| </l>
 
                     <l xml:id="SS.1.15.17">
                         <label>1938 ed. 1.15.17</label>
                         <caesura/>
-                         teṣāṃ yathāsvaṃ saṃśodhanaṃ kṣapaṇaṃ ca kṣayādaviruddhaiḥ
-                        kriyāviśeṣaiḥ prakurvīta ||17|| </l>
+                         teṣāṃ yathāsvaṃ saṃśodhanaṃ kṣapaṇaṃ ca kṣayādaviruddhaiḥ kriyāviśeṣaiḥ
+                        prakurvīta ||17|| </l>
 
                     <l xml:id="SS.1.15.18">
                         <label>1938 ed. 1.15.18</label>
@@ -3306,44 +3428,41 @@
                     <l xml:id="SS.1.15.19">
                         <label>1938 ed. 1.15.19</label>
                         <caesura/>
-                         balalakṣaṇaṃ balakṣayalakṣaṇaṃ cāta ūrdhvam upadekṣyāmaḥ | tatra
-                        rasādīnāṃ śukrāntānāṃ dhātūnāṃ yat paraṃ tejastat khalvojastad eva
-                        balam ity ucyate, svaśāstrasiddhāntāt ||19|| </l>
+                         balalakṣaṇaṃ balakṣayalakṣaṇaṃ cāta ūrdhvam upadekṣyāmaḥ | tatra rasādīnāṃ
+                        śukrāntānāṃ dhātūnāṃ yat paraṃ tejastat khalvojastad eva balam ity ucyate,
+                        svaśāstrasiddhāntāt ||19|| </l>
 
                     <l xml:id="SS.1.15.20">
                         <label>1938 ed. 1.15.20</label>
                         <caesura/>
-                         tatra balena sthiropacitamāṃsatā sarvaceṣṭāsvapratighātaḥ
-                        svaravarṇaprasādo bāhyānāmābhyantarāṇāṃ ca
-                        karaṇānāmātmakāryapratipattir bhavati ||20|| </l>
+                         tatra balena sthiropacitamāṃsatā sarvaceṣṭāsvapratighātaḥ svaravarṇaprasādo
+                        bāhyānāmābhyantarāṇāṃ ca karaṇānāmātmakāryapratipattir bhavati ||20|| </l>
 
                     <l xml:id="SS.1.15.21">
                         <label>1938 ed. 1.15.21</label>
                         <caesura/>
-                         bhavanti cātra - ojaḥ somātmakaṃ snigdhaṃ śuklaṃ śītaṃ sthiraṃ
-                        saram | viviktaṃ mṛdu mṛtsnaṃ ca prāṇāyatanam uttamam ||21|| </l>
+                         bhavanti cātra - ojaḥ somātmakaṃ snigdhaṃ śuklaṃ śītaṃ sthiraṃ saram |
+                        viviktaṃ mṛdu mṛtsnaṃ ca prāṇāyatanam uttamam ||21|| </l>
 
                     <l xml:id="SS.1.15.22">
                         <label>1938 ed. 1.15.22</label>
                         <caesura/>
-                         dehaḥ sāvayavastena vyāpto bhavati dehinaḥ | tadabhāvāc ca
-                        śīryante śarīrāṇi śarīriṇām ||22||</l>
+                         dehaḥ sāvayavastena vyāpto bhavati dehinaḥ | tadabhāvāc ca śīryante
+                        śarīrāṇi śarīriṇām ||22||</l>
 
                     <l xml:id="SS.1.15.23">
                         <label>1938 ed. 1.15.23</label>
                         <caesura/>
-                         abhighātātkṣayātkopācchokāddhyānācchramātkṣudhaḥ | ojaḥ
-                        saṅkṣīyate hyebhyo dhātugrahaṇaniḥsṛtam | tejaḥ samīritaṃ tasmād
-                        visraṃsayati dehinaḥ ||23|| </l>
+                         abhighātātkṣayātkopācchokāddhyānācchramātkṣudhaḥ | ojaḥ saṅkṣīyate hyebhyo
+                        dhātugrahaṇaniḥsṛtam | tejaḥ samīritaṃ tasmād visraṃsayati dehinaḥ ||23|| </l>
 
                     <l xml:id="SS.1.15.24">
                         <label>1938 ed. 1.15.24</label>
                         <caesura/>
                          tasya visraṃso vyāpat kṣaya iti (trayo doṣāḥ;) liṅgāni bhavanti
-                        sandhiviśleṣo gātrāṇāṃ sadanaṃ doṣacyavanaṃ kriyāsannirodhaś ca
-                        visraṃse, stabdhagurugātratā vātaśopho varṇabhedo glānistandrā
-                        nidrā ca vyāpanne, mūrcchā māṃsakṣayo mohaḥ pralāpo maraṇam iti ca
-                        kṣaye ||24|| </l>
+                        sandhiviśleṣo gātrāṇāṃ sadanaṃ doṣacyavanaṃ kriyāsannirodhaś ca visraṃse,
+                        stabdhagurugātratā vātaśopho varṇabhedo glānistandrā nidrā ca vyāpanne,
+                        mūrcchā māṃsakṣayo mohaḥ pralāpo maraṇam iti ca kṣaye ||24|| </l>
 
                     <l xml:id="SS.1.15.25">
                         <label>1938 ed. 1.15.25</label>
@@ -3355,21 +3474,21 @@
                     <l xml:id="SS.1.15.26">
                         <label>1938 ed. 1.15.26</label>
                         <caesura/>
-                         aprācuryaṃ kriyāṇāṃ ca balavisraṃsalakṣaṇam | gurutvaṃ
-                        stabdhatā'ṅgeṣu glānirvarṇasya bhedanam ||26||</l>
+                         aprācuryaṃ kriyāṇāṃ ca balavisraṃsalakṣaṇam | gurutvaṃ stabdhatā'ṅgeṣu
+                        glānirvarṇasya bhedanam ||26||</l>
 
                     <l xml:id="SS.1.15.27">
                         <label>1938 ed. 1.15.27</label>
                         <caesura/>
-                         tandrā nidrā vātaśopho balavyāpadi lakṣaṇam | mūrcchā māṃsakṣayo
-                        mohaḥ pralāpo 'jñānam eva ca ||27|| </l>
+                         tandrā nidrā vātaśopho balavyāpadi lakṣaṇam | mūrcchā māṃsakṣayo mohaḥ
+                        pralāpo 'jñānam eva ca ||27|| </l>
 
                     <l xml:id="SS.1.15.28">
                         <label>1938 ed. 1.15.28</label>
                         <caesura/>
-                         pūrvoktāni ca liṅgāni maraṇaṃ ca balakṣaye | tatra visraṃse
-                        vyāpanne ca kriyāviśeṣairaviruddhairbalamāpyāyayet ; itaraṃ tu
-                        mūḍhasañjñaṃ varjayet ||28|| </l>
+                         pūrvoktāni ca liṅgāni maraṇaṃ ca balakṣaye | tatra visraṃse vyāpanne ca
+                        kriyāviśeṣairaviruddhairbalamāpyāyayet ; itaraṃ tu mūḍhasañjñaṃ varjayet
+                        ||28|| </l>
 
                     <l xml:id="SS.1.15.29">
                         <label>1938 ed. 1.15.29</label>
@@ -3380,30 +3499,29 @@
                     <l xml:id="SS.1.15.30">
                         <label>1938 ed. 1.15.30</label>
                         <caesura/>
-                         yadyadāhārajātaṃ tu kṣīṇaḥ prārthayate naraḥ | tasya tasya sa
-                        lābhe tu taṃ taṃ kṣayamapohati ||30|| </l>
+                         yadyadāhārajātaṃ tu kṣīṇaḥ prārthayate naraḥ | tasya tasya sa lābhe tu taṃ
+                        taṃ kṣayamapohati ||30|| </l>
 
                     <l xml:id="SS.1.15.31">
                         <label>1938 ed. 1.15.31</label>
                         <caesura/>
-                         yasya dhātukṣayādvāyuḥ sañjñāṃ karma ca nāśayet | prakṣīṇaṃ ca
-                        balaṃ yasya nāsau śakyaścikitsitum ||31|| </l>
+                         yasya dhātukṣayādvāyuḥ sañjñāṃ karma ca nāśayet | prakṣīṇaṃ ca balaṃ yasya
+                        nāsau śakyaścikitsitum ||31|| </l>
 
                     <l xml:id="SS.1.15.32">
                         <label>1938 ed. 1.15.32</label>
                         <caesura/>
                          rasanimittam eva sthaulyaṃ kārśyaṃ ca | tatra śleṣmalāhārasevino
-                        'dhyaśanaśīlasyāvyāyāmino divāsvapnaratasya cāma evānnaraso
-                        madhurataraś ca śarīramanukrāmannatisnehānmedo janayati,
-                        tadatisthaulyamāpādayati ; tamatisthūlaṃ
+                        'dhyaśanaśīlasyāvyāyāmino divāsvapnaratasya cāma evānnaraso madhurataraś ca
+                        śarīramanukrāmannatisnehānmedo janayati, tadatisthaulyamāpādayati ;
+                        tamatisthūlaṃ
                         kṣudraśvāsapipāsākṣutsvapnasvedagātradaurgandhyakrathanagātrasādagadgadatvāni
                         kṣipramevāviśanti, saukumāryānmedasaḥ sarvakriyāsvasamarthaḥ,
-                        kaphamedoniruddhamārgatvāccālpavyavāyo bhavati, āvṛtamārgatvād eva
-                        śeṣā dhātavo nāpyāyante 'tyarthamato 'lpaprāṇo bhavati,
-                        pramehapiḍakājvarabhagandaravidradhivātavikārāṇāmanyatamaṃ prāpya
-                        pañcatvam upayāti, sarva eva cāsya rogā balavanto
-                        bhavantyāvṛtamārgatvāt srotasām; atas tasyotpattihetuṃ pariharet |
-                        utpanne tu
+                        kaphamedoniruddhamārgatvāccālpavyavāyo bhavati, āvṛtamārgatvād eva śeṣā
+                        dhātavo nāpyāyante 'tyarthamato 'lpaprāṇo bhavati,
+                        pramehapiḍakājvarabhagandaravidradhivātavikārāṇāmanyatamaṃ prāpya pañcatvam
+                        upayāti, sarva eva cāsya rogā balavanto bhavantyāvṛtamārgatvāt srotasām;
+                        atas tasyotpattihetuṃ pariharet | utpanne tu
                         śilājatuguggulugomūtratriphalāloharajorasāñjanamadhuyavamudgakoradūṣakaśyāmākoddālakādīnāṃ
                         virūkṣaṇacchedanīyānāṃ ca dravyāṇāṃ vidhivadupayogo vyāyāmo
                         lekhanabastyupayogaśceti ||32|| </l>
@@ -3414,24 +3532,23 @@
                          tatra punarvātalāhārasevino
                         'tivyāyāmavyavāyādhyayanabhayaśokadhyānarātrijāgaraṇapipāsākṣu
                         tkaṣāyālpāśanaprabhṛtibhir upaśoṣito rasadhātuḥ
-                        śarīramananukrāmannalpatvānna prīṇāti, tasmād atikārśyaṃ bhavati;
-                        so 'tikṛśaḥ kṣutpipāsāśītoṣṇavātavarṣabhārādāneṣv
-                        asahiṣṇurvātarogaprāyo 'lpaprāṇaśca kriyāsu bhavati,
-                        śvāsakāsaśoṣaplīhodarāgnisādagulmaraktapittānām anyatamamāsādya
-                        maraṇam upayāti, sarva eva cāsya rogā balavanto
-                        bhavantyalpaprāṇatvāt ; atas tasyotpattihetuṃ pariharet | utpanne
-                        tu payasyāśvagandhāvidārigandhāśatāvarībalātibalānāgabalānāṃ
-                        madhurāṇāmanyāsāṃ cauṣadhīnām upayogaḥ,
-                        kṣīradadhighṛtamāṃsaśāliṣaṣṭikayavagodhūmānāṃ ca,
+                        śarīramananukrāmannalpatvānna prīṇāti, tasmād atikārśyaṃ bhavati; so
+                        'tikṛśaḥ kṣutpipāsāśītoṣṇavātavarṣabhārādāneṣv asahiṣṇurvātarogaprāyo
+                        'lpaprāṇaśca kriyāsu bhavati,
+                        śvāsakāsaśoṣaplīhodarāgnisādagulmaraktapittānām anyatamamāsādya maraṇam
+                        upayāti, sarva eva cāsya rogā balavanto bhavantyalpaprāṇatvāt ; atas
+                        tasyotpattihetuṃ pariharet | utpanne tu
+                        payasyāśvagandhāvidārigandhāśatāvarībalātibalānāgabalānāṃ madhurāṇāmanyāsāṃ
+                        cauṣadhīnām upayogaḥ, kṣīradadhighṛtamāṃsaśāliṣaṣṭikayavagodhūmānāṃ ca,
                         divāsvapnabrahmacaryāvyāyāmabṛṃhaṇabastyupayogaśceti ||33|| </l>
 
                     <l xml:id="SS.1.15.34">
                         <label>1938 ed. 1.15.34</label>
                         <caesura/>
-                         yaḥ punarubhayasādhāraṇānyāseveta tasyānnarasaḥ śarīramanukrāman
-                        samān dhātūnupacinoti, samadhātutvānmadhyaśarīro bhavati
-                        sarvakriyāsu samarthaḥ kṣutpipāsāśītoṣṇavātavarṣātapasaho
-                        balavāṃśca, sa satatamanupālayitavya iti ||34|| </l>
+                         yaḥ punarubhayasādhāraṇānyāseveta tasyānnarasaḥ śarīramanukrāman samān
+                        dhātūnupacinoti, samadhātutvānmadhyaśarīro bhavati sarvakriyāsu samarthaḥ
+                        kṣutpipāsāśītoṣṇavātavarṣātapasaho balavāṃśca, sa satatamanupālayitavya iti
+                        ||34|| </l>
 
                     <l xml:id="SS.1.15.35">
                         <label>1938 ed. 1.15.35</label>
@@ -3449,27 +3566,27 @@
                     <l xml:id="SS.1.15.37">
                         <label>1938 ed. 1.15.37</label>
                         <caesura/>
-                         vailakṣaṇyāccharīrāṇāmasthāyitvāt tathaiva ca | doṣadhātumalānāṃ
-                        tu parimāṇaṃ na vidyate ||37|| </l>
+                         vailakṣaṇyāccharīrāṇāmasthāyitvāt tathaiva ca | doṣadhātumalānāṃ tu
+                        parimāṇaṃ na vidyate ||37|| </l>
 
                     <l xml:id="SS.1.15.38">
                         <label>1938 ed. 1.15.38</label>
                         <caesura/>
-                         eṣāṃ samatvaṃ yac cāpi bhiṣagbhir avadhāryate | na tat
-                        svāsthyādṛte śakyaṃ vaktumanyena hetunā ||38|| </l>
+                         eṣāṃ samatvaṃ yac cāpi bhiṣagbhir avadhāryate | na tat svāsthyādṛte śakyaṃ
+                        vaktumanyena hetunā ||38|| </l>
 
                     <l xml:id="SS.1.15.39">
                         <label>1938 ed. 1.15.39</label>
                         <caesura/>
-                         doṣādīnāṃ tvasamatāmanumānena lakṣayet | aprasannendriyaṃ vīkṣya
-                        puruṣaṃ kuśalo bhiṣak ||39|| </l>
+                         doṣādīnāṃ tvasamatāmanumānena lakṣayet | aprasannendriyaṃ vīkṣya puruṣaṃ
+                        kuśalo bhiṣak ||39|| </l>
 
                     <l xml:id="SS.1.15.40">
                         <label>1938 ed. 1.15.40</label>
                         <caesura/>
-                         (svasthasya rakṣaṇaṃ kuryād asvasthasya tu buddhimān) | kṣapayed
-                        bṛṃhayec cāpi doṣadhātumalān bhiṣak | tāvadyāvadarogaḥ
-                        syādetatsāmyasya lakṣaṇam ||40|| </l>
+                         (svasthasya rakṣaṇaṃ kuryād asvasthasya tu buddhimān) | kṣapayed bṛṃhayec
+                        cāpi doṣadhātumalān bhiṣak | tāvadyāvadarogaḥ syādetatsāmyasya lakṣaṇam
+                        ||40|| </l>
 
                     <l xml:id="SS.1.15.41">
                         <label>1938 ed. 1.15.41</label>
@@ -3481,9 +3598,8 @@
                     <l xml:id="SS.1.15.trailer">
                         <label>1938 ed. 1.15.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne
-                        doṣadhātumalakṣayavṛddhivijñānīyo nāma pañcadaśo 'dhyāyaḥ ||15||
-                    </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne doṣadhātumalakṣayavṛddhivijñānīyo nāma
+                        pañcadaśo 'dhyāyaḥ ||15|| </l>
                 </div>
 
                 <div n="16" type="adhyāya">
@@ -3494,8 +3610,8 @@
                     <l xml:id="SS.1.16.1">
                         <label>1938 ed. 1.16.1</label>
                         <caesura/>
-                         athātaḥ karṇavyadha<pc> </pc>bandha<pc> </pc>vidhim adhyāyaṃ
-                        vyākhyāsyāmaḥ || </l>
+                         athātaḥ karṇavyadha<pc> </pc>bandha<pc> </pc>vidhim adhyāyaṃ vyākhyāsyāmaḥ
+                        || </l>
 
 
                     <l xml:id="SS.1.16.2">
@@ -3507,14 +3623,13 @@
                     <l xml:id="SS.1.16.3">
                         <label>1938 ed. 1.16.3</label>
                         <caesura/>
-                         rakṣābhūṣaṇanimittaṃ bālasya karṇau vidhyete | tau ṣaṣṭhe māsi
-                        saptame vā śuklapakṣe praśasteṣu tithikaraṇamuhūrtanakṣatreṣu
-                        kṛtamaṅgalasvastivācanaṃ dhātryaṅke kumāradharāṅke vā kumāram
-                        upaveśya bālakrīḍanakaiḥ pralobhyābhisāntvayan bhiṣag
-                        vāmahastenākṛṣya karṇaṃ daivakṛte chidra ādityakarāvabhāsite
-                        śanaiḥ śanair dakṣiṇahastena rju vidhyet pratanukaṃ sūcyā bahalam
-                        ārayā pūrvaṃ dakṣiṇaṃ kumārasya vāmaṃ kumāryāḥ tataḥ picuvartiṃ
-                        praveśayet || </l>
+                         rakṣābhūṣaṇanimittaṃ bālasya karṇau vidhyete | tau ṣaṣṭhe māsi saptame vā
+                        śuklapakṣe praśasteṣu tithikaraṇamuhūrtanakṣatreṣu kṛtamaṅgalasvastivācanaṃ
+                        dhātryaṅke kumāradharāṅke vā kumāram upaveśya bālakrīḍanakaiḥ
+                        pralobhyābhisāntvayan bhiṣag vāmahastenākṛṣya karṇaṃ daivakṛte chidra
+                        ādityakarāvabhāsite śanaiḥ śanair dakṣiṇahastena rju vidhyet pratanukaṃ
+                        sūcyā bahalam ārayā pūrvaṃ dakṣiṇaṃ kumārasya vāmaṃ kumāryāḥ tataḥ
+                        picuvartiṃ praveśayet || </l>
 
 
                     <l xml:id="SS.1.16.4">
@@ -3527,11 +3642,11 @@
                     <l xml:id="SS.1.16.5">
                         <label>1938 ed. 1.16.5</label>
                         <caesura/>
-                         tatrājñena yadṛcchayā viddhāsu sirāsu
-                        kālikāmarmarikālohitikāsūpadravā bhavanti | tatra kālikāyāṃ jvaro
-                        dāhaḥ śvayathur vedanā ca bhavati marmarikāyāṃ vedanā jvaro
-                        granthayaś ca lohitikāyāṃ manyāstambhāpatānakaśirograhakarṇaśūlāni
-                        bhavanti | teṣu yathāsvaṃ pratikurvīta || </l>
+                         tatrājñena yadṛcchayā viddhāsu sirāsu kālikāmarmarikālohitikāsūpadravā
+                        bhavanti | tatra kālikāyāṃ jvaro dāhaḥ śvayathur vedanā ca bhavati
+                        marmarikāyāṃ vedanā jvaro granthayaś ca lohitikāyāṃ
+                        manyāstambhāpatānakaśirograhakarṇaśūlāni bhavanti | teṣu yathāsvaṃ
+                        pratikurvīta || </l>
 
 
                     <l xml:id="SS.1.16.6">
@@ -3539,24 +3654,23 @@
                         <caesura/>
                          kliṣṭajihmāpraśastasūcīvyadhād gāḍhataravartitvād doṣasamudāyād
                         apraśastavyadhād vā yatra saṃrambho vedanā vā bhavati tatra vartim
-                        upahṛtyāśu madhukairaṇḍa<pc> </pc>mūla<pc
-                            > </pc>mañjiṣṭhā<pc> </pc>yava<pc> </pc>tila<pc> </pc>kalkair
-                        madhughṛtapragāḍhair ālepayet tāvad yāvat surūḍha iti surūḍhaṃ
-                        cainaṃ punar vidhyet vidhānaṃ tu pūrvoktam eva || </l>
+                        upahṛtyāśu madhukairaṇḍa<pc> </pc>mūla<pc> </pc>mañjiṣṭhā<pc
+                            > </pc>yava<pc> </pc>tila<pc> </pc>kalkair madhughṛtapragāḍhair ālepayet
+                        tāvad yāvat surūḍha iti surūḍhaṃ cainaṃ punar vidhyet vidhānaṃ tu pūrvoktam
+                        eva || </l>
 
 
                     <l xml:id="SS.1.16.7">
                         <label>1938 ed. 1.16.7</label>
                         <caesura/>
-                         tatra samyagviddham āmatailena pariṣecayet tryahāt tryahāc ca
-                        vartiṃ sthūlatarāṃ dadyāt pariṣekaṃ ca tam eva || </l>
+                         tatra samyagviddham āmatailena pariṣecayet tryahāt tryahāc ca vartiṃ
+                        sthūlatarāṃ dadyāt pariṣekaṃ ca tam eva || </l>
 
 
                     <l xml:id="SS.1.16.8">
                         <label>1938 ed. 1.16.8</label>
                         <caesura/>
-                         atha vyapagatadoṣopadrave karṇe vardhanārthaṃ laghuvardhanakaṃ
-                        kuryāt || </l>
+                         atha vyapagatadoṣopadrave karṇe vardhanārthaṃ laghuvardhanakaṃ kuryāt || </l>
 
 
                     <l xml:id="SS.1.16.9">
@@ -3570,27 +3684,23 @@
                     <l xml:id="SS.1.16.10">
                         <label>1938 ed. 1.16.10</label>
                         <caesura/>
-                         tatra samāsena pañcadaśakarṇabandhākṛtayaḥ | tad yathā
-                        nemisandhānaka utpalabhedyako vallūraka āsaṅgimo gaṇḍakarṇa āhāryo
-                        nirvedhimo vyāyojimaḥ kapāṭasandhiko 'rdhakapāṭasandhikaḥ
-                        saṃkṣipto hīnakarṇo vallīkarṇo yaṣṭikarṇaḥ kākauṣṭhaka iti | teṣu
-                        pṛthulāyatasamobhayapālir nemisandhānakaḥ vṛttāyatasamobhayapālir
-                        utpalabhedyakaḥ hrasvavṛttasamobhayapālir vallūrakaḥ
-                        abhyantaradīrghaikapālir āsaṅgimaḥ bāhya<pc> </pc>dīrghaikapālir
-                        gaṇḍakarṇaḥ | apālir ubhayato 'py āhāryaḥ pīṭhopamapālir ubhayataḥ
-                        kṣīṇaputrikāśrito nirvedhimaḥ | sthūlāṇusamaviṣamapālir vyāyojimaḥ
-                        | abhyantaradīrghaikapālir itarālpapāliḥ | kapāṭasandhikaḥ
-                        bāhyadīrghaikapālir itarālpapālir ardhakapāṭasandhikaḥ | tatra
-                        daśaite karṇabandhavikalpāḥ sādhyāḥ teṣāṃ svanāmabhir evākṛtayaḥ
-                        prāyeṇa vyākhyātāḥ | saṃkṣiptādayaḥ pañcāsādhyāḥ | tatra
-                        śuṣkaśaṣkulir utsannapālir itarālpapāliḥ saṃkṣiptaḥ
-                        anadhiṣṭhānapāliḥ paryantayoḥ kṣīṇamāṃso hīnakarṇaḥ
-                        tanuviṣamālpapālir vallīkarṇaḥ
+                         tatra samāsena pañcadaśakarṇabandhākṛtayaḥ | tad yathā nemisandhānaka
+                        utpalabhedyako vallūraka āsaṅgimo gaṇḍakarṇa āhāryo nirvedhimo vyāyojimaḥ
+                        kapāṭasandhiko 'rdhakapāṭasandhikaḥ saṃkṣipto hīnakarṇo vallīkarṇo
+                        yaṣṭikarṇaḥ kākauṣṭhaka iti | teṣu pṛthulāyatasamobhayapālir nemisandhānakaḥ
+                        vṛttāyatasamobhayapālir utpalabhedyakaḥ hrasvavṛttasamobhayapālir vallūrakaḥ
+                        abhyantaradīrghaikapālir āsaṅgimaḥ bāhya<pc> </pc>dīrghaikapālir gaṇḍakarṇaḥ
+                        | apālir ubhayato 'py āhāryaḥ pīṭhopamapālir ubhayataḥ kṣīṇaputrikāśrito
+                        nirvedhimaḥ | sthūlāṇusamaviṣamapālir vyāyojimaḥ | abhyantaradīrghaikapālir
+                        itarālpapāliḥ | kapāṭasandhikaḥ bāhyadīrghaikapālir itarālpapālir
+                        ardhakapāṭasandhikaḥ | tatra daśaite karṇabandhavikalpāḥ sādhyāḥ teṣāṃ
+                        svanāmabhir evākṛtayaḥ prāyeṇa vyākhyātāḥ | saṃkṣiptādayaḥ pañcāsādhyāḥ |
+                        tatra śuṣkaśaṣkulir utsannapālir itarālpapāliḥ saṃkṣiptaḥ anadhiṣṭhānapāliḥ
+                        paryantayoḥ kṣīṇamāṃso hīnakarṇaḥ tanuviṣamālpapālir vallīkarṇaḥ
                         grathitamāṃsastabdhasirāsaṃtatasūkṣmapālir yaṣṭikarṇaḥ
-                        nirmāṃsasaṃkṣiptāgrālpaśoṇitapāliḥ kākauṣṭhaka iti | baddheṣv api
-                        tu śopha<pc> </pc>dāha<pc> </pc>rāga<pc> </pc>pāka<pc
-                            > </pc>piḍakā<pc> </pc>srāva<pc> </pc>yuktā na siddhim
-                        upayānti || </l>
+                        nirmāṃsasaṃkṣiptāgrālpaśoṇitapāliḥ kākauṣṭhaka iti | baddheṣv api tu
+                            śopha<pc> </pc>dāha<pc> </pc>rāga<pc> </pc>pāka<pc
+                            > </pc>piḍakā<pc> </pc>srāva<pc> </pc>yuktā na siddhim upayānti || </l>
 
 
                     <l xml:id="SS.1.16.11">
@@ -3630,20 +3740,17 @@
                     <l xml:id="SS.1.16.15">
                         <label>1938 ed. 1.16.15</label>
                         <caesura/>
-                         ato nyatamaṃ bandhaṃ cikīrṣur
-                        agropaharaṇīyoktopasaṃbhṛtasaṃbhāraṃ viśeṣataś cātropaharet
-                        surāmaṇḍaṃ kṣīram udakaṃ dhānyāmlaṃ kapālacūrṇaṃ ceti | tato
-                        'ṅganāṃ puruṣaṃ vā grathitakeśāntaṃ laghubhuktavantam āptaiḥ
-                        suparigṛhītaṃ ca kṛtvā bandham upadhārya
-                        chedyabhedyalekhyavyadhanair upapannair upapādya karṇaśoṇitam
-                        avekṣya duṣṭam aduṣṭaṃ veti tatra vātaduṣṭe dhānyāmloṣṇodakābhyāṃ
-                        pittaduṣṭe śītodakapayobhyāṃ śleṣmaduṣṭe surāmaṇḍoṣṇodakābhyāṃ
-                        prakṣālya karṇau punar avalikhyānunnatam ahīnam aviṣamaṃ ca
-                        karṇasandhiṃ sanniveśya sthitaraktaṃ sandadhyāt | tato
-                        madhughṛtenābhyajya picuprotayor anyatareṇāvaguṇṭhya
-                        sūtreṇānavagāḍhaman atiśithilaṃ ca baddhvā
-                        kapālacūrṇenāvakīryācārikam upadiśed dvivraṇīyoktena ca
-                        vidhānenopacaret || </l>
+                         ato nyatamaṃ bandhaṃ cikīrṣur agropaharaṇīyoktopasaṃbhṛtasaṃbhāraṃ
+                        viśeṣataś cātropaharet surāmaṇḍaṃ kṣīram udakaṃ dhānyāmlaṃ kapālacūrṇaṃ ceti
+                        | tato 'ṅganāṃ puruṣaṃ vā grathitakeśāntaṃ laghubhuktavantam āptaiḥ
+                        suparigṛhītaṃ ca kṛtvā bandham upadhārya chedyabhedyalekhyavyadhanair
+                        upapannair upapādya karṇaśoṇitam avekṣya duṣṭam aduṣṭaṃ veti tatra vātaduṣṭe
+                        dhānyāmloṣṇodakābhyāṃ pittaduṣṭe śītodakapayobhyāṃ śleṣmaduṣṭe
+                        surāmaṇḍoṣṇodakābhyāṃ prakṣālya karṇau punar avalikhyānunnatam ahīnam
+                        aviṣamaṃ ca karṇasandhiṃ sanniveśya sthitaraktaṃ sandadhyāt | tato
+                        madhughṛtenābhyajya picuprotayor anyatareṇāvaguṇṭhya sūtreṇānavagāḍhaman
+                        atiśithilaṃ ca baddhvā kapālacūrṇenāvakīryācārikam upadiśed dvivraṇīyoktena
+                        ca vidhānenopacaret || </l>
 
 
                     <l xml:id="SS.1.16.16">
@@ -3671,28 +3778,26 @@
                     <l xml:id="SS.1.16.17">
                         <label>1938 ed. 1.16.17</label>
                         <caesura/>
-                         na cāśuddharaktam atipravṛttaraktaṃ kṣīṇaraktaṃ vā saṃdadhyāt |
-                        sa hi vātaduṣṭe rakte rūḍho 'pi paripuṭanavān pittaduṣṭe
-                        dāhapākarāgavedanāvān śleṣmaduṣṭe stabdhaḥ kaṇḍūmān
-                        atipravṛttarakte śyāvaśophavān kṣīṇo 'lpamāṃso na vṛddhim upaiti
-                        || </l>
+                         na cāśuddharaktam atipravṛttaraktaṃ kṣīṇaraktaṃ vā saṃdadhyāt | sa hi
+                        vātaduṣṭe rakte rūḍho 'pi paripuṭanavān pittaduṣṭe dāhapākarāgavedanāvān
+                        śleṣmaduṣṭe stabdhaḥ kaṇḍūmān atipravṛttarakte śyāvaśophavān kṣīṇo 'lpamāṃso
+                        na vṛddhim upaiti || </l>
 
 
                     <l xml:id="SS.1.16.18">
                         <label>1938 ed. 1.16.18</label>
                         <caesura/>
-                         āmatailena trirātraṃ pariṣecayet trirātrāc ca picuṃ parivartayet
-                        | sa yadā surūḍho nirupadravaḥ savarṇo bhavati tadainaṃ śanaiś
-                        śanair abhivardhayet | ato 'nyathā saṃrambhadāhapākarāgavedanāvān
-                        punaś chidyate vā || </l>
+                         āmatailena trirātraṃ pariṣecayet trirātrāc ca picuṃ parivartayet | sa yadā
+                        surūḍho nirupadravaḥ savarṇo bhavati tadainaṃ śanaiś śanair abhivardhayet |
+                        ato 'nyathā saṃrambhadāhapākarāgavedanāvān punaś chidyate vā || </l>
 
 
                     <l xml:id="SS.1.16.19">
                         <label>1938 ed. 1.16.19</label>
                         <caesura/>
                          athāsyāpraduṣṭasyābhivardhanārtham abhyaṅgaḥ | tad yathā
-                        godhāpratudaviṣkirānūpaudakavasāmajjānau payaḥ sarpis tailaṃ
-                        gaurasarṣapajaṃ ca yathālābhaṃ
+                        godhāpratudaviṣkirānūpaudakavasāmajjānau payaḥ sarpis tailaṃ gaurasarṣapajaṃ
+                        ca yathālābhaṃ
                         saṃbhṛtyārkālarkabalātibalānantāpāmārgāśvagandhāvidārigandhākṣīraśuklājalaśūkamadhuravargapayasyāprativāpaṃ
                         tailaṃ vā pācayitvā svanuguptaṃ nidadhyāt || </l>
 
@@ -3978,9 +4083,8 @@
                         <caesura/>
                          ya evam eva jānīyāt sa rājñaḥ kartum arhati || </l>
 
-                    <trailer xml:id="SS.1.16.colophon">iti śrīsuśrutasaṃhitāyāṃ
-                        sūtrasthāne karṇavyadhabandhavidhirnāma ṣoḍaśo 'dhyāyaḥ ||
-                    </trailer>
+                    <trailer xml:id="SS.1.16.colophon">iti śrīsuśrutasaṃhitāyāṃ sūtrasthāne
+                        karṇavyadhabandhavidhirnāma ṣoḍaśo 'dhyāyaḥ || </trailer>
                 </div>
 
                 <div n="17" type="adhyāya">
@@ -3989,141 +4093,131 @@
                     <l xml:id="SS.1.17.3">
                         <label>1938 ed. 1.17.3</label>
                         <caesura/>
-                         śophasamutthānā granthividradhyalajīprabhṛtayaḥ prāyeṇa vyādhayo
-                        'bhihitā anekākṛtayaḥ, tairvilakṣaṇaḥ pṛthurgrathitaḥ samo viṣamo
-                        vā tvaṅmāṃsasthāyī doṣasaṅghātaḥ śarīraikadeśotthitaḥ śopha ity
-                        ucyate ||3|| </l>
+                         śophasamutthānā granthividradhyalajīprabhṛtayaḥ prāyeṇa vyādhayo 'bhihitā
+                        anekākṛtayaḥ, tairvilakṣaṇaḥ pṛthurgrathitaḥ samo viṣamo vā tvaṅmāṃsasthāyī
+                        doṣasaṅghātaḥ śarīraikadeśotthitaḥ śopha ity ucyate ||3|| </l>
 
                     <l xml:id="SS.1.17.4">
                         <label>1938 ed. 1.17.4</label>
                         <caesura/>
                          sa ṣaḍvidho vātapittakaphaśoṇitasannipātāgantunimittaḥ | tasya
-                        doṣarūpavyañjanairlakṣaṇāni vyākhyāsyāmaḥ | tatra, vātaśophaḥ
-                        kṛṣṇo 'ruṇo vā paruṣo mṛduranavasthitāstodādayaś cātra
-                        vedanāviśeṣā bhavanti; pittaśophaḥ pīto mṛduḥ sarakto vā
-                        śīghrānusāryoṣādayaś cātra vedanāviśeṣā bhavanti; śleṣmaśvayathuḥ
-                        pāṇḍuḥ kaṭhinaḥ snigdhaḥ śīto snigdho mandānusārī kaṇḍvādayaś
-                        cātra vedanāviśeṣā bhavanti; sarvavarṇavedanaḥ sannipātaśvayathuḥ;
-                        pittavacchoṇitajo 'tikṛṣṇaśca; pittaraktalakṣaṇa
+                        doṣarūpavyañjanairlakṣaṇāni vyākhyāsyāmaḥ | tatra, vātaśophaḥ kṛṣṇo 'ruṇo vā
+                        paruṣo mṛduranavasthitāstodādayaś cātra vedanāviśeṣā bhavanti; pittaśophaḥ
+                        pīto mṛduḥ sarakto vā śīghrānusāryoṣādayaś cātra vedanāviśeṣā bhavanti;
+                        śleṣmaśvayathuḥ pāṇḍuḥ kaṭhinaḥ snigdhaḥ śīto snigdho mandānusārī
+                        kaṇḍvādayaś cātra vedanāviśeṣā bhavanti; sarvavarṇavedanaḥ
+                        sannipātaśvayathuḥ; pittavacchoṇitajo 'tikṛṣṇaśca; pittaraktalakṣaṇa
                         āganturlohitāvabhāsaś ca ||4|| </l>
 
                     <l xml:id="SS.1.17.5">
                         <label>1938 ed. 1.17.5</label>
                         <caesura/>
                          sa yadā bāhyābhyantaraiḥ kriyāviśeṣairna sambhāvitaḥ praśamayituṃ
-                        kriyāviparyayādbahutvād vā doṣāṇāṃ tadā pākābhimukho bhavati |
-                        tasyāmasya pacyamānasya pakvasya ca lakṣaṇamucyamānam upadhāraya-
-                        | tatra, mandoṣmatā tvaksavarṇatā śītaśophatā sthairyaṃ
-                        mandavedanatā'lpaśophatā cāmalakṣaṇamuddiṣṭaṃ; sūcibhir iva
-                        nistudyate, daśyata iva pipīlikābhiḥ, tābhiś ca saṃsarpyata iva,
-                        chidyata iva śastreṇa, bhidyata iva śaktibhiḥ, tāḍyata iva
-                        daṇḍena, pīḍyata iva pāṇinā, ghaṭyata iva cāṅgulyā, dahyate
-                        pacyata iva cāgnikṣārābhyām, oṣacoṣaparīdāhāś ca bhavanti,
-                        vṛścikaviddha iva ca sthānāsanaśayaneṣu na śāntim upaiti,
-                        ādhmātabastirivātataś ca śopho bhavati , tvagvaivarṇyaṃ
-                        śophābhivṛddhirjvaradāhapipāsā bhaktāruciś ca pacyamānaliṅgaṃ;
-                        vedanopaśāntiḥ pāṇḍutā'lpaśophatā valīprādurbhāvastvakparipuṭanaṃ
-                        nimnadarśanamaṅgulyā'vapīḍite pratyunnamanaṃ,
-                        bastāvivodakasañcaraṇaṃ pūyasya prapīḍayatyekamantamante
+                        kriyāviparyayādbahutvād vā doṣāṇāṃ tadā pākābhimukho bhavati | tasyāmasya
+                        pacyamānasya pakvasya ca lakṣaṇamucyamānam upadhāraya- | tatra, mandoṣmatā
+                        tvaksavarṇatā śītaśophatā sthairyaṃ mandavedanatā'lpaśophatā
+                        cāmalakṣaṇamuddiṣṭaṃ; sūcibhir iva nistudyate, daśyata iva pipīlikābhiḥ,
+                        tābhiś ca saṃsarpyata iva, chidyata iva śastreṇa, bhidyata iva śaktibhiḥ,
+                        tāḍyata iva daṇḍena, pīḍyata iva pāṇinā, ghaṭyata iva cāṅgulyā, dahyate
+                        pacyata iva cāgnikṣārābhyām, oṣacoṣaparīdāhāś ca bhavanti, vṛścikaviddha iva
+                        ca sthānāsanaśayaneṣu na śāntim upaiti, ādhmātabastirivātataś ca śopho
+                        bhavati , tvagvaivarṇyaṃ śophābhivṛddhirjvaradāhapipāsā bhaktāruciś ca
+                        pacyamānaliṅgaṃ; vedanopaśāntiḥ pāṇḍutā'lpaśophatā
+                        valīprādurbhāvastvakparipuṭanaṃ nimnadarśanamaṅgulyā'vapīḍite
+                        pratyunnamanaṃ, bastāvivodakasañcaraṇaṃ pūyasya prapīḍayatyekamantamante
                         cāvapīḍite, muhurmuhustodaḥ kaṇḍūrunnatatā
-                        vyādherupadravaśāntirbhaktābhikāṅkṣā ca pakvaliṅgam | kaphajeṣu tu
-                        rogeṣu gambhīragatitvād abhighātajeṣu vā keṣucidasamastaṃ
-                        pakvalakṣaṇaṃ dṛṣṭvā pakvamapakvam iti manyamāno bhiṣaṅmoham
-                        upaiti; tatra hi tvaksavarṇatā śītaśophatā
-                        sthairyamalparujatā'śmavac ca ghanatā, na moham upeyād iti ||5|| </l>
+                        vyādherupadravaśāntirbhaktābhikāṅkṣā ca pakvaliṅgam | kaphajeṣu tu rogeṣu
+                        gambhīragatitvād abhighātajeṣu vā keṣucidasamastaṃ pakvalakṣaṇaṃ dṛṣṭvā
+                        pakvamapakvam iti manyamāno bhiṣaṅmoham upaiti; tatra hi tvaksavarṇatā
+                        śītaśophatā sthairyamalparujatā'śmavac ca ghanatā, na moham upeyād iti ||5|| </l>
 
                     <l xml:id="SS.1.17.6">
                         <label>1938 ed. 1.17.6</label>
                         <caesura/>
-                         bhavanti cātra - āmaṃ vipacyamānaṃ ca samyak pakvaṃ ca yo bhiṣak
-                        | jānīyāt sa bhavedvaidyaḥ śeṣāstaskaravṛttayaḥ ||6|| </l>
+                         bhavanti cātra - āmaṃ vipacyamānaṃ ca samyak pakvaṃ ca yo bhiṣak | jānīyāt
+                        sa bhavedvaidyaḥ śeṣāstaskaravṛttayaḥ ||6|| </l>
 
                     <l xml:id="SS.1.17.7">
                         <label>1938 ed. 1.17.7</label>
                         <caesura/>
-                         vātādṛte nāsti rujā na pākaḥ pittādṛte nāsti kaphāc ca pūyaḥ |
-                        tasmāt samastān paripākakāle pacanti śophāṃstraya eva doṣāḥ ||7|| </l>
+                         vātādṛte nāsti rujā na pākaḥ pittādṛte nāsti kaphāc ca pūyaḥ | tasmāt
+                        samastān paripākakāle pacanti śophāṃstraya eva doṣāḥ ||7|| </l>
 
                     <l xml:id="SS.1.17.8">
                         <label>1938 ed. 1.17.8</label>
                         <caesura/>
-                         kālāntareṇābhyuditaṃ tu pittaṃ kṛtvā vaśe vātakaphau prasahya |
-                        pacatyataḥ śoṇitam eva pāko mato 'pareṣāṃ viduṣāṃ dvitīyaḥ
-                        ||8||</l>
+                         kālāntareṇābhyuditaṃ tu pittaṃ kṛtvā vaśe vātakaphau prasahya | pacatyataḥ
+                        śoṇitam eva pāko mato 'pareṣāṃ viduṣāṃ dvitīyaḥ ||8||</l>
 
                     <l xml:id="SS.1.17.9">
                         <label>1938 ed. 1.17.9</label>
                         <caesura/>
                          tatra, āmacchede māṃsasirāsnāyusandhyasthivyāpādanamatimātraṃ
                         śoṇitātipravṛttirvedanāprādurbhāvo 'vadaraṇamanekopadravadarśanaṃ
-                        kṣatavidradhirvā bhavati | sa yadā bhayamohābhyāṃ pakvamapyapakvam
-                        iti manyamānaściramupekṣate vyādhiṃ vaidyastadā gambhīrānugato
-                        dvāramalabhamānaḥ pūyaḥ svamāśrayamavadāryotsaṅgaṃ
-                        mahāntamavakāśaṃ kṛtvā nāḍīṃ janayitvā kṛcchrasādhyo
-                        bhavatyasādhyo veti ||9|| </l>
+                        kṣatavidradhirvā bhavati | sa yadā bhayamohābhyāṃ pakvamapyapakvam iti
+                        manyamānaściramupekṣate vyādhiṃ vaidyastadā gambhīrānugato dvāramalabhamānaḥ
+                        pūyaḥ svamāśrayamavadāryotsaṅgaṃ mahāntamavakāśaṃ kṛtvā nāḍīṃ janayitvā
+                        kṛcchrasādhyo bhavatyasādhyo veti ||9|| </l>
 
                     <l xml:id="SS.1.17.10">
                         <label>1938 ed. 1.17.10</label>
                         <caesura/>
-                         bhavati cātra - yaśchinattyāmamajñānādyaśca pakvamupekṣate |
-                        śvapacāviva mantavyau tāvaniścitakāriṇau ||10|| </l>
+                         bhavati cātra - yaśchinattyāmamajñānādyaśca pakvamupekṣate | śvapacāviva
+                        mantavyau tāvaniścitakāriṇau ||10|| </l>
 
                     <l xml:id="SS.1.17.11">
                         <label>1938 ed. 1.17.11</label>
                         <caesura/>
-                         prāk śastrakarmaṇaśceṣṭaṃ bhojayed āturaṃ bhiṣak | madyapaṃ
-                        pāyayenmadyaṃ tīkṣṇaṃ yo vedanā'sahaḥ ||11|| </l>
+                         prāk śastrakarmaṇaśceṣṭaṃ bhojayed āturaṃ bhiṣak | madyapaṃ pāyayenmadyaṃ
+                        tīkṣṇaṃ yo vedanā'sahaḥ ||11|| </l>
 
                     <l xml:id="SS.1.17.12">
                         <label>1938 ed. 1.17.12</label>
                         <caesura/>
-                         na mūrcchatyannasaṃyogānmattaḥ śastraṃ na budhyate | tasmād
-                        avaśyaṃ bhoktavyaṃ rogeṣūkteṣu karmaṇi ||12||</l>
+                         na mūrcchatyannasaṃyogānmattaḥ śastraṃ na budhyate | tasmād avaśyaṃ
+                        bhoktavyaṃ rogeṣūkteṣu karmaṇi ||12||</l>
 
                     <l xml:id="SS.1.17.13">
                         <label>1938 ed. 1.17.13</label>
                         <caesura/>
-                         prāṇo hyābhyantaro nṝṇāṃ bāhyaprāṇaguṇānvitaḥ |
-                        dhārayatyavirodhena śarīraṃ pāñcabhautikam ||13|| </l>
+                         prāṇo hyābhyantaro nṝṇāṃ bāhyaprāṇaguṇānvitaḥ | dhārayatyavirodhena
+                        śarīraṃ pāñcabhautikam ||13|| </l>
 
                     <l xml:id="SS.1.17.14">
                         <label>1938 ed. 1.17.14</label>
                         <caesura/>
                          alpo mahān vā kriyayā vinā yaḥ samucchritaḥ pākam upaiti śophaḥ |
-                        viśālamūlo viṣamaṃ vidagdhaḥ sa kṛcchratāṃ yātyavagāḍhadoṣaḥ
-                        ||14|| </l>
+                        viśālamūlo viṣamaṃ vidagdhaḥ sa kṛcchratāṃ yātyavagāḍhadoṣaḥ ||14|| </l>
 
                     <l xml:id="SS.1.17.15">
                         <label>1938 ed. 1.17.15</label>
                         <caesura/>
-                         ālepavisrāvaṇāśodhanais tu samyak prayuktairyadi nopaśāmyet |
-                        pacyeta śīghraṃ samamalpamūlaḥ sa piṇḍitaścopari connataḥ syāt
-                        ||15|| </l>
+                         ālepavisrāvaṇāśodhanais tu samyak prayuktairyadi nopaśāmyet | pacyeta
+                        śīghraṃ samamalpamūlaḥ sa piṇḍitaścopari connataḥ syāt ||15|| </l>
 
                     <l xml:id="SS.1.17.16">
                         <label>1938 ed. 1.17.16</label>
                         <caesura/>
-                         kakṣaṃ samāsādya yathaiva vahnirvāyvīritaḥ sandahati prasahya |
-                        tathaiva pūyo 'pyaviniḥsṛto hi māṃsaṃ sirāḥ snāyu ca khādatīha
-                        ||16|| </l>
+                         kakṣaṃ samāsādya yathaiva vahnirvāyvīritaḥ sandahati prasahya | tathaiva
+                        pūyo 'pyaviniḥsṛto hi māṃsaṃ sirāḥ snāyu ca khādatīha ||16|| </l>
 
                     <l xml:id="SS.1.17.17">
                         <label>1938 ed. 1.17.17</label>
                         <caesura/>
-                         ādau vimlāpanaṃ kuryād dvitīyamavasecanam | tṛtīyam upanāhaṃ tu
-                        caturthīṃ pāṭanakriyām ||17|| </l>
+                         ādau vimlāpanaṃ kuryād dvitīyamavasecanam | tṛtīyam upanāhaṃ tu caturthīṃ
+                        pāṭanakriyām ||17|| </l>
 
                     <l xml:id="SS.1.17.18">
                         <label>1938 ed. 1.17.18</label>
                         <caesura/>
-                         pañcamaṃ śodhanaṃ kuryāt ṣaṣṭhaṃ ropaṇamiṣyate | ete kramā
-                        vraṇasyoktāḥ saptamaṃ vaikṛtāpaham ||18||</l>
+                         pañcamaṃ śodhanaṃ kuryāt ṣaṣṭhaṃ ropaṇamiṣyate | ete kramā vraṇasyoktāḥ
+                        saptamaṃ vaikṛtāpaham ||18||</l>
 
                     <l xml:id="SS.1.17.trailer">
                         <label>1938 ed. 1.17.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne āmapakvaiṣaṇīyo nāma saptadaśo
-                        'dhyāyaḥ ||17|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne āmapakvaiṣaṇīyo nāma saptadaśo 'dhyāyaḥ
+                        ||17|| </l>
                 </div>
 
                 <div n="18" type="adhyāya">
@@ -4135,25 +4229,23 @@
                         <label>1938 ed. 1.18.4</label>
                         <caesura/>
                          tatra pratilomamālimpet | pratilome hi samyagauṣadhamavatiṣṭhate
-                        'nupraviśati romakūpān svedavāhibhiśca sirāmukhairvīryaṃ prāpnoti
-                        ||4|| </l>
+                        'nupraviśati romakūpān svedavāhibhiśca sirāmukhairvīryaṃ prāpnoti ||4|| </l>
 
                     <l xml:id="SS.1.18.5">
                         <label>1938 ed. 1.18.5</label>
                         <caesura/>
-                         na ca śuṣyamāṇamupekṣeta, anyatra pīḍayitavyāt | śuṣko hy
-                        apārthako rukkaraś ca ||5|| </l>
+                         na ca śuṣyamāṇamupekṣeta, anyatra pīḍayitavyāt | śuṣko hy apārthako
+                        rukkaraś ca ||5|| </l>
 
                     <l xml:id="SS.1.18.6">
                         <label>1938 ed. 1.18.6</label>
                         <caesura/>
-                         sa trividhaḥ- pralepaḥ, pradeha, ālepaś ca | pralepapradehayor
-                        antaraṃ - tatra pralepaḥ śītastanuraviśoṣī viśoṣī vā;
-                        pradehastūṣṇaḥ śīto vā bahalo 'bahuraviśoṣī ca; madhyamo 'trālepaḥ
-                        | tatra, raktapittaprasādakṛdālepaḥ; pradeho vātaśleṣmapraśamanaḥ
-                        śodhano ropaṇaḥ śophavedanāpahaśca; tasyopayogaḥ kṣatākṣateṣu; yas
-                        tu kṣateṣūpayujyate sa bhūyaḥ ‘kalka’ iti sañjñāṃ labhate
-                        niruddhālepanasañjñaḥ; tenāsrāvasannirodho mṛdutā
+                         sa trividhaḥ- pralepaḥ, pradeha, ālepaś ca | pralepapradehayor antaraṃ -
+                        tatra pralepaḥ śītastanuraviśoṣī viśoṣī vā; pradehastūṣṇaḥ śīto vā bahalo
+                        'bahuraviśoṣī ca; madhyamo 'trālepaḥ | tatra, raktapittaprasādakṛdālepaḥ;
+                        pradeho vātaśleṣmapraśamanaḥ śodhano ropaṇaḥ śophavedanāpahaśca;
+                        tasyopayogaḥ kṣatākṣateṣu; yas tu kṣateṣūpayujyate sa bhūyaḥ ‘kalka’ iti
+                        sañjñāṃ labhate niruddhālepanasañjñaḥ; tenāsrāvasannirodho mṛdutā
                         pūtimāṃsāpakarṣaṇamanantardoṣatā vraṇaśuddhiś ca bhavati ||6|| </l>
 
                     <l xml:id="SS.1.18.7">
@@ -4165,15 +4257,15 @@
                     <l xml:id="SS.1.18.8">
                         <label>1938 ed. 1.18.8</label>
                         <caesura/>
-                         tvakprasādanamevāgryaṃ māṃsaraktaprasādanam | dāhapraśamanaṃ
-                        śreṣṭhaṃ rujākaṇḍūvināśanam ||8|| marmadeśeṣu ye rogā guhyeṣv api
-                        tathā nṛṇām | saṃśodhanāya teṣāṃ hi kuryād ālepanaṃ bhiṣak ||9|| </l>
+                         tvakprasādanamevāgryaṃ māṃsaraktaprasādanam | dāhapraśamanaṃ śreṣṭhaṃ
+                        rujākaṇḍūvināśanam ||8|| marmadeśeṣu ye rogā guhyeṣv api tathā nṛṇām |
+                        saṃśodhanāya teṣāṃ hi kuryād ālepanaṃ bhiṣak ||9|| </l>
 
                     <l xml:id="SS.1.18.9">
                         <label>1938 ed. 1.18.9</label>
                         <caesura/>
-                         (ṣaḍbhāgaṃ paittike snehaṃ caturbhāgaṃ tu vātike | aṣṭabhāgaṃ tu
-                        kaphaje snehamātrāṃ pradāpayet) ||10||</l>
+                         (ṣaḍbhāgaṃ paittike snehaṃ caturbhāgaṃ tu vātike | aṣṭabhāgaṃ tu kaphaje
+                        snehamātrāṃ pradāpayet) ||10||</l>
 
                     <l xml:id="SS.1.18.11">
                         <label>1938 ed. 1.18.11</label>
@@ -4189,44 +4281,42 @@
                     <l xml:id="SS.1.18.13">
                         <label>1938 ed. 1.18.13</label>
                         <caesura/>
-                         pradehasādhye vyādhau tu hitamālepanaṃ divā |
-                        pittaraktābhighātotthe saviṣe ca viśeṣataḥ ||13||</l>
+                         pradehasādhye vyādhau tu hitamālepanaṃ divā | pittaraktābhighātotthe saviṣe
+                        ca viśeṣataḥ ||13||</l>
 
                     <l xml:id="SS.1.18.14">
                         <label>1938 ed. 1.18.14</label>
                         <caesura/>
-                         na ca paryuṣitaṃ lepaṃ kadācidavacārayet | uparyupari lepaṃ ca na
-                        kadācit pradāpayet ||14|| ūṣmāṇaṃ vedanāṃ dāhaṃ ghanatvājjanayet
-                        sa hi | na ca tenaiva lepena pradehaṃ dāpayet punaḥ |
-                        śuṣkabhāvātsa nirvīryo yukto 'pi syādapārthakaḥ ||15|| </l>
+                         na ca paryuṣitaṃ lepaṃ kadācidavacārayet | uparyupari lepaṃ ca na kadācit
+                        pradāpayet ||14|| ūṣmāṇaṃ vedanāṃ dāhaṃ ghanatvājjanayet sa hi | na ca
+                        tenaiva lepena pradehaṃ dāpayet punaḥ | śuṣkabhāvātsa nirvīryo yukto 'pi
+                        syādapārthakaḥ ||15|| </l>
 
                     <l xml:id="SS.1.18.16">
                         <label>1938 ed. 1.18.16</label>
                         <caesura/>
                          ata ūrdhvaṃ vraṇabandhanadravyāṇyupadekṣyāmaḥ; tad yathā-
                         kṣaumakārpāsāvikadukūlakauśeyapatrorṇacīnapaṭṭacarmāntarvalkalālābūśakalalatāvidalarajjutūlaphalasantānikālauhānīti
-                        ; teṣāṃ vyādhiṃ kālaṃ cāvekṣyopayogaḥ; prakaraṇataścaiṣāmādeśaḥ
-                        ||16|| </l>
+                        ; teṣāṃ vyādhiṃ kālaṃ cāvekṣyopayogaḥ; prakaraṇataścaiṣāmādeśaḥ ||16|| </l>
 
                     <l xml:id="SS.1.18.17">
                         <label>1938 ed. 1.18.17</label>
                         <caesura/>
                          tatra
                         kośadāmasvastikānuvellitamu(pra)tolīmaṇḍalasthagikāyamakakhaṭvācīnavibandhavitānagophaṇāḥ
-                        pañcāṅgī ceti caturdaśa bandhaviśeṣāḥ | teṣāṃ nāmabhir evākṛtayaḥ
-                        prāyeṇa vyākhyātāḥ ||17|| </l>
+                        pañcāṅgī ceti caturdaśa bandhaviśeṣāḥ | teṣāṃ nāmabhir evākṛtayaḥ prāyeṇa
+                        vyākhyātāḥ ||17|| </l>
 
                     <l xml:id="SS.1.18.18">
                         <label>1938 ed. 1.18.18</label>
                         <caesura/>
                          tatra kośamaṅguṣṭhāṅguliparvasu vidadhyāt, dāma sambādhe 'ṅge,
-                        sandhikūrcakabhrūstanāntaratalakarṇeṣu svastikaṃ, anuvellitaṃ
-                        śākhāsu, grīvāmeḍhrayoḥ mu(pra)tolīṃ, vṛtte 'ṅge maṇḍalam,
-                        aṅguṣṭhāṅgulimeḍhrāgreṣu sthagikāṃ, yamalavraṇayor yamakaṃ,
-                        hanuśaṅkhagaṇḍeṣu khaṭvām, apāṅgayoścīnaṃ, pṛṣṭhodaroraḥsu
-                        vibandhaṃ, mūrdhani vitānaṃ, cibukanāsauṣṭhāṃsabastiṣu gophaṇāṃ,
-                        jatruṇa ūrdhvaṃ pañcāṅgīmiti; yo vā yasmin śarīrapradeśe suniviṣṭo
-                        bhavati taṃ tasmin vidadhyāt ||18|| </l>
+                        sandhikūrcakabhrūstanāntaratalakarṇeṣu svastikaṃ, anuvellitaṃ śākhāsu,
+                        grīvāmeḍhrayoḥ mu(pra)tolīṃ, vṛtte 'ṅge maṇḍalam, aṅguṣṭhāṅgulimeḍhrāgreṣu
+                        sthagikāṃ, yamalavraṇayor yamakaṃ, hanuśaṅkhagaṇḍeṣu khaṭvām,
+                        apāṅgayoścīnaṃ, pṛṣṭhodaroraḥsu vibandhaṃ, mūrdhani vitānaṃ,
+                        cibukanāsauṣṭhāṃsabastiṣu gophaṇāṃ, jatruṇa ūrdhvaṃ pañcāṅgīmiti; yo vā
+                        yasmin śarīrapradeśe suniviṣṭo bhavati taṃ tasmin vidadhyāt ||18|| </l>
 
                     <l xml:id="SS.1.18.19">
                         <label>1938 ed. 1.18.19</label>
@@ -4236,61 +4326,56 @@
                     <l xml:id="SS.1.18.20">
                         <label>1938 ed. 1.18.20</label>
                         <caesura/>
-                         tatra ghanāṃ kavalikāṃ dattvā
-                        vāmahastaparikṣepamṛjumanāviddhamasaṅkucitaṃ mṛdu paṭṭaṃ niveśya
-                        badhnīyāt | na ca vraṇasyopari kuryād granthimābādhakaraṃ ca
-                        ||20|| </l>
+                         tatra ghanāṃ kavalikāṃ dattvā vāmahastaparikṣepamṛjumanāviddhamasaṅkucitaṃ
+                        mṛdu paṭṭaṃ niveśya badhnīyāt | na ca vraṇasyopari kuryād
+                        granthimābādhakaraṃ ca ||20|| </l>
 
                     <l xml:id="SS.1.18.21">
                         <label>1938 ed. 1.18.21</label>
                         <caesura/>
-                         na ca vikeśikauṣadhe atisnigdhe atirūkṣe viṣame vā kurvīta;
-                        yasmādatisnehāt kledo, raukṣyācchedo,
-                        durnyāsādvraṇavartmāvagharṣaṇam iti ||21|| </l>
+                         na ca vikeśikauṣadhe atisnigdhe atirūkṣe viṣame vā kurvīta; yasmādatisnehāt
+                        kledo, raukṣyācchedo, durnyāsādvraṇavartmāvagharṣaṇam iti ||21|| </l>
 
                     <l xml:id="SS.1.18.22">
                         <label>1938 ed. 1.18.22</label>
                         <caesura/>
-                         tatra vraṇāyatanaviśeṣādbandhaviśeṣastrividho bhavati- gāḍhaḥ,
-                        samaḥ, śithila iti ||22|| </l>
+                         tatra vraṇāyatanaviśeṣādbandhaviśeṣastrividho bhavati- gāḍhaḥ, samaḥ,
+                        śithila iti ||22|| </l>
 
                     <l xml:id="SS.1.18.23">
                         <label>1938 ed. 1.18.23</label>
                         <caesura/>
-                         pīḍayannarujo gāḍhaḥ socchvāsaḥ śithilaḥ smṛtaḥ | naiva gāḍho na
-                        śithilaḥ samo bandhaḥ prakīrtitaḥ ||23|| </l>
+                         pīḍayannarujo gāḍhaḥ socchvāsaḥ śithilaḥ smṛtaḥ | naiva gāḍho na śithilaḥ
+                        samo bandhaḥ prakīrtitaḥ ||23|| </l>
 
                     <l xml:id="SS.1.18.24">
                         <label>1938 ed. 1.18.24</label>
                         <caesura/>
                          tatra sphikkukṣikakṣāvaṅkṣaṇoruśiraḥsu gāḍhaḥ,
-                        śākhāvadanakarṇakaṇṭhameḍhramuṣkapṛṣṭhapārśvodaroraḥsu samaḥ,
-                        akṣṇoḥ sandhiṣu ca śithila iti ||24|| </l>
+                        śākhāvadanakarṇakaṇṭhameḍhramuṣkapṛṣṭhapārśvodaroraḥsu samaḥ, akṣṇoḥ
+                        sandhiṣu ca śithila iti ||24|| </l>
 
                     <l xml:id="SS.1.18.25">
                         <label>1938 ed. 1.18.25</label>
                         <caesura/>
                          tatra paittikaṃ gāḍhasthāne samaṃ badhnīyāt, samasthāne śithilaṃ,
-                        śithilasthāne naiva; evaṃ śoṇitaduṣṭaṃ ca; ślaiṣmikaṃ
-                        śithilasthāne samaṃ, samasthāne gāḍhaṃ, gāḍhasthāne gāḍhataraṃ;
-                        evaṃ vātaduṣṭaṃ ca ||25|| </l>
+                        śithilasthāne naiva; evaṃ śoṇitaduṣṭaṃ ca; ślaiṣmikaṃ śithilasthāne samaṃ,
+                        samasthāne gāḍhaṃ, gāḍhasthāne gāḍhataraṃ; evaṃ vātaduṣṭaṃ ca ||25|| </l>
 
                     <l xml:id="SS.1.18.26">
                         <label>1938 ed. 1.18.26</label>
                         <caesura/>
-                         tatra paittikaṃ śaradi grīṣme dvirahno badhnīyāt,
-                        raktopadrutamapyevaṃ; ślaiṣmikaṃ hemantavasantayostryahāt ,
-                        vātopadrutamapyevam | evamabhyūhya bandhaviparyayaṃ ca kuryāt
-                        ||26|| </l>
+                         tatra paittikaṃ śaradi grīṣme dvirahno badhnīyāt, raktopadrutamapyevaṃ;
+                        ślaiṣmikaṃ hemantavasantayostryahāt , vātopadrutamapyevam | evamabhyūhya
+                        bandhaviparyayaṃ ca kuryāt ||26|| </l>
 
                     <l xml:id="SS.1.18.27">
                         <label>1938 ed. 1.18.27</label>
                         <caesura/>
-                         tatra, samaśithilasthāneṣu gāḍhaṃ baddhe
-                        vikeśikauṣadhanairarthakyaṃ śophavedanāprādurbhāvaśca,
-                        gāḍhasamasthāneṣu śithilaṃ baddhe vikeśikauṣadhapatanaṃ
-                        paṭṭasañcārādvraṇavartmāvagharṣaṇamiti; gāḍhaśithilasthāneṣu samaṃ
-                        baddhe ca guṇābhāva iti ||27|| </l>
+                         tatra, samaśithilasthāneṣu gāḍhaṃ baddhe vikeśikauṣadhanairarthakyaṃ
+                        śophavedanāprādurbhāvaśca, gāḍhasamasthāneṣu śithilaṃ baddhe
+                        vikeśikauṣadhapatanaṃ paṭṭasañcārādvraṇavartmāvagharṣaṇamiti;
+                        gāḍhaśithilasthāneṣu samaṃ baddhe ca guṇābhāva iti ||27|| </l>
 
                     <l xml:id="SS.1.18.28">
                         <label>1938 ed. 1.18.28</label>
@@ -4300,22 +4385,21 @@
                     <l xml:id="SS.1.18.29">
                         <label>1938 ed. 1.18.29</label>
                         <caesura/>
-                         abadhyamāno
-                        daṃśamaśakatṛṇakāṣṭhopalapāṃśuśītavātātapaprabhṛtibhir
-                        viśeṣairabhihanyate vraṇaḥ, vividhavedanopadrutaś ca duṣṭatām
-                        upaiti, ālepanādīni cāsya viśoṣam upayānti ||29|| </l>
+                         abadhyamāno daṃśamaśakatṛṇakāṣṭhopalapāṃśuśītavātātapaprabhṛtibhir
+                        viśeṣairabhihanyate vraṇaḥ, vividhavedanopadrutaś ca duṣṭatām upaiti,
+                        ālepanādīni cāsya viśoṣam upayānti ||29|| </l>
 
                     <l xml:id="SS.1.18.30">
                         <label>1938 ed. 1.18.30</label>
                         <caesura/>
-                         cūrṇitaṃ mathitaṃ bhagnaṃ viśliṣṭamatipātitam |
-                        asthisnāyusirācchinnamāśu bandhena rohati ||30|| </l>
+                         cūrṇitaṃ mathitaṃ bhagnaṃ viśliṣṭamatipātitam | asthisnāyusirācchinnamāśu
+                        bandhena rohati ||30|| </l>
 
                     <l xml:id="SS.1.18.31">
                         <label>1938 ed. 1.18.31</label>
                         <caesura/>
-                         sukhamevaṃ vraṇī śete sukhaṃ gacchati tiṣṭhati | sukhaṃ
-                        śayyāsanasthasya kṣipraṃ saṃrohati vraṇaḥ ||31|| </l>
+                         sukhamevaṃ vraṇī śete sukhaṃ gacchati tiṣṭhati | sukhaṃ śayyāsanasthasya
+                        kṣipraṃ saṃrohati vraṇaḥ ||31|| </l>
 
                     <l xml:id="SS.1.18.32">
                         <label>1938 ed. 1.18.32</label>
@@ -4327,8 +4411,8 @@
                     <l xml:id="SS.1.18.33">
                         <label>1938 ed. 1.18.33</label>
                         <caesura/>
-                         kuṣṭhināmagnidagdhānāṃ piḍakā madhumehinām | karṇikāśconduruviṣe
-                        viṣajuṣṭāś ca ye vraṇāḥ ||33|| </l>
+                         kuṣṭhināmagnidagdhānāṃ piḍakā madhumehinām | karṇikāśconduruviṣe viṣajuṣṭāś
+                        ca ye vraṇāḥ ||33|| </l>
 
                     <l xml:id="SS.1.18.34">
                         <label>1938 ed. 1.18.34</label>
@@ -4339,44 +4423,44 @@
                     <l xml:id="SS.1.18.35">
                         <label>1938 ed. 1.18.35</label>
                         <caesura/>
-                         deśaṃ doṣaṃ ca vijñāya vraṇaṃ ca vraṇakovidaḥ | ṛtūṃś ca
-                        parisaṅkhyāya tato bandhānniveśayet ||35||</l>
+                         deśaṃ doṣaṃ ca vijñāya vraṇaṃ ca vraṇakovidaḥ | ṛtūṃś ca parisaṅkhyāya tato
+                        bandhānniveśayet ||35||</l>
 
                     <l xml:id="SS.1.18.36">
                         <label>1938 ed. 1.18.36</label>
                         <caesura/>
-                         ūrdhvaṃ tiryagadhastāc ca yantraṇā trividhā smṛtā | yathā ca
-                        badhyate bandhas tathā vakṣyāmyaśeṣataḥ ||36|| </l>
+                         ūrdhvaṃ tiryagadhastāc ca yantraṇā trividhā smṛtā | yathā ca badhyate
+                        bandhas tathā vakṣyāmyaśeṣataḥ ||36|| </l>
 
                     <l xml:id="SS.1.18.37">
                         <label>1938 ed. 1.18.37</label>
                         <caesura/>
-                         ghanāṃ kavalikāṃ dattvā mṛdu caivāpi paṭṭakam | vikeśikāmauṣadhaṃ
-                        ca nātisnigdhaṃ samācaret ||37|| </l>
+                         ghanāṃ kavalikāṃ dattvā mṛdu caivāpi paṭṭakam | vikeśikāmauṣadhaṃ ca
+                        nātisnigdhaṃ samācaret ||37|| </l>
 
                     <l xml:id="SS.1.18.38">
                         <label>1938 ed. 1.18.38</label>
                         <caesura/>
-                         prakledayatyatisnigdhā tathā rūkṣā kṣiṇoti ca | yuktasnehā
-                        ropayati durnyastā vartma gharṣati ||38|| </l>
+                         prakledayatyatisnigdhā tathā rūkṣā kṣiṇoti ca | yuktasnehā ropayati
+                        durnyastā vartma gharṣati ||38|| </l>
 
                     <l xml:id="SS.1.18.39">
                         <label>1938 ed. 1.18.39</label>
                         <caesura/>
-                         viṣamaṃ ca vraṇaṃ kuryāt stambhayet srāvayettathā | yathāvraṇaṃ
-                        viditvā tu yogaṃ vaidyaḥ prayojayet ||39|| </l>
+                         viṣamaṃ ca vraṇaṃ kuryāt stambhayet srāvayettathā | yathāvraṇaṃ viditvā tu
+                        yogaṃ vaidyaḥ prayojayet ||39|| </l>
 
                     <l xml:id="SS.1.18.40">
                         <label>1938 ed. 1.18.40</label>
                         <caesura/>
-                         pittaje raktaje vā'pi sakṛdeva parikṣipet | asakṛt kaphaje vā'pi
-                        vātaje ca vicakṣaṇaḥ ||40|| </l>
+                         pittaje raktaje vā'pi sakṛdeva parikṣipet | asakṛt kaphaje vā'pi vātaje ca
+                        vicakṣaṇaḥ ||40|| </l>
 
                     <l xml:id="SS.1.18.41">
                         <label>1938 ed. 1.18.41</label>
                         <caesura/>
-                         talena pratipīḍyātha srāvayed anulomataḥ | sarvāṃś ca bandhān
-                        gūḍhāntān sandhīṃś ca viniveśayet ||41|| </l>
+                         talena pratipīḍyātha srāvayed anulomataḥ | sarvāṃś ca bandhān gūḍhāntān
+                        sandhīṃś ca viniveśayet ||41|| </l>
 
                     <l xml:id="SS.1.18.42">
                         <label>1938 ed. 1.18.42</label>
@@ -4399,15 +4483,15 @@
                     <l xml:id="SS.1.18.45">
                         <label>1938 ed. 1.18.45</label>
                         <caesura/>
-                         tathā'vagāḍhagambhīrāḥ sarvato viṣamasthitāḥ | naite sādhayituṃ
-                        śakyā ṛte bandhādbhavanti hi ||45|| </l>
+                         tathā'vagāḍhagambhīrāḥ sarvato viṣamasthitāḥ | naite sādhayituṃ śakyā ṛte
+                        bandhādbhavanti hi ||45|| </l>
 
 
                     <l xml:id="SS.1.18.trailer">
                         <label>1938 ed. 1.18.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne
-                        vraṇālepanabandhavidhirnāmāṣṭādaśo 'dhyāyaḥ ||18|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne vraṇālepanabandhavidhirnāmāṣṭādaśo
+                        'dhyāyaḥ ||18|| </l>
                 </div>
 
                 <div n="19" type="adhyāya">
@@ -4417,8 +4501,8 @@
                     <l xml:id="SS.1.19.3">
                         <label>1938 ed. 1.19.3</label>
                         <caesura/>
-                         vraṇitasya prathamamevāgāramanvicchet; taccāgāraṃ praśastavāstvād
-                        ikaṃ kāryam ||3|| </l>
+                         vraṇitasya prathamamevāgāramanvicchet; taccāgāraṃ praśastavāstvād ikaṃ
+                        kāryam ||3|| </l>
 
                     <l xml:id="SS.1.19.4">
                         <label>1938 ed. 1.19.4</label>
@@ -4429,20 +4513,19 @@
                     <l xml:id="SS.1.19.5">
                         <label>1938 ed. 1.19.5</label>
                         <caesura/>
-                         tasmiñ śayanamasambādhaṃ svāstīrṇaṃ manojñaṃ prākśiraskaṃ
-                        saśastraṃ kurvīta ||5|| </l>
+                         tasmiñ śayanamasambādhaṃ svāstīrṇaṃ manojñaṃ prākśiraskaṃ saśastraṃ kurvīta
+                        ||5|| </l>
 
                     <l xml:id="SS.1.19.6">
                         <label>1938 ed. 1.19.6</label>
                         <caesura/>
-                         sukhaceṣṭāpracāraḥ syāt svāstīrṇe śayane vraṇī | prācyāṃ diśi
-                        sthitā devāstatpūjārthaṃ ca tacchiraḥ ||6|| </l>
+                         sukhaceṣṭāpracāraḥ syāt svāstīrṇe śayane vraṇī | prācyāṃ diśi sthitā
+                        devāstatpūjārthaṃ ca tacchiraḥ ||6|| </l>
 
                     <l xml:id="SS.1.19.7">
                         <label>1938 ed. 1.19.7</label>
                         <caesura/>
-                         tasmin suhṛdbhir anukūlaiḥ priyaṃvadair upāsyamāno yatheṣṭamāsīta
-                        ||7|| </l>
+                         tasmin suhṛdbhir anukūlaiḥ priyaṃvadair upāsyamāno yatheṣṭamāsīta ||7|| </l>
 
                     <l xml:id="SS.1.19.8">
                         <label>1938 ed. 1.19.8</label>
@@ -4458,8 +4541,8 @@
                     <l xml:id="SS.1.19.10">
                         <label>1938 ed. 1.19.10</label>
                         <caesura/>
-                         divāsvapnādvraṇe kaṇḍūrgātrāṇāṃ gauravaṃ tathā | śvayathurvedanā
-                        rāgaḥ srāvaś caiva bhṛśaṃ bhavet ||10|| </l>
+                         divāsvapnādvraṇe kaṇḍūrgātrāṇāṃ gauravaṃ tathā | śvayathurvedanā rāgaḥ
+                        srāvaś caiva bhṛśaṃ bhavet ||10|| </l>
 
                     <l xml:id="SS.1.19.11">
                         <label>1938 ed. 1.19.11</label>
@@ -4470,8 +4553,8 @@
                     <l xml:id="SS.1.19.12">
                         <label>1938 ed. 1.19.12</label>
                         <caesura/>
-                         sthānāsanaṃ caṅkramaṇaṃ divāsvapnaṃ tathaiva ca | vraṇito na
-                        niṣeveta śaktimānapi mānavaḥ ||12|| </l>
+                         sthānāsanaṃ caṅkramaṇaṃ divāsvapnaṃ tathaiva ca | vraṇito na niṣeveta
+                        śaktimānapi mānavaḥ ||12|| </l>
 
                     <l xml:id="SS.1.19.13">
                         <label>1938 ed. 1.19.13</label>
@@ -4482,27 +4565,26 @@
                     <l xml:id="SS.1.19.14">
                         <label>1938 ed. 1.19.14</label>
                         <caesura/>
-                         gamyānāṃ ca strīṇāṃ sandarśanasambhāṣaṇasaṃsparśanāni dūrata eva
-                        pariharet ||14|| </l>
+                         gamyānāṃ ca strīṇāṃ sandarśanasambhāṣaṇasaṃsparśanāni dūrata eva pariharet
+                        ||14|| </l>
 
                     <l xml:id="SS.1.19.15">
                         <label>1938 ed. 1.19.15</label>
                         <caesura/>
-                         strīdarśanādibhiḥ śukraṃ kadāciccalitaṃ sravet |
-                        grāmyadharmakṛtāndoṣān so 'saṃsarge 'pyavāpnuyāt ||15|| </l>
+                         strīdarśanādibhiḥ śukraṃ kadāciccalitaṃ sravet | grāmyadharmakṛtāndoṣān so
+                        'saṃsarge 'pyavāpnuyāt ||15|| </l>
 
                     <l xml:id="SS.1.19.16">
                         <label>1938 ed. 1.19.16</label>
                         <caesura/>
                          navadhānyamāṣatilakalāyakulatthaniṣpāvaharitakaśākāmlalavaṇakaṭukaguḍapiṣṭavikṛtivallūraśuṣkaśākājāvikānūpaudaka-
-                        māṃsavasāśītodakakṛśarāpāyasadadhidugdhatakraprabhṛtīni pariharet
-                        ||16|| </l>
+                        māṃsavasāśītodakakṛśarāpāyasadadhidugdhatakraprabhṛtīni pariharet ||16|| </l>
 
                     <l xml:id="SS.1.19.17">
                         <label>1938 ed. 1.19.17</label>
                         <caesura/>
-                         takrānto navadhānyādiryo 'yaṃ varga udāhṛtaḥ | doṣasañjanano
-                        hyeṣa vijñeyaḥ pūyavardhanaḥ ||17|| </l>
+                         takrānto navadhānyādiryo 'yaṃ varga udāhṛtaḥ | doṣasañjanano hyeṣa vijñeyaḥ
+                        pūyavardhanaḥ ||17|| </l>
 
                     <l xml:id="SS.1.19.18">
                         <label>1938 ed. 1.19.18</label>
@@ -4512,8 +4594,8 @@
                     <l xml:id="SS.1.19.19">
                         <label>1938 ed. 1.19.19</label>
                         <caesura/>
-                         madyamamlaṃ tathā rūkṣaṃ tīkṣṇamuṣṇaṃ ca vīryataḥ | āśukāri ca
-                        tat pītaṃ kṣipraṃ vyāpādayed vraṇam ||19|| </l>
+                         madyamamlaṃ tathā rūkṣaṃ tīkṣṇamuṣṇaṃ ca vīryataḥ | āśukāri ca tat pītaṃ
+                        kṣipraṃ vyāpādayed vraṇam ||19|| </l>
 
                     <l xml:id="SS.1.19.20">
                         <label>1938 ed. 1.19.20</label>
@@ -4525,8 +4607,8 @@
                     <l xml:id="SS.1.19.21">
                         <label>1938 ed. 1.19.21</label>
                         <caesura/>
-                         vraṇinaḥ samprataptasya kāraṇair eva mādibhiḥ |
-                        kṣīṇaśoṇitamāṃsasya bhuktaṃ samyaṅna jīryati ||21|| </l>
+                         vraṇinaḥ samprataptasya kāraṇair eva mādibhiḥ | kṣīṇaśoṇitamāṃsasya bhuktaṃ
+                        samyaṅna jīryati ||21|| </l>
 
                     <l xml:id="SS.1.19.22">
                         <label>1938 ed. 1.19.22</label>
@@ -4537,11 +4619,10 @@
                     <l xml:id="SS.1.19.23">
                         <label>1938 ed. 1.19.23</label>
                         <caesura/>
-                         sadā nīcanakharomṇā śucinā śuklavāsasā
-                        śāntimaṅgaladevatābrāhmaṇagurupareṇa bhavitavyam iti | tat kasya
-                        hetoḥ? hiṃsāvihārāṇi hi mahāvīryāṇi rakṣāṃsi
-                        paśupatikuberakumārānucarāṇi māṃsaśoṇitapriyatvāt kṣatajanimittaṃ
-                        vraṇinam upasarpanti, satkārārthaṃ jighāṃsūni vā kadācit ||23|| </l>
+                         sadā nīcanakharomṇā śucinā śuklavāsasā śāntimaṅgaladevatābrāhmaṇagurupareṇa
+                        bhavitavyam iti | tat kasya hetoḥ? hiṃsāvihārāṇi hi mahāvīryāṇi rakṣāṃsi
+                        paśupatikuberakumārānucarāṇi māṃsaśoṇitapriyatvāt kṣatajanimittaṃ vraṇinam
+                        upasarpanti, satkārārthaṃ jighāṃsūni vā kadācit ||23|| </l>
 
                     <l xml:id="SS.1.19.24">
                         <label>1938 ed. 1.19.24</label>
@@ -4553,33 +4634,33 @@
                         <label>1938 ed. 1.19.25</label>
                         <caesura/>
                          te tu santarpitā ātmavantaṃ na hiṃsyuḥ | tasmāt satatamatandrito
-                        janaparivṛto nityaṃ dīpodakaśastrasragdāmapuṣpalājādyalaṅkṛte
-                        veśmani sampanmaṅgalamano 'nukūlāḥ kathāḥ śṛṇvannāsīta ||25|| </l>
+                        janaparivṛto nityaṃ dīpodakaśastrasragdāmapuṣpalājādyalaṅkṛte veśmani
+                        sampanmaṅgalamano 'nukūlāḥ kathāḥ śṛṇvannāsīta ||25|| </l>
 
                     <l xml:id="SS.1.19.26">
                         <label>1938 ed. 1.19.26</label>
                         <caesura/>
-                         sampadādyanukūlābhiḥ kathābhiḥ prītamānasaḥ | āśāvān
-                        vyādhimokṣāya kṣipraṃ sukhamavāpnuyāt ||26||</l>
+                         sampadādyanukūlābhiḥ kathābhiḥ prītamānasaḥ | āśāvān vyādhimokṣāya kṣipraṃ
+                        sukhamavāpnuyāt ||26||</l>
 
                     <l xml:id="SS.1.19.27">
                         <label>1938 ed. 1.19.27</label>
                         <caesura/>
-                         ṛgyajuḥsāmātharvavedābhihitairaparaiś cāśīrvidhānair upādhyāyā
-                        bhiṣajaś ca sandhyayo rakṣāṃ kuryuḥ ||27|| </l>
+                         ṛgyajuḥsāmātharvavedābhihitairaparaiś cāśīrvidhānair upādhyāyā bhiṣajaś ca
+                        sandhyayo rakṣāṃ kuryuḥ ||27|| </l>
 
                     <l xml:id="SS.1.19.28">
                         <label>1938 ed. 1.19.28</label>
                         <caesura/>
-                         sarṣapāriṣṭapatrābhyāṃ sarpiṣā lavaṇena ca | dvirahnaḥ kārayed
-                        dhūpaṃ daśarātramatandritaḥ ||28|| </l>
+                         sarṣapāriṣṭapatrābhyāṃ sarpiṣā lavaṇena ca | dvirahnaḥ kārayed dhūpaṃ
+                        daśarātramatandritaḥ ||28|| </l>
 
                     <l xml:id="SS.1.19.29">
                         <label>1938 ed. 1.19.29</label>
                         <caesura/>
                          chatrāmaticchatrāṃ lāṅgū(ṅga)līṃ jaṭilāṃ brahmacāriṇīṃ lakṣmīṃ
-                        guhāmatiguhāṃ vacāmativiṣāṃ śatavīryāṃ sahasravīryāṃ
-                        siddhārthakāṃś ca śirasā dhārayet ||29|| </l>
+                        guhāmatiguhāṃ vacāmativiṣāṃ śatavīryāṃ sahasravīryāṃ siddhārthakāṃś ca
+                        śirasā dhārayet ||29|| </l>
 
                     <l xml:id="SS.1.19.30">
                         <label>1938 ed. 1.19.30</label>
@@ -4628,16 +4709,15 @@
                     <l xml:id="SS.1.19.36">
                         <label>1938 ed. 1.19.36</label>
                         <caesura/>
-                         (vraṇe śvayathurāyāsāt sa ca rāgaś ca jāgārāt | tau ca ruk ca
-                        divāsvāpāttāś ca mṛtyuś ca maithunāt) ||36|| evaṃvṛttasamācāro
-                        vraṇī sampadyate sukhī | āyuś ca dīrghamāpnoti dhanvantarivaco
-                        yathā ||37|| </l>
+                         (vraṇe śvayathurāyāsāt sa ca rāgaś ca jāgārāt | tau ca ruk ca divāsvāpāttāś
+                        ca mṛtyuś ca maithunāt) ||36|| evaṃvṛttasamācāro vraṇī sampadyate sukhī |
+                        āyuś ca dīrghamāpnoti dhanvantarivaco yathā ||37|| </l>
 
                     <l xml:id="SS.1.19.trailer">
                         <label>1938 ed. 1.19.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne vraṇitopāsanīyo nāmaikonaviṃśo
-                        'dhyāyaḥ ||19|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne vraṇitopāsanīyo nāmaikonaviṃśo 'dhyāyaḥ
+                        ||19|| </l>
                 </div>
 
                 <div n="20" type="adhyāya">
@@ -4647,18 +4727,17 @@
                         <label>1938 ed. 1.20.3</label>
                         <caesura/>
                          yadvāyoḥ pathyaṃ tat pittasyāpathyam ity anena hetunā na
-                        kiñciddravyamekāntena hitamahitaṃ vā'stīti kecidācāryā bruvate |
-                        tat tu na samyak; iha khalu yasmāddravyāṇi svabhāvataḥ saṃyogataś
+                        kiñciddravyamekāntena hitamahitaṃ vā'stīti kecidācāryā bruvate | tat tu na
+                        samyak; iha khalu yasmāddravyāṇi svabhāvataḥ saṃyogataś
                         caikāntahitānyekāntāhitāni hitāhitāni ca bhavanti ||3|| </l>
 
                     <l xml:id="SS.1.20.4">
                         <label>1938 ed. 1.20.4</label>
                         <caesura/>
                          tatra ,ekāntahitāni jātisātmyāt salilaghṛtadugdhaudanaprabhṛtīni;
-                        ekāntāhitāni tu dahanapacanamāraṇādiṣu
-                        pravṛttānyanalakṣāraviṣādīni, saṃyogādaparāṇi viṣatulyāni
-                        bhavanti; hitāhitāni tu yadvāyoḥ pathyaṃ tat pittasyāpathyam iti
-                        ||4|| </l>
+                        ekāntāhitāni tu dahanapacanamāraṇādiṣu pravṛttānyanalakṣāraviṣādīni,
+                        saṃyogādaparāṇi viṣatulyāni bhavanti; hitāhitāni tu yadvāyoḥ pathyaṃ tat
+                        pittasyāpathyam iti ||4|| </l>
 
                     <l xml:id="SS.1.20.5">
                         <label>1938 ed. 1.20.5</label>
@@ -4667,20 +4746,20 @@
                         raktaśāliṣaṣṭikakaṅgukramukundakapāṇḍukapītakapramodakakālakāsanakapuṣpakakardamakaśakunāhṛtasugandhakakalama-
                         nīvārakodravoddālakaśyāmākagodhūmayavavaiṇavaiṇahariṇakuraṅgamṛgamātṛkāśvadaṃṣṭrākarālakrakarakapotalāvatittirikapiñjalavartīravartikā
                         mudgavanamudgamakuṣṭhakalāyamasūramaṅgalyacaṇakahareṇvāḍhakīsatīnāścillivāstukasuniṣaṇṇakajīvantītaṇḍulīyakamaṇḍūkaparṇyaḥ,
-                        gavyaṃ ghṛtaṃ, saindhavaṃ, dāḍimāmalakam ity eṣa vargaḥ
-                        sarvaprāṇināṃ sāmānyataḥ pathyatamaḥ ||5|| </l>
+                        gavyaṃ ghṛtaṃ, saindhavaṃ, dāḍimāmalakam ity eṣa vargaḥ sarvaprāṇināṃ
+                        sāmānyataḥ pathyatamaḥ ||5|| </l>
 
                     <l xml:id="SS.1.20.6">
                         <label>1938 ed. 1.20.6</label>
                         <caesura/>
-                         tathā brahmacaryanivātaśayanoṣṇodakasnānaniśāsvapnavyāyāmāś
-                        caikāntataḥ pathyatamāḥ ||6|| </l>
+                         tathā brahmacaryanivātaśayanoṣṇodakasnānaniśāsvapnavyāyāmāś caikāntataḥ
+                        pathyatamāḥ ||6|| </l>
 
                     <l xml:id="SS.1.20.7">
                         <label>1938 ed. 1.20.7</label>
                         <caesura/>
-                         ekāntahitānyekāntāhitāni tu prāgupadiṣṭāni, hitāhitāni tu
-                        yadvāyoḥ pathyaṃ tat pittasyāpathyam iti ||7|| </l>
+                         ekāntahitānyekāntāhitāni tu prāgupadiṣṭāni, hitāhitāni tu yadvāyoḥ pathyaṃ
+                        tat pittasyāpathyam iti ||7|| </l>
 
                     <l xml:id="SS.1.20.8">
                         <label>1938 ed. 1.20.8</label>
@@ -4692,76 +4771,69 @@
                     <l xml:id="SS.1.20.9">
                         <label>1938 ed. 1.20.9</label>
                         <caesura/>
-                         rogaṃ sātmyaṃ ca deśaṃ ca kālaṃ dehaṃ ca buddhimān |
-                        avekṣyāgnyādikān bhāvān rogavṛtteḥ prayojayet ||9|| </l>
+                         rogaṃ sātmyaṃ ca deśaṃ ca kālaṃ dehaṃ ca buddhimān | avekṣyāgnyādikān
+                        bhāvān rogavṛtteḥ prayojayet ||9|| </l>
 
                     <l xml:id="SS.1.20.10">
                         <label>1938 ed. 1.20.10</label>
                         <caesura/>
-                         avasthāntarabāhulyādrogādīnāṃ vyavasthitam | dravyaṃ necchanti
-                        bhiṣaja icchanti svastharakṣaṇe ||10|| </l>
+                         avasthāntarabāhulyādrogādīnāṃ vyavasthitam | dravyaṃ necchanti bhiṣaja
+                        icchanti svastharakṣaṇe ||10|| </l>
 
                     <l xml:id="SS.1.20.11">
                         <label>1938 ed. 1.20.11</label>
                         <caesura/>
-                         dvayor anyatarādāne vadanti viṣadugdhayoḥ |
-                        dugdhasyaikāntahitatāṃ viṣamekāntato 'hitam ||11|| evaṃ
-                        yuktaraseṣveṣu dravyeṣu salilādiṣu | ekāntahitatāṃ viddhi vatsa
-                        suśruta nānyathā ||12||</l>
+                         dvayor anyatarādāne vadanti viṣadugdhayoḥ | dugdhasyaikāntahitatāṃ
+                        viṣamekāntato 'hitam ||11|| evaṃ yuktaraseṣveṣu dravyeṣu salilādiṣu |
+                        ekāntahitatāṃ viddhi vatsa suśruta nānyathā ||12||</l>
 
                     <l xml:id="SS.1.20.13">
                         <label>1938 ed. 1.20.13</label>
                         <caesura/>
                          ato 'nyānyapi saṃyogādahitāni vakṣyāmaḥ-
-                        navavirūḍhadhānyairvasāmadhupayoguḍamāṣair vā
-                        grāmyānūpaudakapiśitādīni nābhyavaharet; na payomadhubhyāṃ
-                        rohiṇīśākaṃ jātukaśākaṃ vā'śnīyāt, balākāṃ vāruṇīkulmāṣābhyāṃ,
-                        kākamācīṃ pippalīmaricābhyāṃ; nāḍībhaṅgaśākakukkuṭadadhīni ca
-                        naikadhyaṃ; madhu coṣṇodakānupānaṃ; pittena cāmamāṃsāni;
-                        surākṛśarāpāyasāṃś ca naikadhyaṃ; sauvīrakeṇa saha tilaśaṣkulīṃ;
-                        matsyaiḥ sahekṣuvikārān; guḍena kākamācīṃ, madhunā mūlakaṃ, guḍena
-                        vārāhaṃ madhunā ca saha viruddhaṃ; kṣīreṇa mūlakam,
-                        āmrajāmbavaśvāvicchūkaragodhāśca; sarvāṃś ca matsyān payasā,
-                        viśeṣeṇa cilicimaṃ; kadalīphalaṃ tālaphalena payasā dadhnā takreṇa
-                        vā; lakucaphalaṃ payasā dadhnā māṣasūpena vā, prāk payasaḥ payaso
-                        'nte vā ||13|| </l>
+                        navavirūḍhadhānyairvasāmadhupayoguḍamāṣair vā grāmyānūpaudakapiśitādīni
+                        nābhyavaharet; na payomadhubhyāṃ rohiṇīśākaṃ jātukaśākaṃ vā'śnīyāt, balākāṃ
+                        vāruṇīkulmāṣābhyāṃ, kākamācīṃ pippalīmaricābhyāṃ;
+                        nāḍībhaṅgaśākakukkuṭadadhīni ca naikadhyaṃ; madhu coṣṇodakānupānaṃ; pittena
+                        cāmamāṃsāni; surākṛśarāpāyasāṃś ca naikadhyaṃ; sauvīrakeṇa saha
+                        tilaśaṣkulīṃ; matsyaiḥ sahekṣuvikārān; guḍena kākamācīṃ, madhunā mūlakaṃ,
+                        guḍena vārāhaṃ madhunā ca saha viruddhaṃ; kṣīreṇa mūlakam,
+                        āmrajāmbavaśvāvicchūkaragodhāśca; sarvāṃś ca matsyān payasā, viśeṣeṇa
+                        cilicimaṃ; kadalīphalaṃ tālaphalena payasā dadhnā takreṇa vā; lakucaphalaṃ
+                        payasā dadhnā māṣasūpena vā, prāk payasaḥ payaso 'nte vā ||13|| </l>
 
                     <l xml:id="SS.1.20.14">
                         <label>1938 ed. 1.20.14</label>
                         <caesura/>
                          ataḥ karmaviruddhān vakṣyāmaḥ- kapotān sarṣapatailabhṛṣṭānnādyāt;
-                        kapiñjalamayūralāvatittirigodhāścairaṇḍadārvyagnisiddhā
-                        eraṇḍatailasiddhā vā nādyāt; kāṃsyabhājane daśarātraparyuṣitaṃ
-                        sarpiḥ; madhu coṣṇair uṣṇe vā; matsyaparipacane
-                        śṛṅgaveraparipacane vā siddhāṃ kākamācīṃ;
-                        tilakalkasiddhamupodikāśākaṃ; nārikelena varāhavasāparibhṛṣṭāṃ
-                        balākāṃ; bhāsamaṅgāraśūlyaṃ nāśnīyāditi ||14|| </l>
+                        kapiñjalamayūralāvatittirigodhāścairaṇḍadārvyagnisiddhā eraṇḍatailasiddhā vā
+                        nādyāt; kāṃsyabhājane daśarātraparyuṣitaṃ sarpiḥ; madhu coṣṇair uṣṇe vā;
+                        matsyaparipacane śṛṅgaveraparipacane vā siddhāṃ kākamācīṃ;
+                        tilakalkasiddhamupodikāśākaṃ; nārikelena varāhavasāparibhṛṣṭāṃ balākāṃ;
+                        bhāsamaṅgāraśūlyaṃ nāśnīyāditi ||14|| </l>
 
                     <l xml:id="SS.1.20.15">
                         <label>1938 ed. 1.20.15</label>
                         <caesura/>
-                         ato mānaviruddhān vakṣyāmaḥ- madhvambunī madhusarpiṣī
-                        mānatastulye nāśnīyāt; snehau madhusnehau jalasnehau vā
-                        viśeṣādāntarīkṣodakānupānau ||15|| </l>
+                         ato mānaviruddhān vakṣyāmaḥ- madhvambunī madhusarpiṣī mānatastulye
+                        nāśnīyāt; snehau madhusnehau jalasnehau vā viśeṣādāntarīkṣodakānupānau
+                        ||15|| </l>
 
                     <l xml:id="SS.1.20.16">
                         <label>1938 ed. 1.20.16</label>
                         <caesura/>
-                         ata ūrdhvaṃ rasadvandvāni rasato vīryato vipākataś ca viruddhāni
-                        vakṣyāmaḥ- tatra madhurāmlau rasavīryaviruddhau, madhuralavaṇau
-                        ca, madhurakaṭukau ca sarvataḥ, madhuratiktau rasavipākābhyāṃ,
-                        madhurakaṣāyau ca, amlalavaṇau rasataḥ, amlakaṭukau
-                        rasavipākābhyām, amlatiktāvamlakaṣāyau ca sarvataḥ, lavaṇakaṭukau
-                        rasavipākābhyāṃ, lavaṇatiktau lavaṇakaṣāyau ca sarvataḥ,
-                        kaṭutiktau rasavīryābhyāṃ kaṭukaṣāyau ca, tiktakaṣāyau rasataḥ
-                        ||16|| </l>
+                         ata ūrdhvaṃ rasadvandvāni rasato vīryato vipākataś ca viruddhāni vakṣyāmaḥ-
+                        tatra madhurāmlau rasavīryaviruddhau, madhuralavaṇau ca, madhurakaṭukau ca
+                        sarvataḥ, madhuratiktau rasavipākābhyāṃ, madhurakaṣāyau ca, amlalavaṇau
+                        rasataḥ, amlakaṭukau rasavipākābhyām, amlatiktāvamlakaṣāyau ca sarvataḥ,
+                        lavaṇakaṭukau rasavipākābhyāṃ, lavaṇatiktau lavaṇakaṣāyau ca sarvataḥ,
+                        kaṭutiktau rasavīryābhyāṃ kaṭukaṣāyau ca, tiktakaṣāyau rasataḥ ||16|| </l>
 
                     <l xml:id="SS.1.20.17">
                         <label>1938 ed. 1.20.17</label>
                         <caesura/>
-                         taratamayogayuktāṃśca
-                        bhāvānatisnigdhānatirūkṣānatyuṣṇānatiśītānity evamādīn vivarjayet
-                        ||17|| </l>
+                         taratamayogayuktāṃśca bhāvānatisnigdhānatirūkṣānatyuṣṇānatiśītānity
+                        evamādīn vivarjayet ||17|| </l>
 
                     <l xml:id="SS.1.20.18">
                         <label>1938 ed. 1.20.18</label>
@@ -4772,75 +4844,74 @@
                     <l xml:id="SS.1.20.19">
                         <label>1938 ed. 1.20.19</label>
                         <caesura/>
-                         vyādhimindriyadaurbalyaṃ maraṇaṃ cādhigacchati |
-                        viruddharasavīryāṇi bhuñjāno 'nātmavān naraḥ ||19|| </l>
+                         vyādhimindriyadaurbalyaṃ maraṇaṃ cādhigacchati | viruddharasavīryāṇi
+                        bhuñjāno 'nātmavān naraḥ ||19|| </l>
 
                     <l xml:id="SS.1.20.20">
                         <label>1938 ed. 1.20.20</label>
                         <caesura/>
-                         yatkiñciddoṣamutkleśya bhuktaṃ kāyānna nirharet |
-                        rasādiṣvayathārthaṃ vā tadvikārāya kalpate ||20|| </l>
+                         yatkiñciddoṣamutkleśya bhuktaṃ kāyānna nirharet | rasādiṣvayathārthaṃ vā
+                        tadvikārāya kalpate ||20|| </l>
 
                     <l xml:id="SS.1.20.21">
                         <label>1938 ed. 1.20.21</label>
                         <caesura/>
-                         viruddhāśanajān rogān pratihanti virecanam | vamanaṃ śamanaṃ
-                        vā'pi pūrvaṃ vā hitasevanam ||21|| </l>
+                         viruddhāśanajān rogān pratihanti virecanam | vamanaṃ śamanaṃ vā'pi pūrvaṃ
+                        vā hitasevanam ||21|| </l>
 
                     <l xml:id="SS.1.20.22">
                         <label>1938 ed. 1.20.22</label>
                         <caesura/>
-                         sātmyato 'lpatayā vā'pi dīptāgnestaruṇasya ca |
-                        snigdhavyāyāmabalināṃ viruddhaṃ vitathaṃ bhavet ||22|| </l>
+                         sātmyato 'lpatayā vā'pi dīptāgnestaruṇasya ca | snigdhavyāyāmabalināṃ
+                        viruddhaṃ vitathaṃ bhavet ||22|| </l>
 
                     <l xml:id="SS.1.20.23">
                         <label>1938 ed. 1.20.23</label>
                         <caesura/>
-                         atha vātaguṇān vakṣyāmaḥ- pūrvaḥ samadhuraḥ snigdho lavaṇaś caiva
-                        mārutaḥ | gururvidāhajanano raktapittābhivardhanaḥ ||23|| </l>
+                         atha vātaguṇān vakṣyāmaḥ- pūrvaḥ samadhuraḥ snigdho lavaṇaś caiva mārutaḥ |
+                        gururvidāhajanano raktapittābhivardhanaḥ ||23|| </l>
 
                     <l xml:id="SS.1.20.24">
                         <label>1938 ed. 1.20.24</label>
                         <caesura/>
-                         kṣatānāṃ viṣajuṣṭānāṃ vraṇinaḥ śleṣmalāś ca ye | teṣāṃ eva
-                        viśeṣeṇa sadā rogavivardhanaḥ ||24|| </l>
+                         kṣatānāṃ viṣajuṣṭānāṃ vraṇinaḥ śleṣmalāś ca ye | teṣāṃ eva viśeṣeṇa sadā
+                        rogavivardhanaḥ ||24|| </l>
 
                     <l xml:id="SS.1.20.25">
                         <label>1938 ed. 1.20.25</label>
                         <caesura/>
-                         vātalānāṃ praśastaś ca śrāntānāṃ kaphaśoṣiṇām | madhuraś cāvidāhī
-                        ca kaṣāyānuraso laghuḥ | dakṣiṇo mārutaḥ śreṣṭhaścakṣuṣyo
-                        balavardhanaḥ ||25|| </l>
+                         vātalānāṃ praśastaś ca śrāntānāṃ kaphaśoṣiṇām | madhuraś cāvidāhī ca
+                        kaṣāyānuraso laghuḥ | dakṣiṇo mārutaḥ śreṣṭhaścakṣuṣyo balavardhanaḥ ||25|| </l>
 
                     <l xml:id="SS.1.20.26">
                         <label>1938 ed. 1.20.26</label>
                         <caesura/>
-                         raktapittapraśamano na ca vātaprakopaṇaḥ | viśado rūkṣaparuṣaḥ
-                        kharaḥ snehabalāpahaḥ ||26|| </l>
+                         raktapittapraśamano na ca vātaprakopaṇaḥ | viśado rūkṣaparuṣaḥ kharaḥ
+                        snehabalāpahaḥ ||26|| </l>
 
                     <l xml:id="SS.1.20.27">
                         <label>1938 ed. 1.20.27</label>
                         <caesura/>
-                         paścimo mārutastīkṣṇaḥ kaphamedoviśoṣaṇaḥ | sadyaḥ
-                        prāṇakṣayakaraḥ śoṣaṇas tu śarīriṇām ||27|| </l>
+                         paścimo mārutastīkṣṇaḥ kaphamedoviśoṣaṇaḥ | sadyaḥ prāṇakṣayakaraḥ śoṣaṇas
+                        tu śarīriṇām ||27|| </l>
 
                     <l xml:id="SS.1.20.28">
                         <label>1938 ed. 1.20.28</label>
                         <caesura/>
-                         uttaro mārutaḥ snigdho mṛdurmadhura eva ca | kaṣāyānurasaḥ śīto
-                        doṣāṇāṃ cāprakopaṇaḥ ||28|| </l>
+                         uttaro mārutaḥ snigdho mṛdurmadhura eva ca | kaṣāyānurasaḥ śīto doṣāṇāṃ
+                        cāprakopaṇaḥ ||28|| </l>
 
                     <l xml:id="SS.1.20.29">
                         <label>1938 ed. 1.20.29</label>
                         <caesura/>
-                         tasmāc ca prakṛtisthānāṃ kledano balavardhanaḥ |
-                        kṣīṇakṣayaviṣārtānāṃ viśeṣeṇa tu pūjitaḥ ||29||</l>
+                         tasmāc ca prakṛtisthānāṃ kledano balavardhanaḥ | kṣīṇakṣayaviṣārtānāṃ
+                        viśeṣeṇa tu pūjitaḥ ||29||</l>
 
                     <l xml:id="SS.1.20.trailer">
                         <label>1938 ed. 1.20.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne hitāhitīyo nāma viṃśo 'dhyāyaḥ
-                        ||20|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne hitāhitīyo nāma viṃśo 'dhyāyaḥ ||20||
+                    </l>
                 </div>
 
                 <div n="21" type="adhyāya">
@@ -4850,130 +4921,122 @@
                     <l xml:id="SS.1.21.3">
                         <label>1938 ed. 1.21.3</label>
                         <caesura/>
-                         vātapittaśleṣmāṇa eva dehasambhavahetavaḥ |
-                        tairevāvyāpannairadhomadhyor dhvasanniviṣṭaiḥ śarīramidaṃ dhāryate
-                        'gāram iva sthūṇābhis tisṛbhiḥ ataś ca tristhūṇamāhureke | ta eva
-                        ca vyāpannāḥ pralayahetavaḥ | tadebhir eva śoṇitacaturthaiḥ
-                        sambhavasthitipralayeṣv apy avirahitaṃ śarīraṃ bhavati ||3|| </l>
+                         vātapittaśleṣmāṇa eva dehasambhavahetavaḥ | tairevāvyāpannairadhomadhyor
+                        dhvasanniviṣṭaiḥ śarīramidaṃ dhāryate 'gāram iva sthūṇābhis tisṛbhiḥ ataś ca
+                        tristhūṇamāhureke | ta eva ca vyāpannāḥ pralayahetavaḥ | tadebhir eva
+                        śoṇitacaturthaiḥ sambhavasthitipralayeṣv apy avirahitaṃ śarīraṃ bhavati
+                        ||3|| </l>
 
                     <l xml:id="SS.1.21.4">
                         <label>1938 ed. 1.21.4</label>
                         <caesura/>
-                         bhavati cātra - narte dehaḥ kaphādasti na pittānna ca mārutāt |
-                        śoṇitād api vā nityaṃ deha etais tu dhāryate ||4|| </l>
+                         bhavati cātra - narte dehaḥ kaphādasti na pittānna ca mārutāt | śoṇitād api
+                        vā nityaṃ deha etais tu dhāryate ||4|| </l>
 
                     <l xml:id="SS.1.21.5">
                         <label>1938 ed. 1.21.5</label>
                         <caesura/>
-                         tatra ‘vā’ gatigandhanayoḥ, iti dhātuḥ, ‘tapa’ santāpe, ‘śliṣa’
-                        āliṅgane, eteṣāṃ kṛdvihitaiḥ pratyayair vātaḥ pittaṃ śleṣmeti ca
-                        rūpāṇi bhavanti ||5|| </l>
+                         tatra ‘vā’ gatigandhanayoḥ, iti dhātuḥ, ‘tapa’ santāpe, ‘śliṣa’ āliṅgane,
+                        eteṣāṃ kṛdvihitaiḥ pratyayair vātaḥ pittaṃ śleṣmeti ca rūpāṇi bhavanti ||5|| </l>
 
                     <l xml:id="SS.1.21.6">
                         <label>1938 ed. 1.21.6</label>
                         <caesura/>
-                         doṣasthānānyata ūrdhvaṃ vakṣyāmaḥ- tatra samāsena vātaḥ
-                        śroṇigudasaṃśrayaḥ; taduparyadho nābheḥ pakvāśayaḥ,
-                        pakvāmāśayamadhyaṃ pittasya; āmāśayaḥ śleṣmaṇaḥ ||6|| </l>
+                         doṣasthānānyata ūrdhvaṃ vakṣyāmaḥ- tatra samāsena vātaḥ śroṇigudasaṃśrayaḥ;
+                        taduparyadho nābheḥ pakvāśayaḥ, pakvāmāśayamadhyaṃ pittasya; āmāśayaḥ
+                        śleṣmaṇaḥ ||6|| </l>
 
                     <l xml:id="SS.1.21.7">
                         <label>1938 ed. 1.21.7</label>
                         <caesura/>
-                         ataḥ paraṃ pañcadhā vibhajyante | tatra vātasya vātavyādhau
-                        vakṣyāmaḥ; pittasya yakṛtplīhānau hṛdayaṃ dṛṣṭistvak pūrvoktaṃ ca;
-                        śleṣmaṇa uraḥ śiraḥ kaṇṭho jihvāmūlaṃ sandhaya iti pūrvoktaṃ ca;
-                        etāni khalu doṣāṇāṃ sthānānyavyāpannānām ||7|| </l>
+                         ataḥ paraṃ pañcadhā vibhajyante | tatra vātasya vātavyādhau vakṣyāmaḥ;
+                        pittasya yakṛtplīhānau hṛdayaṃ dṛṣṭistvak pūrvoktaṃ ca; śleṣmaṇa uraḥ śiraḥ
+                        kaṇṭho jihvāmūlaṃ sandhaya iti pūrvoktaṃ ca; etāni khalu doṣāṇāṃ
+                        sthānānyavyāpannānām ||7|| </l>
 
                     <l xml:id="SS.1.21.8">
                         <label>1938 ed. 1.21.8</label>
                         <caesura/>
-                         bhavati cātra - visargodānavikṣepaiḥ somasūryānilā yathā |
-                        dhārayanti jagaddehaṃ kaphapittānilāstathā ||8|| </l>
+                         bhavati cātra - visargodānavikṣepaiḥ somasūryānilā yathā | dhārayanti
+                        jagaddehaṃ kaphapittānilāstathā ||8|| </l>
 
                     <l xml:id="SS.1.21.9">
                         <label>1938 ed. 1.21.9</label>
                         <caesura/>
-                         tatra jijñāsyaṃ kiṃ pittavyatirekādanyo 'gniḥ? āhosvit
-                        pittamevāgniriti? | atrocyate- na khalu pittavyatirekādanyo
-                        'gnirupalabhyate, āgneyatvāt pitte
-                        dahanapacanādiṣvabhipravartamāne 'gnivadupacāraḥ kriyate
-                        'ntaragniriti; kṣīṇe hy agniguṇe tatsamānadravyopayogāt ,
-                        ativṛddhe śītakriyopayogāt , āgamāc ca paśyāmo na khalu
-                        pittavyatirekādanyo 'gniriti ||9|| </l>
+                         tatra jijñāsyaṃ kiṃ pittavyatirekādanyo 'gniḥ? āhosvit pittamevāgniriti? |
+                        atrocyate- na khalu pittavyatirekādanyo 'gnirupalabhyate, āgneyatvāt pitte
+                        dahanapacanādiṣvabhipravartamāne 'gnivadupacāraḥ kriyate 'ntaragniriti;
+                        kṣīṇe hy agniguṇe tatsamānadravyopayogāt , ativṛddhe śītakriyopayogāt ,
+                        āgamāc ca paśyāmo na khalu pittavyatirekādanyo 'gniriti ||9|| </l>
 
                     <l xml:id="SS.1.21.10">
                         <label>1938 ed. 1.21.10</label>
                         <caesura/>
                          taccādṛṣṭahetukena viśeṣeṇa pakvāmāśayamadhyasthaṃ pittaṃ
-                        caturvidhamannapānaṃ pacati, vivecayati ca doṣarasamūtrapurīṣāṇi;
-                        tatrastham eva cātmaśaktyā śeṣāṇāṃ pittasthānānāṃ śarīrasya
-                        cāgnikarmaṇā'nugrahaṃ karoti, tasmin pitte pācako 'gniriti sañjñā;
-                        yat tu yakṛtplīhnoḥ pittaṃ tasmin rañjako 'gniriti sañjñā, sa
-                        rasasya rāgakṛduktaḥ; yat pittaṃ hṛdayasthaṃ tasmin sādhako
-                        'gniriti sañjñā, so 'bhiprārthitamanorathasādhanakṛduktaḥ;
-                        yaddṛṣṭyāṃ pittaṃ tasminnālocako 'gniriti sañjñā, sa
-                        rūpagrahaṇā'dhikṛtaḥ; yattu tvaci pittaṃ tasmin bhrājako 'gniriti
-                        sañjñā, so 'bhyaṅgapariṣekāvagāhālepanādīnāṃ kriyādravyāṇāṃ paktā
+                        caturvidhamannapānaṃ pacati, vivecayati ca doṣarasamūtrapurīṣāṇi; tatrastham
+                        eva cātmaśaktyā śeṣāṇāṃ pittasthānānāṃ śarīrasya cāgnikarmaṇā'nugrahaṃ
+                        karoti, tasmin pitte pācako 'gniriti sañjñā; yat tu yakṛtplīhnoḥ pittaṃ
+                        tasmin rañjako 'gniriti sañjñā, sa rasasya rāgakṛduktaḥ; yat pittaṃ
+                        hṛdayasthaṃ tasmin sādhako 'gniriti sañjñā, so
+                        'bhiprārthitamanorathasādhanakṛduktaḥ; yaddṛṣṭyāṃ pittaṃ tasminnālocako
+                        'gniriti sañjñā, sa rūpagrahaṇā'dhikṛtaḥ; yattu tvaci pittaṃ tasmin bhrājako
+                        'gniriti sañjñā, so 'bhyaṅgapariṣekāvagāhālepanādīnāṃ kriyādravyāṇāṃ paktā
                         chāyānāṃ ca prakāśakaḥ ||10|| </l>
 
                     <l xml:id="SS.1.21.11">
                         <label>1938 ed. 1.21.11</label>
                         <caesura/>
-                         bhavati cātra - pittaṃ tīkṣṇaṃ dravaṃ pūti nīlaṃ pītaṃ tathaiva
-                        ca | uṣṇaṃ kaṭurasaṃ caiva vidagdhaṃ cāmlam eva ca ||11|| </l>
+                         bhavati cātra - pittaṃ tīkṣṇaṃ dravaṃ pūti nīlaṃ pītaṃ tathaiva ca | uṣṇaṃ
+                        kaṭurasaṃ caiva vidagdhaṃ cāmlam eva ca ||11|| </l>
 
                     <l xml:id="SS.1.21.12">
                         <label>1938 ed. 1.21.12</label>
                         <caesura/>
                          ata ūrdhvaṃ śleṣmasthānānyanuvyākhyāsyāmaḥ | tatra, āmāśayaḥ
-                        pittāśayasyopariṣṭāt tatpratyanīkatvād ūrdhvagatitvāt tejasaḥ,
-                        candra iva ādity asya , caturvidhasyāhārasyādhāraḥ; sa ca
-                        tatraudakairguṇairāhāraḥ praklinno bhinnasaṅghātaḥ sukhajaro
-                        bhavati ||12|| </l>
+                        pittāśayasyopariṣṭāt tatpratyanīkatvād ūrdhvagatitvāt tejasaḥ, candra iva
+                        ādity asya , caturvidhasyāhārasyādhāraḥ; sa ca tatraudakairguṇairāhāraḥ
+                        praklinno bhinnasaṅghātaḥ sukhajaro bhavati ||12|| </l>
 
                     <l xml:id="SS.1.21.13">
                         <label>1938 ed. 1.21.13</label>
                         <caesura/>
-                         mādhuryāt picchilatvāc ca prakleditvāt tathaiva ca | āmāśaye
-                        sambhavati śleṣmā madhuraśītalaḥ ||13|| </l>
+                         mādhuryāt picchilatvāc ca prakleditvāt tathaiva ca | āmāśaye sambhavati
+                        śleṣmā madhuraśītalaḥ ||13|| </l>
 
                     <l xml:id="SS.1.21.14">
                         <label>1938 ed. 1.21.14</label>
                         <caesura/>
                          sa tatrastha eva svaśaktyā śeṣāṇāṃ śleṣmasthānānāṃ śarīrasya
                         codakakarmaṇā'nugrahaṃ karoti;
-                        uraḥsthastrikasandhāraṇamātmavīryeṇānnarasasahitena
-                        hṛdayāvalambanaṃ karoti; jihvāmūlakaṇṭhastho jihvendriyasya
-                        saumyatvāt samyagrasajñāne vartate; śiraḥsthaḥ
-                        snehasantarpaṇādhikṛtatvād indriyāṇāmātmavīryeṇānugrahaṃ karot;
-                        sandhisthaḥ śleṣmā sarvasandhisaṃśleṣāt sarvasandhyanugrahaṃ
-                        karoti ||14|| </l>
+                        uraḥsthastrikasandhāraṇamātmavīryeṇānnarasasahitena hṛdayāvalambanaṃ karoti;
+                        jihvāmūlakaṇṭhastho jihvendriyasya saumyatvāt samyagrasajñāne vartate;
+                        śiraḥsthaḥ snehasantarpaṇādhikṛtatvād indriyāṇāmātmavīryeṇānugrahaṃ karot;
+                        sandhisthaḥ śleṣmā sarvasandhisaṃśleṣāt sarvasandhyanugrahaṃ karoti ||14|| </l>
 
                     <l xml:id="SS.1.21.15">
                         <label>1938 ed. 1.21.15</label>
                         <caesura/>
-                         bhavati cātra - śleṣmā śveto guruḥ snigdhaḥ picchilaḥ śīta eva ca
-                        | madhurastvavidagdhaḥ syādvidagdho lavaṇa smṛtaḥ ||15|| </l>
+                         bhavati cātra - śleṣmā śveto guruḥ snigdhaḥ picchilaḥ śīta eva ca |
+                        madhurastvavidagdhaḥ syādvidagdho lavaṇa smṛtaḥ ||15|| </l>
 
                     <l xml:id="SS.1.21.16">
                         <label>1938 ed. 1.21.16</label>
                         <caesura/>
-                         śoṇitasya sthānaṃ yakṛtplīhānau, tacca prāgabhihitaṃ; tatrastham
-                        eva śeṣāṇāṃ śoṇitasthānānāmanugrahaṃ karoti ||16|| </l>
+                         śoṇitasya sthānaṃ yakṛtplīhānau, tacca prāgabhihitaṃ; tatrastham eva
+                        śeṣāṇāṃ śoṇitasthānānāmanugrahaṃ karoti ||16|| </l>
 
                     <l xml:id="SS.1.21.17">
                         <label>1938 ed. 1.21.17</label>
                         <caesura/>
-                         bhavati cātra - anuṣṇaśītaṃ madhuraṃ snigdhaṃ raktaṃ ca varṇataḥ
-                        | śoṇitaṃ guru visraṃ syādvidāhaś cāsya pittavat ||17|| </l>
+                         bhavati cātra - anuṣṇaśītaṃ madhuraṃ snigdhaṃ raktaṃ ca varṇataḥ | śoṇitaṃ
+                        guru visraṃ syādvidāhaś cāsya pittavat ||17|| </l>
 
                     <l xml:id="SS.1.21.18">
                         <label>1938 ed. 1.21.18</label>
                         <caesura/>
-                         etāni khalu doṣasthānāni; eṣu sañcīyante doṣāḥ | prāk
-                        sañcayahetur uktaḥ | tatra sañcitānāṃ khalu doṣāṇāṃ
-                        stabdhapūrṇakoṣṭhatā pītāvabhāsatā mandoṣmatā cāṅgānāṃ
-                        gauravamālasyaṃ cayakāraṇavidveṣaśceti liṅgāni bhavanti | tatra
+                         etāni khalu doṣasthānāni; eṣu sañcīyante doṣāḥ | prāk sañcayahetur uktaḥ |
+                        tatra sañcitānāṃ khalu doṣāṇāṃ stabdhapūrṇakoṣṭhatā pītāvabhāsatā mandoṣmatā
+                        cāṅgānāṃ gauravamālasyaṃ cayakāraṇavidveṣaśceti liṅgāni bhavanti | tatra
                         prathamaḥ kriyākālaḥ ||18|| </l>
 
                     <l xml:id="SS.1.21.19">
@@ -4988,8 +5051,8 @@
                     <l xml:id="SS.1.21.20">
                         <label>1938 ed. 1.21.20</label>
                         <caesura/>
-                         sa śītābhrapravāteṣu gharmānte ca viśeṣataḥ | pratyūṣasyaparāhṇe
-                        tu jīrṇe 'nne ca prakupyati ||20|| </l>
+                         sa śītābhrapravāteṣu gharmānte ca viśeṣataḥ | pratyūṣasyaparāhṇe tu jīrṇe
+                        'nne ca prakupyati ||20|| </l>
 
                     <l xml:id="SS.1.21.21">
                         <label>1938 ed. 1.21.21</label>
@@ -5002,22 +5065,22 @@
                     <l xml:id="SS.1.21.22">
                         <label>1938 ed. 1.21.22</label>
                         <caesura/>
-                         taduṣṇair uṣṇakāle ca ghanānte ca viśeṣataḥ | madhyāhne
-                        cārdharātre ca jīryatyanne ca kupyati ||22|| </l>
+                         taduṣṇair uṣṇakāle ca ghanānte ca viśeṣataḥ | madhyāhne cārdharātre ca
+                        jīryatyanne ca kupyati ||22|| </l>
 
                     <l xml:id="SS.1.21.23">
                         <label>1938 ed. 1.21.23</label>
                         <caesura/>
                          divāsvapnāvyāyāmālasyamadhurāmlalavaṇaśītasnigdhagurupicchilābhiṣyandihāyanakayavakanaiṣadhetkaṭa-
                         māṣamahāmāṣagodhūmatilapiṣṭavikṛtidadhidugdhakṛśarāpāyasekṣuvikārānūpaudakamāṃsavasābisamṛṇāla-
-                        kaserukaśṛṅgāṭakamadhuravallīphalasamaśanādhyaśanaprabhṛtibhiḥ
-                        śleṣmā prakopamāpadyate ||23|| </l>
+                        kaserukaśṛṅgāṭakamadhuravallīphalasamaśanādhyaśanaprabhṛtibhiḥ śleṣmā
+                        prakopamāpadyate ||23|| </l>
 
                     <l xml:id="SS.1.21.24">
                         <label>1938 ed. 1.21.24</label>
                         <caesura/>
-                         sa śītaiḥ śītakāle ca vasante ca viśeṣataḥ | pūrvāhṇe ca pradoṣe
-                        ca bhuktamātre prakupyati ||24|| </l>
+                         sa śītaiḥ śītakāle ca vasante ca viśeṣataḥ | pūrvāhṇe ca pradoṣe ca
+                        bhuktamātre prakupyati ||24|| </l>
 
                     <l xml:id="SS.1.21.25">
                         <label>1938 ed. 1.21.25</label>
@@ -5029,27 +5092,26 @@
                     <l xml:id="SS.1.21.26">
                         <label>1938 ed. 1.21.26</label>
                         <caesura/>
-                         yasmādraktaṃ vinā doṣairna kadācit prakupyati | tasmāt tasya
-                        yathādoṣaṃ kālaṃ vidyat prakopaṇe ||26|| </l>
+                         yasmādraktaṃ vinā doṣairna kadācit prakupyati | tasmāt tasya yathādoṣaṃ
+                        kālaṃ vidyat prakopaṇe ||26|| </l>
 
                     <l xml:id="SS.1.21.27">
                         <label>1938 ed. 1.21.27</label>
                         <caesura/>
                          teṣāṃ prakopāt
-                        koṣṭhatodasañcaraṇāmlīkāpipāsāparidāhānnadveṣahṛdayotkledāśca
-                        jāyante | tatra dvitīyaḥ kriyākālaḥ ||27|| </l>
+                        koṣṭhatodasañcaraṇāmlīkāpipāsāparidāhānnadveṣahṛdayotkledāśca jāyante |
+                        tatra dvitīyaḥ kriyākālaḥ ||27|| </l>
 
                     <l xml:id="SS.1.21.28">
                         <label>1938 ed. 1.21.28</label>
                         <caesura/>
-                         ata ūrdhvaṃ prasaraṃ vakṣyāmaḥ- teṣāṃ ebhir ātaṅkaviśeṣaiḥ
-                        prakupitānāṃ kiṇvodakapiṣṭasamavāya ivodriktānāṃ prasaro bhavati |
-                        teṣāṃ vāyurgatimattvāt prasaraṇahetuḥ satyapyacaitanye | sa hi
-                        rajobhūyiṣṭhaḥ; rajaśca pravartakaṃ sarvabhāvānām | yathā-
-                        mahānudakasañcayo 'tivṛddhaḥ setumavadāryāpareṇodakena vyāmiśraḥ
-                        sarvataḥ pradhāvati, evaṃ doṣāḥ kadācidekaśo dviśaḥ samastāḥ
-                        śoṇitasahitā vā'nekadhā prasaranti | tad yathā- vātaḥ, pittaṃ,
-                        śleṣmā, śoṇitaṃ, vātapitte, vātaśleṣmāṇau, pittaśleṣmāṇau,
+                         ata ūrdhvaṃ prasaraṃ vakṣyāmaḥ- teṣāṃ ebhir ātaṅkaviśeṣaiḥ prakupitānāṃ
+                        kiṇvodakapiṣṭasamavāya ivodriktānāṃ prasaro bhavati | teṣāṃ vāyurgatimattvāt
+                        prasaraṇahetuḥ satyapyacaitanye | sa hi rajobhūyiṣṭhaḥ; rajaśca pravartakaṃ
+                        sarvabhāvānām | yathā- mahānudakasañcayo 'tivṛddhaḥ
+                        setumavadāryāpareṇodakena vyāmiśraḥ sarvataḥ pradhāvati, evaṃ doṣāḥ
+                        kadācidekaśo dviśaḥ samastāḥ śoṇitasahitā vā'nekadhā prasaranti | tad yathā-
+                        vātaḥ, pittaṃ, śleṣmā, śoṇitaṃ, vātapitte, vātaśleṣmāṇau, pittaśleṣmāṇau,
                         vātaśoṇite, pittaśoṇite, śleṣmaśoṇite, vātapittaśoṇitāni,
                         vātaśleṣmaśoṇitāni, pittaśleṣmaśoṇitāni, vātapittakaphāḥ,
                         vātapittakaphaśoṇitānīti; evaṃ pañcadaśadhā prasaranti ||28|| </l>
@@ -5057,46 +5119,43 @@
                     <l xml:id="SS.1.21.29">
                         <label>1938 ed. 1.21.29</label>
                         <caesura/>
-                         kṛtsne 'rdhe 'vayave vā'pi yatrāṅge kupito bhṛśam | doṣo vikāraṃ
-                        nabhasi meghavattatra varṣati ||29|| </l>
+                         kṛtsne 'rdhe 'vayave vā'pi yatrāṅge kupito bhṛśam | doṣo vikāraṃ nabhasi
+                        meghavattatra varṣati ||29|| </l>
 
                     <l xml:id="SS.1.21.30">
                         <label>1938 ed. 1.21.30</label>
                         <caesura/>
-                         nātyarthaṃ kupitaś cāpi līno mārgeṣu tiṣṭhati | niṣpratyanīkaḥ
-                        kālena hetumāsādya kupyati ||30||</l>
+                         nātyarthaṃ kupitaś cāpi līno mārgeṣu tiṣṭhati | niṣpratyanīkaḥ kālena
+                        hetumāsādya kupyati ||30||</l>
 
                     <l xml:id="SS.1.21.31">
                         <label>1938 ed. 1.21.31</label>
                         <caesura/>
                          tatra vāyoḥ pittasthānagatasya pittavat pratīkāraḥ, pittasya ca
-                        kaphasthānagatasya kaphavat, kaphasya ca vātasthānagatasya vātavat
-                        ; eṣa kriyāvibhāgaḥ ||31|| </l>
+                        kaphasthānagatasya kaphavat, kaphasya ca vātasthānagatasya vātavat ; eṣa
+                        kriyāvibhāgaḥ ||31|| </l>
 
                     <l xml:id="SS.1.21.32">
                         <label>1938 ed. 1.21.32</label>
                         <caesura/>
                          evaṃ prakupitānāṃ prasaratāṃ vāyor vimārgagamanāṭopau,
-                        oṣacoṣaparidāhadhūmāyanāni pittasya,
-                        arocakāvipākāṅgasādāśchardiśceti śleṣmaṇo liṅgāni bhavanti; tatra
-                        tṛtīyaḥ kriyākālaḥ ||32|| </l>
+                        oṣacoṣaparidāhadhūmāyanāni pittasya, arocakāvipākāṅgasādāśchardiśceti
+                        śleṣmaṇo liṅgāni bhavanti; tatra tṛtīyaḥ kriyākālaḥ ||32|| </l>
 
                     <l xml:id="SS.1.21.33">
                         <label>1938 ed. 1.21.33</label>
                         <caesura/>
                          ata ūrdhvaṃ sthānasaṃśrayaṃ vakṣyāmaḥ | evaṃ prakupitātāṃstāñ
-                        śarīrapradeśānāgamya tāṃstān vyādhīn janayanti | te
-                        yadodarasanniveśaṃ kurvanti tadā gulma
-                        vidradhyudarāgnisaṅgānāhavisūcikātisāraprabhṛtīñjanayanti;
-                        bastigatāḥ pramehāśmarīmūtrāghātamūtradoṣaprabhṛtīn; meḍhragatā
-                        niruddhaprakaśopadaṃśaśūkadoṣaprabhṛtīn; gudagatā
-                        bhagandarārśaḥprabhṛtīn; vṛṣaṇagatā vṛddhīḥ;
-                        ūrdhvajatrugatāstūrdhvajān; tvaṅmaṃsaśoṇitasthāḥ kṣudrarogān
-                        kuṣṭhāni visarpāṃśca; medogatā
+                        śarīrapradeśānāgamya tāṃstān vyādhīn janayanti | te yadodarasanniveśaṃ
+                        kurvanti tadā gulma
+                        vidradhyudarāgnisaṅgānāhavisūcikātisāraprabhṛtīñjanayanti; bastigatāḥ
+                        pramehāśmarīmūtrāghātamūtradoṣaprabhṛtīn; meḍhragatā
+                        niruddhaprakaśopadaṃśaśūkadoṣaprabhṛtīn; gudagatā bhagandarārśaḥprabhṛtīn;
+                        vṛṣaṇagatā vṛddhīḥ; ūrdhvajatrugatāstūrdhvajān; tvaṅmaṃsaśoṇitasthāḥ
+                        kṣudrarogān kuṣṭhāni visarpāṃśca; medogatā
                         granthyapacyarbudagalagaṇḍālajīprabhṛtīn; asthigatā
-                        vidradhyanuśayīprabhṛtīn; pādagatāḥ
-                        ślīpadavātaśoṇitavātakaṇṭakaprabhṛtīn; sarvāṅgagatā
-                        jvarasarvāṅgarogaprabhṛtīn; teṣāṃ evamabhis anniviṣṭānāṃ
+                        vidradhyanuśayīprabhṛtīn; pādagatāḥ ślīpadavātaśoṇitavātakaṇṭakaprabhṛtīn;
+                        sarvāṅgagatā jvarasarvāṅgarogaprabhṛtīn; teṣāṃ evamabhis anniviṣṭānāṃ
                         pūrvarūpaprādurbhāvaḥ ; taṃ pratirogaṃ vakṣyāmaḥ | tatraSS.1.20.
                         pūrvarūpagateṣu caturthaḥ kriyākālaḥ ||33|| </l>
 
@@ -5110,45 +5169,45 @@
                     <l xml:id="SS.1.21.35">
                         <label>1938 ed. 1.21.35</label>
                         <caesura/>
-                         ata ūrdhvameteṣāmavadīrṇānāṃ vraṇabhāvamāpannānāṃ ṣaṣṭhaḥ
-                        kriyākālaḥ, jvarātisāraprabhṛtīnāṃ ca dīrghakālānubandhaḥ |
-                        tatrāpratikriyamāṇe 'sādhyatām upayānti ||35|| </l>
+                         ata ūrdhvameteṣāmavadīrṇānāṃ vraṇabhāvamāpannānāṃ ṣaṣṭhaḥ kriyākālaḥ,
+                        jvarātisāraprabhṛtīnāṃ ca dīrghakālānubandhaḥ | tatrāpratikriyamāṇe
+                        'sādhyatām upayānti ||35|| </l>
 
                     <l xml:id="SS.1.21.36">
                         <label>1938 ed. 1.21.36</label>
                         <caesura/>
-                         bhavanti cātra - sañcayaṃ ca prakopaṃ ca prasaraṃ sthānasaṃśrayam
-                        | vyaktiṃ bhedaṃ ca yo vetti doṣāṇāṃ sa bhavedbhiṣak ||36|| </l>
+                         bhavanti cātra - sañcayaṃ ca prakopaṃ ca prasaraṃ sthānasaṃśrayam | vyaktiṃ
+                        bhedaṃ ca yo vetti doṣāṇāṃ sa bhavedbhiṣak ||36|| </l>
 
                     <l xml:id="SS.1.21.37">
                         <label>1938 ed. 1.21.37</label>
                         <caesura/>
-                         sañcaye 'pahṛtā doṣā labhante nottarā gatīḥ | te tūttarāsu gatiṣu
-                        bhavanti balavattarāḥ ||37|| </l>
+                         sañcaye 'pahṛtā doṣā labhante nottarā gatīḥ | te tūttarāsu gatiṣu bhavanti
+                        balavattarāḥ ||37|| </l>
 
                     <l xml:id="SS.1.21.38">
                         <label>1938 ed. 1.21.38</label>
                         <caesura/>
-                         sarvairbhāvaistribhir vā'pi dvābhyāmekena vā punaḥ | saṃsarge
-                        kupitaḥ kruddhaṃ doṣaṃ doṣo 'nudhāvati ||38|| </l>
+                         sarvairbhāvaistribhir vā'pi dvābhyāmekena vā punaḥ | saṃsarge kupitaḥ
+                        kruddhaṃ doṣaṃ doṣo 'nudhāvati ||38|| </l>
 
                     <l xml:id="SS.1.21.39">
                         <label>1938 ed. 1.21.39</label>
                         <caesura/>
-                         saṃsarge yo garīyān syādupakramyaḥ sa vai bhavet |
-                        śeṣadoṣāvirodhena sannipāte tathaiva ca ||39|| </l>
+                         saṃsarge yo garīyān syādupakramyaḥ sa vai bhavet | śeṣadoṣāvirodhena
+                        sannipāte tathaiva ca ||39|| </l>
 
                     <l xml:id="SS.1.21.40">
                         <label>1938 ed. 1.21.40</label>
                         <caesura/>
-                         vṛṇoti yasmādrūḍhe 'pi vraṇavas tu na naśyati |
-                        ādehadhāraṇāttasmād vraṇa ity ucyate budhaiḥ ||40|| </l>
+                         vṛṇoti yasmādrūḍhe 'pi vraṇavas tu na naśyati | ādehadhāraṇāttasmād vraṇa
+                        ity ucyate budhaiḥ ||40|| </l>
 
                     <l xml:id="SS.1.21.trailer">
                         <label>1938 ed. 1.21.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne vraṇapraśnādhyāyo
-                        nāmaikaviṃśodhyāyaḥ ||21|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne vraṇapraśnādhyāyo nāmaikaviṃśodhyāyaḥ
+                        ||21|| </l>
                 </div>
 
                 <div n="22" type="adhyāya">
@@ -5157,8 +5216,8 @@
                     <l xml:id="SS.1.22.3">
                         <label>1938 ed. 1.22.3</label>
                         <caesura/>
-                         tvaṅmāṃsasirāsnāyvasthisandhikoṣṭhamarmāṇītyaṣṭau vraṇavastūni |
-                        atra sarvavraṇasanniveśaḥ ||3|| </l>
+                         tvaṅmāṃsasirāsnāyvasthisandhikoṣṭhamarmāṇītyaṣṭau vraṇavastūni | atra
+                        sarvavraṇasanniveśaḥ ||3|| </l>
 
                     <l xml:id="SS.1.22.4">
                         <label>1938 ed. 1.22.4</label>
@@ -5169,48 +5228,44 @@
                     <l xml:id="SS.1.22.5">
                         <label>1938 ed. 1.22.5</label>
                         <caesura/>
-                         tatrāyataścaturasro vṛttastripuṭaka iti vraṇākṛtisamāsaḥ, śeṣās
-                        tu vikṛtākṛtayo durupakramā bhavanti ||5|| </l>
+                         tatrāyataścaturasro vṛttastripuṭaka iti vraṇākṛtisamāsaḥ, śeṣās tu
+                        vikṛtākṛtayo durupakramā bhavanti ||5|| </l>
 
                     <l xml:id="SS.1.22.6">
                         <label>1938 ed. 1.22.6</label>
                         <caesura/>
-                         sarva eva vraṇāḥ kṣipraṃ saṃrohantyātmavatāṃ
-                        subhiṣagbhiścopakrāntāḥ; anātmavatāmajñaiścopakrāntāḥ praduṣyanti,
-                        pravṛddhatvād doṣāṇām ||6|| </l>
+                         sarva eva vraṇāḥ kṣipraṃ saṃrohantyātmavatāṃ subhiṣagbhiścopakrāntāḥ;
+                        anātmavatāmajñaiścopakrāntāḥ praduṣyanti, pravṛddhatvād doṣāṇām ||6|| </l>
 
                     <l xml:id="SS.1.22.7">
                         <label>1938 ed. 1.22.7</label>
                         <caesura/>
-                         tatrātisaṃvṛto 'tivivṛto 'tikaṭhino 'timṛdurutsanno 'vasanno
-                        'tiśīto 'tyuṣṇaḥ nagandhātyarthadāhapākarāgavedanāvāniti pittena,
-                        śeṣāḥ kaphena; unmārgī mukhāt mukhāntaravān, utsaṅgaḥ koṭaraḥ’ iti
-                        cakraḥ; kṛṣṇaraktapītaśuklādīnāṃ varṇānām anyatamavarṇo bhairavaḥ
+                         tatrātisaṃvṛto 'tivivṛto 'tikaṭhino 'timṛdurutsanno 'vasanno 'tiśīto
+                        'tyuṣṇaḥ nagandhātyarthadāhapākarāgavedanāvāniti pittena, śeṣāḥ kaphena;
+                        unmārgī mukhāt mukhāntaravān, utsaṅgaḥ koṭaraḥ’ iti cakraḥ;
+                        kṛṣṇaraktapītaśuklādīnāṃ varṇānām anyatamavarṇo bhairavaḥ
                         pūtipūyamāṃsasirāsnāyuprabhṛtibhiḥ pūrṇaḥ
-                        pūtipūyāsrāvyunmārgyutsaṅgyamanojñadarśanagandho 'tyarthaṃ
-                        vedanāvān dāhapākarāgakaṇḍūśophapiḍakopadruto 'tyarthaṃ
-                        duṣṭaśoṇitāsrāvī dīrghakālānubandhī ceti duṣṭavraṇaliṅgāni | tasya
-                        doṣocchrāyeṇa ṣaṭtvaṃ vibhajya yathāsvaṃ pratīkāre prayateta ||7|| </l>
+                        pūtipūyāsrāvyunmārgyutsaṅgyamanojñadarśanagandho 'tyarthaṃ vedanāvān
+                        dāhapākarāgakaṇḍūśophapiḍakopadruto 'tyarthaṃ duṣṭaśoṇitāsrāvī
+                        dīrghakālānubandhī ceti duṣṭavraṇaliṅgāni | tasya doṣocchrāyeṇa ṣaṭtvaṃ
+                        vibhajya yathāsvaṃ pratīkāre prayateta ||7|| </l>
 
                     <l xml:id="SS.1.22.8">
                         <label>1938 ed. 1.22.8</label>
                         <caesura/>
-                         ata ūrdhvaṃ sarvasrāvān vakṣyāmaḥ- tatra ghṛṣṭāsu chinnāsu vā
-                        tvakṣu sphoṭe bhinne vidārite vā salilaprakāśo bhavatyāsrāvaḥ
-                        kiñcidvisraḥ pītāvabhāsaśca; māṃsagataḥ sarpiḥprakāśaḥ sāndraḥ
-                        śvetaḥ picchilaśca; sirāgataḥ sadyaśchinnāsu sirāsu
-                        raktātipravṛttiḥ pakvāsu ca toyanāḍībhir iva toyāgamanaṃ pūyasya,
-                        āsrāvaś cātra tanurvicchinnaḥ picchilo 'valambī śyāvo
-                        'vaśyāyapratimaśca; snāyugataḥ snigdho ghanaḥ siṅghāṇakapratimaḥ
-                        saraktaśca; asthigato 'sthanyabhihate sphuṭite bhinne doṣāvadārite
-                        vā doṣabhakṣitatvād asthi niḥsāraṃ śuktidhautamivābhāti , āsrāvaś
-                        cātra majjamiśraḥ sarudhiraḥ snigdhaśca; sandhigataḥ pīḍyamāno na
-                        pravartate,
-                        ākuñcanaprasāraṇonnamanavinamanapradhāvanotkāsanapravāhaṇaiśca
-                        sravati, āsrāvaś cātra picchilo 'valambī sarudhironmathitaś ca ;
-                        koṣṭhagato 'sṛṅmūtrapurīṣapūyodakāni sravati;
-                        marmagatastvagādiṣvavaruddhatvānnocyate | tatra
-                        tvagādigatānāmāsrāvāṇāṃ yathākramaṃ
+                         ata ūrdhvaṃ sarvasrāvān vakṣyāmaḥ- tatra ghṛṣṭāsu chinnāsu vā tvakṣu sphoṭe
+                        bhinne vidārite vā salilaprakāśo bhavatyāsrāvaḥ kiñcidvisraḥ pītāvabhāsaśca;
+                        māṃsagataḥ sarpiḥprakāśaḥ sāndraḥ śvetaḥ picchilaśca; sirāgataḥ
+                        sadyaśchinnāsu sirāsu raktātipravṛttiḥ pakvāsu ca toyanāḍībhir iva
+                        toyāgamanaṃ pūyasya, āsrāvaś cātra tanurvicchinnaḥ picchilo 'valambī śyāvo
+                        'vaśyāyapratimaśca; snāyugataḥ snigdho ghanaḥ siṅghāṇakapratimaḥ saraktaśca;
+                        asthigato 'sthanyabhihate sphuṭite bhinne doṣāvadārite vā doṣabhakṣitatvād
+                        asthi niḥsāraṃ śuktidhautamivābhāti , āsrāvaś cātra majjamiśraḥ sarudhiraḥ
+                        snigdhaśca; sandhigataḥ pīḍyamāno na pravartate,
+                        ākuñcanaprasāraṇonnamanavinamanapradhāvanotkāsanapravāhaṇaiśca sravati,
+                        āsrāvaś cātra picchilo 'valambī sarudhironmathitaś ca ; koṣṭhagato
+                        'sṛṅmūtrapurīṣapūyodakāni sravati; marmagatastvagādiṣvavaruddhatvānnocyate |
+                        tatra tvagādigatānāmāsrāvāṇāṃ yathākramaṃ
                         pāruṣyaśyāvāvaśyāyadadhimastukṣārodakamāṃsadhāvanapulākodakasannibhatvāni
                         mārutādbhavanti; pittād
                         gomedakagomūtrabhasmaśaṅkhakaṣāyodakamādhvīkatailasannibhatvāni;
@@ -5229,8 +5284,8 @@
                     <l xml:id="SS.1.22.10">
                         <label>1938 ed. 1.22.10</label>
                         <caesura/>
-                         āmāśayāt kalāyāmbhonibhaś ca trikasandhijaḥ | srāvānetān
-                        parīkṣyādau tataḥ karmācaredbhiṣak ||10||</l>
+                         āmāśayāt kalāyāmbhonibhaś ca trikasandhijaḥ | srāvānetān parīkṣyādau tataḥ
+                        karmācaredbhiṣak ||10||</l>
 
                     <l xml:id="SS.1.22.11">
                         <label>1938 ed. 1.22.11</label>
@@ -5240,20 +5295,19 @@
                         vidāraṇotpāṭanakampanavividhaśūlaviśleṣaṇavikiraṇastambhanapūraṇasvapnākuñjanāṅku
                         śikāḥ sambhavanti, animittavividhavedanāprādurbhāvo vā
                         muhurmuhuryatrāgacchanti vedanāviśeṣāstaṃ vātikam iti vidyāt;
-                        oṣacoṣaparidāhadhūmāyanāni yatra gātramaṅgārāvakīrṇam iva pacyate
-                        yatra coṣmābhivṛddhiḥ kṣate kṣārāvasiktavac ca vedanāviśeṣāstaṃ
-                        paittikam iti vidyāt; pittavadraktasamutthaṃ jānīyāt;
-                        kaṇḍūrgurutvaṃ suptatvam upadeho 'lpavedanatvaṃ stambhaḥ śaity aṃ
-                        ca yatra taṃ ślaiṣmikam iti vidyāt; yatra sarvāsāṃ
-                        vedanānāmutpattistaṃ sānnipātikam iti vidyāt ||11|| </l>
+                        oṣacoṣaparidāhadhūmāyanāni yatra gātramaṅgārāvakīrṇam iva pacyate yatra
+                        coṣmābhivṛddhiḥ kṣate kṣārāvasiktavac ca vedanāviśeṣāstaṃ paittikam iti
+                        vidyāt; pittavadraktasamutthaṃ jānīyāt; kaṇḍūrgurutvaṃ suptatvam upadeho
+                        'lpavedanatvaṃ stambhaḥ śaity aṃ ca yatra taṃ ślaiṣmikam iti vidyāt; yatra
+                        sarvāsāṃ vedanānāmutpattistaṃ sānnipātikam iti vidyāt ||11|| </l>
 
                     <l xml:id="SS.1.22.12">
                         <label>1938 ed. 1.22.12</label>
                         <caesura/>
-                         ata ūrdhvaṃ vraṇavarṇān vakṣyāmaḥ- bhasmakapotāsthivarṇaḥ paruṣo
-                        'ruṇaḥ kṛṣṇa iti mārutajasyaḥ nīlaḥ pīto haritaḥ śyāvaḥ kṛṣṇo
-                        raktaḥ piṅgalaḥ kapila iti raktapittasamutthayoḥ; śvetaḥ snigdhaḥ
-                        pāṇḍuriti śleṣmajasya; sarvavarṇopetaḥ sānnipātika iti ||12|| </l>
+                         ata ūrdhvaṃ vraṇavarṇān vakṣyāmaḥ- bhasmakapotāsthivarṇaḥ paruṣo 'ruṇaḥ
+                        kṛṣṇa iti mārutajasyaḥ nīlaḥ pīto haritaḥ śyāvaḥ kṛṣṇo raktaḥ piṅgalaḥ
+                        kapila iti raktapittasamutthayoḥ; śvetaḥ snigdhaḥ pāṇḍuriti śleṣmajasya;
+                        sarvavarṇopetaḥ sānnipātika iti ||12|| </l>
 
                     <l xml:id="SS.1.22.13">
                         <label>1938 ed. 1.22.13</label>
@@ -5264,8 +5318,8 @@
                     <l xml:id="SS.1.22.trailer">
                         <label>1938 ed. 1.22.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne vraṇāsrāvavijñānīyo nāma
-                        dvāviṃśatitamo 'dhyāyaḥ ||22|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne vraṇāsrāvavijñānīyo nāma dvāviṃśatitamo
+                        'dhyāyaḥ ||22|| </l>
                 </div>
 
                 <div n="23" type="adhyāya">
@@ -5288,43 +5342,41 @@
                         <caesura/>
                          akṣidantanāsāpāṅgaśrotranābhijaṭharasevanīnitambapārśvakukṣivakṣaḥkakṣāstanasandhibhāgagatāḥ
                         saphenapūyaraktānilavāhino 'ntaḥśalyāś ca duścikitsyāḥ;
-                        adhobhāgāścordhvabhāganirvāhiṇo ,
-                        romāntopanakhamarmajaṅghāsthisaṃśritāśca, bhagandaramapi
-                        cāntarmukhaṃ sevanīkuṭakāsthisaṃśritam ||6|| </l>
+                        adhobhāgāścordhvabhāganirvāhiṇo , romāntopanakhamarmajaṅghāsthisaṃśritāśca,
+                        bhagandaramapi cāntarmukhaṃ sevanīkuṭakāsthisaṃśritam ||6|| </l>
 
                     <l xml:id="SS.1.23.7">
                         <label>1938 ed. 1.23.7</label>
                         <caesura/>
-                         kuṣṭhināṃ viṣajuṣṭānāṃ śoṣiṇāṃ madhumehinām | vraṇāḥ kṛcchreṇa
-                        sidhyanti yeṣāṃ cāpi vraṇe vraṇāḥ ||7|| </l>
+                         kuṣṭhināṃ viṣajuṣṭānāṃ śoṣiṇāṃ madhumehinām | vraṇāḥ kṛcchreṇa sidhyanti
+                        yeṣāṃ cāpi vraṇe vraṇāḥ ||7|| </l>
 
                     <l xml:id="SS.1.23.8">
                         <label>1938 ed. 1.23.8</label>
                         <caesura/>
-                         avapāṭikāniruddhaprakaśasanniruddhagudajaṭharāṇi,
-                        granthikṣatakrimayaḥ pratiśyāyajāḥ koṣṭhajāś ca tvagdoṣiṇāṃ
-                        pramehiṇāṃ vā ye parikṣateṣu dṛśyante, śarkarā sikatāmeho
-                        vātakuṇḍalikā'ṣṭhīlā dantaśarkaropakuśaḥ kaṇṭhaśālūkaṃ
-                        niṣkoṣaṇadūṣitāś ca dantaveṣṭā
+                         avapāṭikāniruddhaprakaśasanniruddhagudajaṭharāṇi, granthikṣatakrimayaḥ
+                        pratiśyāyajāḥ koṣṭhajāś ca tvagdoṣiṇāṃ pramehiṇāṃ vā ye parikṣateṣu
+                        dṛśyante, śarkarā sikatāmeho vātakuṇḍalikā'ṣṭhīlā dantaśarkaropakuśaḥ
+                        kaṇṭhaśālūkaṃ niṣkoṣaṇadūṣitāś ca dantaveṣṭā
                         visarpāsthikṣatoraḥkṣatavraṇagranthiprabhṛtayaś ca yāpyāḥ ||8|| </l>
 
                     <l xml:id="SS.1.23.9">
                         <label>1938 ed. 1.23.9</label>
                         <caesura/>
-                         sādhyā yāpyatvamāyānti yāpyāś cāsādhyatāṃ tathā | ghnanti
-                        prāṇānasādhyās tu narāṇāmakriyāvatām ||9|| </l>
+                         sādhyā yāpyatvamāyānti yāpyāś cāsādhyatāṃ tathā | ghnanti prāṇānasādhyās tu
+                        narāṇāmakriyāvatām ||9|| </l>
 
                     <l xml:id="SS.1.23.10">
                         <label>1938 ed. 1.23.10</label>
                         <caesura/>
-                         yāpanīyaṃ vijānīyāt kriyā dhārayate tu yam | kriyāyāṃ tu
-                        nivṛttāyāṃ sadya eva vinaśyati ||10|| </l>
+                         yāpanīyaṃ vijānīyāt kriyā dhārayate tu yam | kriyāyāṃ tu nivṛttāyāṃ sadya
+                        eva vinaśyati ||10|| </l>
 
                     <l xml:id="SS.1.23.11">
                         <label>1938 ed. 1.23.11</label>
                         <caesura/>
-                         prāptā kriyāṃ dhārayati yāpyavyādhitamāturam |
-                        prapatiṣyadivāgāraṃ viṣkambhaḥ sādhuyojitaḥ ||11|| </l>
+                         prāptā kriyāṃ dhārayati yāpyavyādhitamāturam | prapatiṣyadivāgāraṃ
+                        viṣkambhaḥ sādhuyojitaḥ ||11|| </l>
 
                     <l xml:id="SS.1.23.12">
                         <label>1938 ed. 1.23.12</label>
@@ -5333,75 +5385,74 @@
                         'ntaḥpūyavedanāvanto 'śvāpānavadudvṛttauṣṭhāḥ , kecit kaṭhinā
                         gośṛṅgavadudgatamṛdumāṃsaprarohāḥ, apare
                         duṣṭarudhirāsrāviṇastanuśītapicchilāsrāviṇo vā madhyonnatāḥ,
-                        kecidavasannaśuṣiraparyantāḥ śaṇatūlavat snāyujālavanto
-                        durdarśanāḥ, vasāmedomajjamastuluṅgasrāviṇaś ca doṣasamutthāḥ,
+                        kecidavasannaśuṣiraparyantāḥ śaṇatūlavat snāyujālavanto durdarśanāḥ,
+                        vasāmedomajjamastuluṅgasrāviṇaś ca doṣasamutthāḥ,
                         pītāsitamūtrapurīṣavātavāhinaś ca koṣṭhasthāḥ, ta
-                        evobhayatobhāgavraṇamukheṣu pūyaraktanirvāhiṇaḥ, (kṣīṇamāṃsānāṃ ca
-                        ) sarvatogatayaś cāṇumukhā māṃsabudbudavantaḥ,
-                        saśabdavātavāhinaśca śiraḥkaṇṭhasthāḥ, kṣīṇamāṃsānāṃ ca
-                        pūyaraktanirvāhiṇo 'rocakāvipākakāsaśvāsopadravayuktāḥ, bhinne vā
-                        śiraḥkapāle yatra mastuluṅgadarśanaṃ tridoṣaliṅgaprādurbhāvaḥ
-                        kāsaśvāsau vā yasyeti ||12|| </l>
+                        evobhayatobhāgavraṇamukheṣu pūyaraktanirvāhiṇaḥ, (kṣīṇamāṃsānāṃ ca )
+                        sarvatogatayaś cāṇumukhā māṃsabudbudavantaḥ, saśabdavātavāhinaśca
+                        śiraḥkaṇṭhasthāḥ, kṣīṇamāṃsānāṃ ca pūyaraktanirvāhiṇo
+                        'rocakāvipākakāsaśvāsopadravayuktāḥ, bhinne vā śiraḥkapāle yatra
+                        mastuluṅgadarśanaṃ tridoṣaliṅgaprādurbhāvaḥ kāsaśvāsau vā yasyeti ||12|| </l>
 
                     <l xml:id="SS.1.23.13">
                         <label>1938 ed. 1.23.13</label>
                         <caesura/>
-                         bhavati cātra - vasāṃ medo 'tha majjānaṃ mastuluṅgaṃ ca yaḥ
-                        sravet | āgantus tu vraṇaḥ sidhyenna sidhyeddoṣasambhavaḥ ||13|| </l>
+                         bhavati cātra - vasāṃ medo 'tha majjānaṃ mastuluṅgaṃ ca yaḥ sravet |
+                        āgantus tu vraṇaḥ sidhyenna sidhyeddoṣasambhavaḥ ||13|| </l>
 
                     <l xml:id="SS.1.23.14">
                         <label>1938 ed. 1.23.14</label>
                         <caesura/>
-                         amarmopahite deśe sirāsandhyasthivarjite | vikāroyo 'nuparyeti
-                        tad asādhyasya lakṣaṇam ||14|| </l>
+                         amarmopahite deśe sirāsandhyasthivarjite | vikāroyo 'nuparyeti tad
+                        asādhyasya lakṣaṇam ||14|| </l>
 
                     <l xml:id="SS.1.23.15">
                         <label>1938 ed. 1.23.15</label>
                         <caesura/>
-                         krameṇopacayaṃ prāpya ; dhātūnanugataḥ śanaiḥ | na śakya
-                        unmūlayituṃ vṛddho vṛkṣa ivāmayaḥ ||15||</l>
+                         krameṇopacayaṃ prāpya ; dhātūnanugataḥ śanaiḥ | na śakya unmūlayituṃ vṛddho
+                        vṛkṣa ivāmayaḥ ||15||</l>
 
                     <l xml:id="SS.1.23.16">
                         <label>1938 ed. 1.23.16</label>
                         <caesura/>
-                         sa sthiratvānmahattvāc ca dhātvanukramaṇena ca |
-                        nihantyauṣadhavīryāṇi mantrān duṣṭagraho yathā ||16||</l>
+                         sa sthiratvānmahattvāc ca dhātvanukramaṇena ca | nihantyauṣadhavīryāṇi
+                        mantrān duṣṭagraho yathā ||16||</l>
 
                     <l xml:id="SS.1.23.17">
                         <label>1938 ed. 1.23.17</label>
                         <caesura/>
-                         ato yo viparītaḥ syāt sukhasādhyaḥ sa ucyate | abaddhamūlaḥ
-                        kṣupako yadvadutpāṭane sukhaḥ ||17|| </l>
+                         ato yo viparītaḥ syāt sukhasādhyaḥ sa ucyate | abaddhamūlaḥ kṣupako
+                        yadvadutpāṭane sukhaḥ ||17|| </l>
 
                     <l xml:id="SS.1.23.18">
                         <label>1938 ed. 1.23.18</label>
                         <caesura/>
-                         tribhir doṣairanākrāntaḥ śyāvauṣṭhaḥ piḍakī samaḥ | avedano
-                        nirāsrāvo vraṇaḥ śuddha ihocyate ||18|| </l>
+                         tribhir doṣairanākrāntaḥ śyāvauṣṭhaḥ piḍakī samaḥ | avedano nirāsrāvo
+                        vraṇaḥ śuddha ihocyate ||18|| </l>
 
                     <l xml:id="SS.1.23.19">
                         <label>1938 ed. 1.23.19</label>
                         <caesura/>
-                         kapotavarṇapratimā yasyāntāḥ kledavarjitāḥ | sthirāścipiṭikāvanto
-                        rohatīti tam ādiśet ||19|| </l>
+                         kapotavarṇapratimā yasyāntāḥ kledavarjitāḥ | sthirāścipiṭikāvanto rohatīti
+                        tam ādiśet ||19|| </l>
 
                     <l xml:id="SS.1.23.20">
                         <label>1938 ed. 1.23.20</label>
                         <caesura/>
-                         rūḍhavartmānamagranthimaśūnamarujaṃ vraṇam | tvaksavarṇaṃ
-                        samatalaṃ samyagrūḍhaṃ vinirdiśet ||20|| </l>
+                         rūḍhavartmānamagranthimaśūnamarujaṃ vraṇam | tvaksavarṇaṃ samatalaṃ
+                        samyagrūḍhaṃ vinirdiśet ||20|| </l>
 
                     <l xml:id="SS.1.23.21">
                         <label>1938 ed. 1.23.21</label>
                         <caesura/>
-                         doṣaprakopādvyāyāmādabhighātādajīrṇataḥ | harṣāt
-                        krodhādbhayādvā'pi vraṇo rūḍho 'pi dīryate ||21|| </l>
+                         doṣaprakopādvyāyāmādabhighātādajīrṇataḥ | harṣāt krodhādbhayādvā'pi vraṇo
+                        rūḍho 'pi dīryate ||21|| </l>
 
                     <l xml:id="SS.1.23.trailer">
                         <label>1938 ed. 1.23.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne kṛtyākṛtyavidhirnāma trayoviṃśo
-                        'dhyāyaḥ ||23|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne kṛtyākṛtyavidhirnāma trayoviṃśo 'dhyāyaḥ
+                        ||23|| </l>
                 </div>
 
 
@@ -5411,65 +5462,60 @@
                     <l xml:id="SS.1.24.3">
                         <label>1938 ed. 1.24.3</label>
                         <caesura/>
-                         dvividhās tu vyādhayaḥ- śastrasādhyāḥ, snehādikriyāsādhyāś ca |
-                        tatra śastrasādhyeṣu snehādikriyā na pratiṣidhyate,
-                        snehādikriyāsādhyeṣu śastrakarma na kriyate ||3|| </l>
+                         dvividhās tu vyādhayaḥ- śastrasādhyāḥ, snehādikriyāsādhyāś ca | tatra
+                        śastrasādhyeṣu snehādikriyā na pratiṣidhyate, snehādikriyāsādhyeṣu
+                        śastrakarma na kriyate ||3|| </l>
 
                     <l xml:id="SS.1.24.4">
                         <label>1938 ed. 1.24.4</label>
                         <caesura/>
                          asmin punaḥ śāstre sarvatantrasāmānyāt sarveṣāṃ vyādhīnāṃ
-                        yathāsthūlamavarodhaḥ kriyate | prāgabhihitaṃ ‘tadduḥkhasaṃyogā
-                        vyādhaya’ (sū. a. 1) iti | tac ca duḥkhaṃ trividham- ādhyātmikam,
-                        ādhibhautikam, ādhidaivikam iti | tattu saptavidhe
-                        vyādhāvupanipatati | te punaḥ saptavidhā vyādhayaḥ; tad yathā-
-                        ādibalapravṛttāḥ, janmabalapravṛttāḥ, doṣabalapravṛttāḥ,
-                        saṅghātabalapravṛttāḥ, kālabalapravṛttāḥ, daivabalapravṛttāḥ,
-                        svabhāvabalapravṛttā iti ||4|| </l>
+                        yathāsthūlamavarodhaḥ kriyate | prāgabhihitaṃ ‘tadduḥkhasaṃyogā vyādhaya’
+                        (sū. a. 1) iti | tac ca duḥkhaṃ trividham- ādhyātmikam, ādhibhautikam,
+                        ādhidaivikam iti | tattu saptavidhe vyādhāvupanipatati | te punaḥ saptavidhā
+                        vyādhayaḥ; tad yathā- ādibalapravṛttāḥ, janmabalapravṛttāḥ,
+                        doṣabalapravṛttāḥ, saṅghātabalapravṛttāḥ, kālabalapravṛttāḥ,
+                        daivabalapravṛttāḥ, svabhāvabalapravṛttā iti ||4|| </l>
 
                     <l xml:id="SS.1.24.5">
                         <label>1938 ed. 1.24.5</label>
                         <caesura/>
-                         tatra, ādibalapravṛttā ye śukraśoṇitadoṣānvayāḥ
-                        kuṣṭhārśaḥprabhṛtayaḥ; te 'pi dvividhāḥ- mātṛjāḥ, pitṛjāś ca |
-                        janmabalapravṛttā ye māturapacārāt
-                        paṅgujātyandhabadhiramūkaminminavāmanaprabhṛtayo jāyante; te 'pi
-                        dvividhāḥ rasakṛtāḥ, dauhṛdāpacārakṛtāś ca | doṣabalapravṛttā ye
-                        ātaṅkasamutpannā mithyāhārācārakṛtāśca; te 'pi dvividhāḥ
-                        āmāśayasamutthāḥ , pakvāśayasamutthāśca; punaś ca dvividhāḥ-
-                        śārīrā, mānasāś ca | ta ete ādhyātmikāḥ ||5|| </l>
+                         tatra, ādibalapravṛttā ye śukraśoṇitadoṣānvayāḥ kuṣṭhārśaḥprabhṛtayaḥ; te
+                        'pi dvividhāḥ- mātṛjāḥ, pitṛjāś ca | janmabalapravṛttā ye māturapacārāt
+                        paṅgujātyandhabadhiramūkaminminavāmanaprabhṛtayo jāyante; te 'pi dvividhāḥ
+                        rasakṛtāḥ, dauhṛdāpacārakṛtāś ca | doṣabalapravṛttā ye ātaṅkasamutpannā
+                        mithyāhārācārakṛtāśca; te 'pi dvividhāḥ āmāśayasamutthāḥ ,
+                        pakvāśayasamutthāśca; punaś ca dvividhāḥ- śārīrā, mānasāś ca | ta ete
+                        ādhyātmikāḥ ||5|| </l>
 
                     <l xml:id="SS.1.24.6">
                         <label>1938 ed. 1.24.6</label>
                         <caesura/>
-                         saṅghātabalapravṛttā ya āgantavo durbalasya balavadvigrahāt; te
-                        'pi dvividhāḥ- śastrakṛtā, vyālakṛtāś ca | ete ādhibhautikāḥ ||6|| </l>
+                         saṅghātabalapravṛttā ya āgantavo durbalasya balavadvigrahāt; te 'pi
+                        dvividhāḥ- śastrakṛtā, vyālakṛtāś ca | ete ādhibhautikāḥ ||6|| </l>
 
                     <l xml:id="SS.1.24.7">
                         <label>1938 ed. 1.24.7</label>
                         <caesura/>
-                         kālabalapravṛttā ye śītoṣṇavātavarṣātapaprabhṛtinimittāḥ; te 'pi
-                        dvividhāḥ- vyāpannartukṛtāḥ, avyāpannartukṛtāś ca |
-                        daivabalapravṛtā ye devadrohādabhiśaptakā atharvaṇakṛtā
-                        upasargajāśca; te 'pi dvividhāḥ- vidyudaśanikṛtāḥ,
-                        piśācādikṛtāśca; punaś ca dvividhāḥ- saṃsargajā , ākasmikāś ca |
-                        svabhāvabalapravṛttā ye kṣutpipāsājarāmṛtyunidrāprabhṛtayaḥ; te
-                        'pi dvividhāḥ- kālajā, akālajāśca; tatra parirakṣaṇakṛtāḥ kālajāḥ,
-                        aparirakṣaṇakṛtā akālajāḥ | ete ādhidaivikāḥ | atra
-                        sarvavyādhyavarodhaḥ ||7|| </l>
+                         kālabalapravṛttā ye śītoṣṇavātavarṣātapaprabhṛtinimittāḥ; te 'pi dvividhāḥ-
+                        vyāpannartukṛtāḥ, avyāpannartukṛtāś ca | daivabalapravṛtā ye
+                        devadrohādabhiśaptakā atharvaṇakṛtā upasargajāśca; te 'pi dvividhāḥ-
+                        vidyudaśanikṛtāḥ, piśācādikṛtāśca; punaś ca dvividhāḥ- saṃsargajā ,
+                        ākasmikāś ca | svabhāvabalapravṛttā ye kṣutpipāsājarāmṛtyunidrāprabhṛtayaḥ;
+                        te 'pi dvividhāḥ- kālajā, akālajāśca; tatra parirakṣaṇakṛtāḥ kālajāḥ,
+                        aparirakṣaṇakṛtā akālajāḥ | ete ādhidaivikāḥ | atra sarvavyādhyavarodhaḥ
+                        ||7|| </l>
 
                     <l xml:id="SS.1.24.8">
                         <label>1938 ed. 1.24.8</label>
                         <caesura/>
                          sarveṣāṃ ca vyādhīnāṃ vātapittaśleṣmāṇa eva mūlaṃ; talliṅgatvād
-                        dṛṣṭaphalatvād āgamāc ca | yathā hi kṛtsnaṃ vikārajātaṃ
-                        viśvarūpeṇāvasthitaṃ sattvarajastamāṃsi na vyatiricyante, evam eva
-                        kṛtsnaṃ vikārajātaṃ viśvarūpeṇāvasthitamavyatiricya
-                        vātapittaśleṣmāṇo vartante |
-                        doṣadhātumalasaṃsargādāyatanaviśeṣānnimittataścaiṣāṃ vikalpaḥ |
-                        doṣadūṣiteṣv atyarthaṃ dhātuṣu sañjñā- rasajo 'yaṃ, śoṇitajo 'yaṃ,
-                        māṃsajo 'yaṃ, medojo 'yaṃ, asthijo 'yaṃ majjajo 'yaṃ, śukrajo 'yaṃ
-                        vyādhiriti ||8|| </l>
+                        dṛṣṭaphalatvād āgamāc ca | yathā hi kṛtsnaṃ vikārajātaṃ viśvarūpeṇāvasthitaṃ
+                        sattvarajastamāṃsi na vyatiricyante, evam eva kṛtsnaṃ vikārajātaṃ
+                        viśvarūpeṇāvasthitamavyatiricya vātapittaśleṣmāṇo vartante |
+                        doṣadhātumalasaṃsargādāyatanaviśeṣānnimittataścaiṣāṃ vikalpaḥ | doṣadūṣiteṣv
+                        atyarthaṃ dhātuṣu sañjñā- rasajo 'yaṃ, śoṇitajo 'yaṃ, māṃsajo 'yaṃ, medojo
+                        'yaṃ, asthijo 'yaṃ majjajo 'yaṃ, śukrajo 'yaṃ vyādhiriti ||8|| </l>
 
                     <l xml:id="SS.1.24.9">
                         <label>1938 ed. 1.24.9</label>
@@ -5483,35 +5529,32 @@
                         'dhijihvopajihvopakuśagalaśuṇḍikālajīmāṃsasaṅghātauṣṭhaprakopagalagaṇḍagaṇḍamālāprabhṛtayo
                         māṃsadoṣajāḥ;
                         granthivṛddhigalagaṇḍārbudamedojauṣṭhaprakopamadhumehātisthaulyātisvedaprabhṛtayo
-                        medodoṣajāḥ; adhyasthyadhidantāsthitodaśūlakunakhaprabhṛtayo
-                        'sthidoṣajāḥ;
+                        medodoṣajāḥ; adhyasthyadhidantāsthitodaśūlakunakhaprabhṛtayo 'sthidoṣajāḥ;
                         tamodarśanamūrcchābhramaparvasthūlamūlārurjanmanetrābhiṣyandaprabhṛtayo
-                        majjadoṣajāḥ; klaibyāpraharṣaśukrāśmarīśukramehaśukradoṣādayaśca
-                        taddoṣāḥ; tvagdoṣāḥ saṅgo 'tipravṛttirayathāpravṛttirvā
-                        malāyatanadoṣāḥ;
-                        indriyāṇāmapravṛttirayathāpravṛttirvendriyāyatanadoṣāḥ; ity eṣa
-                        samāsa uktaḥ; vistaraṃ nimittāni caiṣāṃ pratirogaṃ vakṣyāmaḥ ||9|| </l>
+                        majjadoṣajāḥ; klaibyāpraharṣaśukrāśmarīśukramehaśukradoṣādayaśca taddoṣāḥ;
+                        tvagdoṣāḥ saṅgo 'tipravṛttirayathāpravṛttirvā malāyatanadoṣāḥ;
+                        indriyāṇāmapravṛttirayathāpravṛttirvendriyāyatanadoṣāḥ; ity eṣa samāsa
+                        uktaḥ; vistaraṃ nimittāni caiṣāṃ pratirogaṃ vakṣyāmaḥ ||9|| </l>
 
                     <l xml:id="SS.1.24.10">
                         <label>1938 ed. 1.24.10</label>
                         <caesura/>
-                         bhavati cātra - kupitānāṃ hi doṣāṇāṃ śarīre paridhāvatām | yatra
-                        saṅgaḥ khavaiguṇyādvyādhistatropajāyate ||10|| </l>
+                         bhavati cātra - kupitānāṃ hi doṣāṇāṃ śarīre paridhāvatām | yatra saṅgaḥ
+                        khavaiguṇyādvyādhistatropajāyate ||10|| </l>
 
                     <l xml:id="SS.1.24.11">
                         <label>1938 ed. 1.24.11</label>
                         <caesura/>
-                         bhūyo 'tra jijñāsyaṃ, kiṃ vātādīnāṃ jvarādīnāṃ ca nity aḥ
-                        saṃśleṣaḥ paricchedo vā? iti; yadi nity aḥ saṃśleṣaḥ syāttarhi
-                        nity āturāḥ sarva eva prāṇinaḥ syuḥ; athāpyanyathā vātādīnāṃ
-                        jvarādīnāṃ ca, ‘anyatra vartamānānām anyatra liṅgaṃ na bhavati’
-                        iti kṛtvā yaducyate vātādayo jvarādīnāṃ mūlānīti tanna |
-                        atrocyate- doṣān pratyākhyāya jvarādayo na bhavanti; atha ca na
-                        (nity aḥ) sambandhaḥ; yathā hi vidyudvātāśanivarṣāṇyākāśaṃ
-                        pratyākhyāya na bhavanti, satyapyākāśe kadācinna bhavanti, atha ca
-                        nimittatastata evotpattiriti; taraṅgabudbudādayaścodakaviśeṣāḥ
-                        eva; vātādīnāṃ jvarādīnāṃ ca nāpyevaṃ saṃśleṣo na paricchedaḥ
-                        śāśvatikaḥ, atha ca nimittata evotpattiriti ||11|| </l>
+                         bhūyo 'tra jijñāsyaṃ, kiṃ vātādīnāṃ jvarādīnāṃ ca nity aḥ saṃśleṣaḥ
+                        paricchedo vā? iti; yadi nity aḥ saṃśleṣaḥ syāttarhi nity āturāḥ sarva eva
+                        prāṇinaḥ syuḥ; athāpyanyathā vātādīnāṃ jvarādīnāṃ ca, ‘anyatra vartamānānām
+                        anyatra liṅgaṃ na bhavati’ iti kṛtvā yaducyate vātādayo jvarādīnāṃ mūlānīti
+                        tanna | atrocyate- doṣān pratyākhyāya jvarādayo na bhavanti; atha ca na
+                        (nity aḥ) sambandhaḥ; yathā hi vidyudvātāśanivarṣāṇyākāśaṃ pratyākhyāya na
+                        bhavanti, satyapyākāśe kadācinna bhavanti, atha ca nimittatastata
+                        evotpattiriti; taraṅgabudbudādayaścodakaviśeṣāḥ eva; vātādīnāṃ jvarādīnāṃ ca
+                        nāpyevaṃ saṃśleṣo na paricchedaḥ śāśvatikaḥ, atha ca nimittata evotpattiriti
+                        ||11|| </l>
 
                     <l xml:id="SS.1.24.12">
                         <label>1938 ed. 1.24.12</label>
@@ -5522,8 +5565,8 @@
                     <l xml:id="SS.1.24.trailer">
                         <label>1938 ed. 1.24.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne vyādhisamuddeśīyo nāma
-                        caturviṃśo 'dhyāyaḥ ||24|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne vyādhisamuddeśīyo nāma caturviṃśo
+                        'dhyāyaḥ ||24|| </l>
                 </div>
 
 
@@ -5538,14 +5581,14 @@
                     <l xml:id="SS.1.25.6">
                         <label>1938 ed. 1.25.6</label>
                         <caesura/>
-                         ādito ye visarpāś ca vṛddhayaḥ savidārikāḥ | pramehapiḍakāḥ
-                        śophaḥ stanarogo 'vamanthakāḥ ||6|| </l>
+                         ādito ye visarpāś ca vṛddhayaḥ savidārikāḥ | pramehapiḍakāḥ śophaḥ
+                        stanarogo 'vamanthakāḥ ||6|| </l>
 
                     <l xml:id="SS.1.25.7">
                         <label>1938 ed. 1.25.7</label>
                         <caesura/>
-                         kumbhīkānuśayī nāḍyo vṛndau puṣkarikā'lajī | prāyaśaḥ kṣudrarogāś
-                        ca puppuṭau tāludantajau ||7||</l>
+                         kumbhīkānuśayī nāḍyo vṛndau puṣkarikā'lajī | prāyaśaḥ kṣudrarogāś ca
+                        puppuṭau tāludantajau ||7||</l>
 
                     <l xml:id="SS.1.25.8">
                         <label>1938 ed. 1.25.8</label>
@@ -5556,14 +5599,14 @@
                     <l xml:id="SS.1.25.9">
                         <label>1938 ed. 1.25.9</label>
                         <caesura/>
-                         lekhyāś catasro rohiṇyaḥ kilāsamupajihvikā | medojo
-                        dantavaidarbho granthirvartmādhijihvikā ||9|| </l>
+                         lekhyāś catasro rohiṇyaḥ kilāsamupajihvikā | medojo dantavaidarbho
+                        granthirvartmādhijihvikā ||9|| </l>
 
                     <l xml:id="SS.1.25.10">
                         <label>1938 ed. 1.25.10</label>
                         <caesura/>
-                         arśāṃsi maṇḍalaṃ māṃsakandī māṃsonnatistathā vedhyāḥ sirā
-                        bahuvidhā mūtravṛddhirdakodaram ||10|| </l>
+                         arśāṃsi maṇḍalaṃ māṃsakandī māṃsonnatistathā vedhyāḥ sirā bahuvidhā
+                        mūtravṛddhirdakodaram ||10|| </l>
 
                     <l xml:id="SS.1.25.11">
                         <label>1938 ed. 1.25.11</label>
@@ -5575,38 +5618,38 @@
                     <l xml:id="SS.1.25.12">
                         <label>1938 ed. 1.25.12</label>
                         <caesura/>
-                         śalyāni mūḍhagarbhāś ca varcaś ca nicitaṃ gude | srāvyā
-                        vidradhayaḥ pañca bhaveyuḥ sarvajādṛte ||12|| </l>
+                         śalyāni mūḍhagarbhāś ca varcaś ca nicitaṃ gude | srāvyā vidradhayaḥ pañca
+                        bhaveyuḥ sarvajādṛte ||12|| </l>
 
                     <l xml:id="SS.1.25.13">
                         <label>1938 ed. 1.25.13</label>
                         <caesura/>
-                         kuṣṭhāni vāyuḥ sarujaḥ śopho yaś caikadeśajaḥ | pālyāmayāḥ
-                        ślīpadāni viṣajuṣṭaṃ ca śoṇitam ||13||</l>
+                         kuṣṭhāni vāyuḥ sarujaḥ śopho yaś caikadeśajaḥ | pālyāmayāḥ ślīpadāni
+                        viṣajuṣṭaṃ ca śoṇitam ||13||</l>
 
                     <l xml:id="SS.1.25.14">
                         <label>1938 ed. 1.25.14</label>
                         <caesura/>
-                         arbudāni visarpāś ca granthayaś cāditaś ca te |
-                        trayastrayaścopadaṃśāḥ stanarogā vidārikā ||14||</l>
+                         arbudāni visarpāś ca granthayaś cāditaś ca te | trayastrayaścopadaṃśāḥ
+                        stanarogā vidārikā ||14||</l>
 
                     <l xml:id="SS.1.25.15">
                         <label>1938 ed. 1.25.15</label>
                         <caesura/>
-                         su(śu)ṣiro galaśālūkaṃ kaṇṭakāḥ kṛmidantakaḥ | dantaveṣṭaḥ
-                        sopakuśaḥ śītādo dantapuppuṭaḥ ||15|| </l>
+                         su(śu)ṣiro galaśālūkaṃ kaṇṭakāḥ kṛmidantakaḥ | dantaveṣṭaḥ sopakuśaḥ śītādo
+                        dantapuppuṭaḥ ||15|| </l>
 
                     <l xml:id="SS.1.25.16">
                         <label>1938 ed. 1.25.16</label>
                         <caesura/>
-                         pittāsṛkkaphajāścauṣṭhyāḥ kṣudrarogāśca bhūyaśaḥ sīvyā
-                        medaḥsamutthāś ca bhinnāḥ sulikhitā gadāḥ ||16|| </l>
+                         pittāsṛkkaphajāścauṣṭhyāḥ kṣudrarogāśca bhūyaśaḥ sīvyā medaḥsamutthāś ca
+                        bhinnāḥ sulikhitā gadāḥ ||16|| </l>
 
                     <l xml:id="SS.1.25.17">
                         <label>1938 ed. 1.25.17</label>
                         <caesura/>
-                         sadyovraṇāś ca ye caiva calasandhivyapāśritāḥ | na
-                        kṣārāgniviṣairjuṣṭā na ca mārutavāhinaḥ ||17|| </l>
+                         sadyovraṇāś ca ye caiva calasandhivyapāśritāḥ | na kṣārāgniviṣairjuṣṭā na
+                        ca mārutavāhinaḥ ||17|| </l>
 
                     <l xml:id="SS.1.25.18">
                         <label>1938 ed. 1.25.18</label>
@@ -5620,44 +5663,44 @@
                     <l xml:id="SS.1.25.19">
                         <label>1938 ed. 1.25.19</label>
                         <caesura/>
-                         ahṛtāni yato 'mūni pācayeyurbhṛśaṃ vraṇam | rujaś ca vividhāḥ
-                        kuryustasmād etān viśodhayet ||19||</l>
+                         ahṛtāni yato 'mūni pācayeyurbhṛśaṃ vraṇam | rujaś ca vividhāḥ kuryustasmād
+                        etān viśodhayet ||19||</l>
 
                     <l xml:id="SS.1.25.20">
                         <label>1938 ed. 1.25.20</label>
                         <caesura/>
-                         tato vraṇaṃ samunnamya sthāpayitvā yathāsthitam | sīvyet sūkṣmeṇa
-                        sūtreṇa valkenāśmantakasya vā ||20||</l>
+                         tato vraṇaṃ samunnamya sthāpayitvā yathāsthitam | sīvyet sūkṣmeṇa sūtreṇa
+                        valkenāśmantakasya vā ||20||</l>
 
                     <l xml:id="SS.1.25.21">
                         <label>1938 ed. 1.25.21</label>
                         <caesura/>
-                         śaṇajakṣaumasūtrābhyāṃ snāyvā bālena vā punaḥ | mūrvāguḍūcītānair
-                        vā sīvyedvellitakaṃ śanaiḥ ||21|| </l>
+                         śaṇajakṣaumasūtrābhyāṃ snāyvā bālena vā punaḥ | mūrvāguḍūcītānair vā
+                        sīvyedvellitakaṃ śanaiḥ ||21|| </l>
 
                     <l xml:id="SS.1.25.22">
                         <label>1938 ed. 1.25.22</label>
                         <caesura/>
-                         sīvyedgophaṇikāṃ vā'pi sīvyedvā tunnasevanīm | ṛjugranthimatho
-                        vā'pi yathāyogamathāpi vā ||22||</l>
+                         sīvyedgophaṇikāṃ vā'pi sīvyedvā tunnasevanīm | ṛjugranthimatho vā'pi
+                        yathāyogamathāpi vā ||22||</l>
 
                     <l xml:id="SS.1.25.23">
                         <label>1938 ed. 1.25.23</label>
                         <caesura/>
-                         deśe 'lpamāṃse sandhau ca sūcī vṛttā'ṅguladvayam | āyatā
-                        tryaṅgulā tryasrā māṃsale cā'pi pūjitā ||23||</l>
+                         deśe 'lpamāṃse sandhau ca sūcī vṛttā'ṅguladvayam | āyatā tryaṅgulā tryasrā
+                        māṃsale cā'pi pūjitā ||23||</l>
 
                     <l xml:id="SS.1.25.24">
                         <label>1938 ed. 1.25.24</label>
                         <caesura/>
-                         dhanurvakrā hitā marmaphalakośodaropari | ity etāstrividhāḥ
-                        sūcīstīkṣṇāgrāḥ susamāhitāḥ ||24||</l>
+                         dhanurvakrā hitā marmaphalakośodaropari | ity etāstrividhāḥ sūcīstīkṣṇāgrāḥ
+                        susamāhitāḥ ||24||</l>
 
                     <l xml:id="SS.1.25.25">
                         <label>1938 ed. 1.25.25</label>
                         <caesura/>
-                         kārayenmālatīpuṣpavṛntāgraparimaṇḍalāḥ | nātidūre nikṛṣṭe vā
-                        sūcīṃ karmaṇi pātayet ||25||</l>
+                         kārayenmālatīpuṣpavṛntāgraparimaṇḍalāḥ | nātidūre nikṛṣṭe vā sūcīṃ karmaṇi
+                        pātayet ||25||</l>
 
                     <l xml:id="SS.1.25.26">
                         <label>1938 ed. 1.25.26</label>
@@ -5673,88 +5716,80 @@
                     <l xml:id="SS.1.25.28">
                         <label>1938 ed. 1.25.28</label>
                         <caesura/>
-                         śallakīphalacūrṇair vā kṣaumadhyāmena vā punaḥ | tato vraṇaṃ
-                        yathāyogaṃ baddhvā''cārikam ādiśet ||28||</l>
+                         śallakīphalacūrṇair vā kṣaumadhyāmena vā punaḥ | tato vraṇaṃ yathāyogaṃ
+                        baddhvā''cārikam ādiśet ||28||</l>
 
                     <l xml:id="SS.1.25.29">
                         <label>1938 ed. 1.25.29</label>
                         <caesura/>
-                         etadaṣṭavidhaṃ karma samāsena prakīrtitam | cikitsiteṣu
-                        kārtsnyena vistaras tasya vakṣyate ||29|| </l>
+                         etadaṣṭavidhaṃ karma samāsena prakīrtitam | cikitsiteṣu kārtsnyena vistaras
+                        tasya vakṣyate ||29|| </l>
 
                     <l xml:id="SS.1.25.30">
                         <label>1938 ed. 1.25.30</label>
                         <caesura/>
-                         hīnātiriktaṃ tiryak ca gātracchedanamātmanaḥ | etāścatasro
-                        'ṣṭavidhe karmaṇi vyāpadaḥ smṛtāḥ ||30|| </l>
+                         hīnātiriktaṃ tiryak ca gātracchedanamātmanaḥ | etāścatasro 'ṣṭavidhe
+                        karmaṇi vyāpadaḥ smṛtāḥ ||30|| </l>
 
                     <l xml:id="SS.1.25.31">
                         <label>1938 ed. 1.25.31</label>
                         <caesura/>
-                         ajñānalobhāhitavākyayogabhayapramohairaparaiś ca bhāvaiḥ | yadā
-                        prayuñjīta bhiṣak kuśastraṃ tadā sa śeṣān kurute vikārān ||31|| </l>
+                         ajñānalobhāhitavākyayogabhayapramohairaparaiś ca bhāvaiḥ | yadā prayuñjīta
+                        bhiṣak kuśastraṃ tadā sa śeṣān kurute vikārān ||31|| </l>
 
                     <l xml:id="SS.1.25.32">
                         <label>1938 ed. 1.25.32</label>
                         <caesura/>
-                         taṃ kṣāraśastrāgnibhir auṣadhaiśca bhūyo 'bhiyuñjānamayuktiyuktam
-                        | jijīviṣurdūrata eva vaidyaṃ vivarjayed ugraviṣāhitulyam ||32|| </l>
+                         taṃ kṣāraśastrāgnibhir auṣadhaiśca bhūyo 'bhiyuñjānamayuktiyuktam |
+                        jijīviṣurdūrata eva vaidyaṃ vivarjayed ugraviṣāhitulyam ||32|| </l>
 
                     <l xml:id="SS.1.25.33">
                         <label>1938 ed. 1.25.33</label>
                         <caesura/>
-                         tad eva yuktaṃ tvati marmasandhīn hiṃsyāt sirāḥ snāyumathāsthi
-                        caiva | mūrkhaprayuktaṃ puruṣaṃ kṣaṇena prāṇairviyuñjyādathavā
-                        kadācit ||33|| </l>
+                         tad eva yuktaṃ tvati marmasandhīn hiṃsyāt sirāḥ snāyumathāsthi caiva |
+                        mūrkhaprayuktaṃ puruṣaṃ kṣaṇena prāṇairviyuñjyādathavā kadācit ||33|| </l>
 
                     <l xml:id="SS.1.25.34">
                         <label>1938 ed. 1.25.34</label>
                         <caesura/>
-                         bhramaḥ pralāpaḥ patanaṃ pramoho viceṣṭanaṃ saṃlayanoṣṇate ca |
-                        srastāṅgatā mūrcchanamūrdhvavātastīvrā rujo vātakṛtāś ca tāstāḥ
-                        ||34||</l>
+                         bhramaḥ pralāpaḥ patanaṃ pramoho viceṣṭanaṃ saṃlayanoṣṇate ca | srastāṅgatā
+                        mūrcchanamūrdhvavātastīvrā rujo vātakṛtāś ca tāstāḥ ||34||</l>
 
                     <l xml:id="SS.1.25.35">
                         <label>1938 ed. 1.25.35</label>
                         <caesura/>
-                         māṃsodakābhaṃ rudhiraṃ ca gacchet sarvendriyārthoparamas tathaiva
-                        | daśārdhasaṅkhyeṣv api vikṣateṣu sāmānyato marmasu liṅgamuktam
-                        ||35||</l>
+                         māṃsodakābhaṃ rudhiraṃ ca gacchet sarvendriyārthoparamas tathaiva |
+                        daśārdhasaṅkhyeṣv api vikṣateṣu sāmānyato marmasu liṅgamuktam ||35||</l>
 
                     <l xml:id="SS.1.25.36">
                         <label>1938 ed. 1.25.36</label>
                         <caesura/>
-                         surendragopapratimaṃ prabhūtaṃ raktaṃ sravedvai kṣatataś ca vāyuḥ
-                        | karoti rogān vividhān yathoktāṃśchinnāsu bhinnāsvathavā sirāsu
-                        ||36|| </l>
+                         surendragopapratimaṃ prabhūtaṃ raktaṃ sravedvai kṣatataś ca vāyuḥ | karoti
+                        rogān vividhān yathoktāṃśchinnāsu bhinnāsvathavā sirāsu ||36|| </l>
 
                     <l xml:id="SS.1.25.37">
                         <label>1938 ed. 1.25.37</label>
                         <caesura/>
-                         kaubjyaṃ śarīrāvayavāvasādaḥ kriyāsvaśaktistumulā rujaś ca |
-                        cirādvrraṇo rohati yasya cāpi taṃ snāyuviddhaṃ manujaṃ vyavasyet
-                        ||37|| </l>
+                         kaubjyaṃ śarīrāvayavāvasādaḥ kriyāsvaśaktistumulā rujaś ca | cirādvrraṇo
+                        rohati yasya cāpi taṃ snāyuviddhaṃ manujaṃ vyavasyet ||37|| </l>
 
                     <l xml:id="SS.1.25.38">
                         <label>1938 ed. 1.25.38</label>
                         <caesura/>
-                         śophātivṛddhistumulā rujaś ca balakṣayaḥ parvasu bhedaśophau |
-                        kṣateṣu sandhiṣvacalācaleṣu syāt sandhikarmoparatiś ca liṅgam
-                        ||38||</l>
+                         śophātivṛddhistumulā rujaś ca balakṣayaḥ parvasu bhedaśophau | kṣateṣu
+                        sandhiṣvacalācaleṣu syāt sandhikarmoparatiś ca liṅgam ||38||</l>
 
                     <l xml:id="SS.1.25.39">
                         <label>1938 ed. 1.25.39</label>
                         <caesura/>
-                         ghorā rujo yasya niśādineṣu sarvāsvavasthāsu na śāntirasti |
-                        tṛṣṇāṅgasādau śvayathuś ca ruk ca tamasthividdhaṃ manujaṃ
-                        vyavasyet ||39||</l>
+                         ghorā rujo yasya niśādineṣu sarvāsvavasthāsu na śāntirasti | tṛṣṇāṅgasādau
+                        śvayathuś ca ruk ca tamasthividdhaṃ manujaṃ vyavasyet ||39||</l>
 
                     <l xml:id="SS.1.25.40">
                         <label>1938 ed. 1.25.40</label>
                         <caesura/>
-                         yathāsvametāni vibhāvayec ca liṅgāni marmasvabhitāḍiteṣu |40|
-                        sparśaṃ na jānāti vipāṇḍuvarṇo yo māṃsamarmaṇyabhitāḍitaḥ syāt
-                        ||40|| </l>
+                         yathāsvametāni vibhāvayec ca liṅgāni marmasvabhitāḍiteṣu |40| sparśaṃ na
+                        jānāti vipāṇḍuvarṇo yo māṃsamarmaṇyabhitāḍitaḥ syāt ||40|| </l>
 
                     <l xml:id="SS.1.25.41">
                         <label>1938 ed. 1.25.41</label>
@@ -5765,14 +5800,14 @@
                     <l xml:id="SS.1.25.42">
                         <label>1938 ed. 1.25.42</label>
                         <caesura/>
-                         tiryak praṇihite śastre doṣāḥ pūrvamudāhṛtāḥ | tasmāt pariharan
-                        doṣān kuryāc chastranipātanam ||42|| </l>
+                         tiryak praṇihite śastre doṣāḥ pūrvamudāhṛtāḥ | tasmāt pariharan doṣān
+                        kuryāc chastranipātanam ||42|| </l>
 
                     <l xml:id="SS.1.25.43">
                         <label>1938 ed. 1.25.43</label>
                         <caesura/>
-                         mātaraṃ pitaraṃ putrān bāndhavānapi cāturaḥ | apyetānabhiśaṅketa
-                        vaidye viśvāsameti ca ||43|| </l>
+                         mātaraṃ pitaraṃ putrān bāndhavānapi cāturaḥ | apyetānabhiśaṅketa vaidye
+                        viśvāsameti ca ||43|| </l>
 
                     <l xml:id="SS.1.25.44">
                         <label>1938 ed. 1.25.44</label>
@@ -5784,20 +5819,20 @@
                     <l xml:id="SS.1.25.45">
                         <label>1938 ed. 1.25.45</label>
                         <caesura/>
-                         dharmārthau kīrtimity arthaṃ satāṃ grahaṇam uttamam | prāpnuyāt
-                        svargavāsaṃ ca hitamārabhya karmaṇā ||45|| </l>
+                         dharmārthau kīrtimity arthaṃ satāṃ grahaṇam uttamam | prāpnuyāt svargavāsaṃ
+                        ca hitamārabhya karmaṇā ||45|| </l>
 
                     <l xml:id="SS.1.25.46">
                         <label>1938 ed. 1.25.46</label>
                         <caesura/>
-                         karmaṇā kaścidekena dvābhyāṃ kaścittribhis tathā | vikāraḥ
-                        sādhyate kaściccaturbhir api karmabhiḥ ||46|| </l>
+                         karmaṇā kaścidekena dvābhyāṃ kaścittribhis tathā | vikāraḥ sādhyate
+                        kaściccaturbhir api karmabhiḥ ||46|| </l>
 
                     <l xml:id="SS.1.25.trailer">
                         <label>1938 ed. 1.25.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne 'ṣṭavidhaśastrakarmīyo nāma
-                        pañcaviṃśo 'dhyāyaḥ ||25|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne 'ṣṭavidhaśastrakarmīyo nāma pañcaviṃśo
+                        'dhyāyaḥ ||25|| </l>
                 </div>
 
 
@@ -5807,8 +5842,7 @@
                     <l xml:id="SS.1.26.3">
                         <label>1938 ed. 1.26.3</label>
                         <caesura/>
-                         ‘śala’ ‘śvala’ āśugamane dhātūḥ; tayor ādyasya śalyam iti rūpam
-                        ||3|| </l>
+                         ‘śala’ ‘śvala’ āśugamane dhātūḥ; tayor ādyasya śalyam iti rūpam ||3|| </l>
 
                     <l xml:id="SS.1.26.4">
                         <label>1938 ed. 1.26.4</label>
@@ -5818,31 +5852,28 @@
                     <l xml:id="SS.1.26.5">
                         <label>1938 ed. 1.26.5</label>
                         <caesura/>
-                         sarvaśarīrābādhakaraṃ śalyaṃ, tadihopadiśyata ity ataḥ
-                        śalyaśāstram ||5|| </l>
+                         sarvaśarīrābādhakaraṃ śalyaṃ, tadihopadiśyata ity ataḥ śalyaśāstram ||5|| </l>
 
                     <l xml:id="SS.1.26.6">
                         <label>1938 ed. 1.26.6</label>
                         <caesura/>
-                         tatra śārīraṃ dantaromanakhādi dhātavo 'nnamalā doṣāś ca duṣṭāḥ;
-                        āgantvapi śārīraśalyavyatirekeṇa yāvanto bhāvā duḥkhamutpādayanti
-                        ||6|| </l>
+                         tatra śārīraṃ dantaromanakhādi dhātavo 'nnamalā doṣāś ca duṣṭāḥ; āgantvapi
+                        śārīraśalyavyatirekeṇa yāvanto bhāvā duḥkhamutpādayanti ||6|| </l>
 
                     <l xml:id="SS.1.26.7">
                         <label>1938 ed. 1.26.7</label>
                         <caesura/>
-                         adhikāro hi lohaveṇuvṛkṣatṛṇaśṛṅgāsthimayeṣu; tatrāpi viśeṣato
-                        loheṣveva , viśasanārthopapannatvāllohasya; lohānām api
-                        durvāratvād aṇumukhatvād dūraprayojanakaratvāc ca śara evādhikṛtaḥ
-                        | sa ca dvividhaḥ karṇī , ślakṣṇaśca; prāyeṇa
-                        vividhavṛkṣapatrapuṣpaphalatulyākṛtayo vyākhyātāḥ,
+                         adhikāro hi lohaveṇuvṛkṣatṛṇaśṛṅgāsthimayeṣu; tatrāpi viśeṣato loheṣveva ,
+                        viśasanārthopapannatvāllohasya; lohānām api durvāratvād aṇumukhatvād
+                        dūraprayojanakaratvāc ca śara evādhikṛtaḥ | sa ca dvividhaḥ karṇī ,
+                        ślakṣṇaśca; prāyeṇa vividhavṛkṣapatrapuṣpaphalatulyākṛtayo vyākhyātāḥ,
                         vyālamṛgapakṣivakrasadṛśāś ca ||7|| </l>
 
                     <l xml:id="SS.1.26.8">
                         <label>1938 ed. 1.26.8</label>
                         <caesura/>
-                         sarvaśalyānāṃ tu mahatāmaṇūnāṃ vā pañcavidho gativiśeṣa
-                        ūrdhvamadho 'rvācīnastiryagṛjuriti ||8|| </l>
+                         sarvaśalyānāṃ tu mahatāmaṇūnāṃ vā pañcavidho gativiśeṣa ūrdhvamadho
+                        'rvācīnastiryagṛjuriti ||8|| </l>
 
                     <l xml:id="SS.1.26.9">
                         <label>1938 ed. 1.26.9</label>
@@ -5853,55 +5884,48 @@
                     <l xml:id="SS.1.26.10">
                         <label>1938 ed. 1.26.10</label>
                         <caesura/>
-                         tatra śalyalakṣaṇamucyamānam upadhāraya | taddvidhaṃ sāmānyaṃ
-                        vaiśeṣikaṃ ca | śyāvaṃ piḍakācitaṃ śophavedanāvantaṃ muhurmuhuḥ
-                        śoṇitāsrāviṇaṃ budbudavadunnataṃ mṛdumāṃsaṃ ca vraṇaṃ jānīyāt
-                        saśalyo 'yamiti; sāmānyametallakṣaṇamuktam | vaiśeṣikaṃ tu-
-                        tvaggate vivarṇaḥ śopho bhavatyāyataḥ kaṭhinaśca; māṃsagate
-                        śophābhi(ti)vṛddhiḥ śalyamārgānupasaṃrohaḥ pīḍanāsahiṣṇutā
-                        coṣapākau ca; peśyantarasthe 'pyetad eva coṣaśophavarjaṃ; sirāgate
-                        sirādhmānaṃ sirāśūlaṃ sirāśophaśca; snāyugate snāyujālotkṣepaṇaṃ
-                        saṃrambhaścogrā ruk ca; srotogate srotasāṃ svakarmaguṇahāniḥ;
-                        dhamanīsthe saphenaṃ raktamīrayannanilaḥ saśabdo
-                        nirgacchatyaṅgamardaḥ pipāsā hṛllāsaśca; asthigate
-                        vividhavedanāprādurbhāvaḥ śophaśca; asthivivaragate
-                        'sthipūrṇatā'sthitodaḥ saṃharṣo balavāṃśca; sandhigate
-                        'sthivacceṣṭoparamaśca; koṣṭhagata āṭopānāhau
-                        mūtrapurīṣāhāradarśanaṃ ca vraṇamukhāt; marmagate
-                        marmaviddhavacceṣṭate | sūkṣmagatiṣu śalyeṣvetānyeva
-                        lakṣaṇānyaspaṣṭāni bhavanti ||10|| </l>
+                         tatra śalyalakṣaṇamucyamānam upadhāraya | taddvidhaṃ sāmānyaṃ vaiśeṣikaṃ ca
+                        | śyāvaṃ piḍakācitaṃ śophavedanāvantaṃ muhurmuhuḥ śoṇitāsrāviṇaṃ
+                        budbudavadunnataṃ mṛdumāṃsaṃ ca vraṇaṃ jānīyāt saśalyo 'yamiti;
+                        sāmānyametallakṣaṇamuktam | vaiśeṣikaṃ tu- tvaggate vivarṇaḥ śopho
+                        bhavatyāyataḥ kaṭhinaśca; māṃsagate śophābhi(ti)vṛddhiḥ
+                        śalyamārgānupasaṃrohaḥ pīḍanāsahiṣṇutā coṣapākau ca; peśyantarasthe 'pyetad
+                        eva coṣaśophavarjaṃ; sirāgate sirādhmānaṃ sirāśūlaṃ sirāśophaśca; snāyugate
+                        snāyujālotkṣepaṇaṃ saṃrambhaścogrā ruk ca; srotogate srotasāṃ
+                        svakarmaguṇahāniḥ; dhamanīsthe saphenaṃ raktamīrayannanilaḥ saśabdo
+                        nirgacchatyaṅgamardaḥ pipāsā hṛllāsaśca; asthigate vividhavedanāprādurbhāvaḥ
+                        śophaśca; asthivivaragate 'sthipūrṇatā'sthitodaḥ saṃharṣo balavāṃśca;
+                        sandhigate 'sthivacceṣṭoparamaśca; koṣṭhagata āṭopānāhau
+                        mūtrapurīṣāhāradarśanaṃ ca vraṇamukhāt; marmagate marmaviddhavacceṣṭate |
+                        sūkṣmagatiṣu śalyeṣvetānyeva lakṣaṇānyaspaṣṭāni bhavanti ||10|| </l>
 
                     <l xml:id="SS.1.26.11">
                         <label>1938 ed. 1.26.11</label>
                         <caesura/>
-                         mahāntyalpāni vā śuddhadehānāmanulomasanniviṣṭāni rohanti
-                        viśeṣataḥ kaṇṭhasrotaḥsirātvakpeśyasthivivareṣaḥ |
-                        doṣaprakopavyāyāmābhighātājīrṇebhyaḥ pracalitāni punarbādhante
-                        ||11|| </l>
+                         mahāntyalpāni vā śuddhadehānāmanulomasanniviṣṭāni rohanti viśeṣataḥ
+                        kaṇṭhasrotaḥsirātvakpeśyasthivivareṣaḥ |
+                        doṣaprakopavyāyāmābhighātājīrṇebhyaḥ pracalitāni punarbādhante ||11|| </l>
 
                     <l xml:id="SS.1.26.12">
                         <label>1938 ed. 1.26.12</label>
                         <caesura/>
-                         tatra, tvakpranaṣṭe snigdhasvinnāyāṃ
-                        mṛnmāṣayavagodhūmagomayamṛditāyāṃ tvaci yatra saṃrambho vedanā vā
-                        bhavati tatra śalyaṃ vijānīyāt , styānaghṛtamṛccandanakalkair vā
-                        pradigdhāyāṃ śalyoṣmaṇā''śu visarati ghṛtam upaśuṣyati cālepo
-                        yatra tatra śalyaṃ vijānīyāt ; māṃsapranaṣṭe snehasvedādibhiḥ
-                        kriyāviśeṣairaviruddhairāturam upapādayet, karśitasya tu
-                        śithilībhūtamanavabaddhaṃ kṣubhyamāṇaṃ yatra saṃrambhaṃ vedanāṃ vā
-                        janayati tatra śalyaṃ vijānīyāt ; koṣṭhāsthisandhipeśīvivareṣv
-                        avasthitamevam eva parīkṣeta; sirādhamanīsrotaḥsnāyupranaṣṭe
-                        khaṇḍacakrasaṃyukte yāne vyādhitamāropyāśu viṣame 'dhvani yāyāt
-                        yatra saṃrambho vedanā vā bhavati tatra śalyaṃ vijānīyāt ;
-                        asthipranaṣṭe snehasvedopapannānyasthīni bandhanapīḍanābhyāṃ
-                        bhṛśamupācaret, yatra saṃrambho vedanā bhavati tatra śalyaṃ
-                        vijānīyāt ; sandhipranaṣṭe snehasvedopapannān sandhīn
-                        prasaraṇākuñcanabandhanapīḍanaiḥ bhṛśamupācaret, yatra saṃrambho
-                        vedanā vā bhavati tatra śalyaṃ vijānīyāt , sandhipranaṣṭe
-                        snehasvedopapannān sandhīn
-                        prasaraṇākuñcanabandhanapīḍanairbhṛśamupācaret; yatra saṃrambho
-                        vedanā vā bhavati tatra śalyaṃ vijānīyāt , marmapranaṣṭe
-                        tvananyabhāvānmarmaṇāmuktaṃ parīkṣaṇaṃ bhavati ||12|| </l>
+                         tatra, tvakpranaṣṭe snigdhasvinnāyāṃ mṛnmāṣayavagodhūmagomayamṛditāyāṃ
+                        tvaci yatra saṃrambho vedanā vā bhavati tatra śalyaṃ vijānīyāt ,
+                        styānaghṛtamṛccandanakalkair vā pradigdhāyāṃ śalyoṣmaṇā''śu visarati ghṛtam
+                        upaśuṣyati cālepo yatra tatra śalyaṃ vijānīyāt ; māṃsapranaṣṭe
+                        snehasvedādibhiḥ kriyāviśeṣairaviruddhairāturam upapādayet, karśitasya tu
+                        śithilībhūtamanavabaddhaṃ kṣubhyamāṇaṃ yatra saṃrambhaṃ vedanāṃ vā janayati
+                        tatra śalyaṃ vijānīyāt ; koṣṭhāsthisandhipeśīvivareṣv avasthitamevam eva
+                        parīkṣeta; sirādhamanīsrotaḥsnāyupranaṣṭe khaṇḍacakrasaṃyukte yāne
+                        vyādhitamāropyāśu viṣame 'dhvani yāyāt yatra saṃrambho vedanā vā bhavati
+                        tatra śalyaṃ vijānīyāt ; asthipranaṣṭe snehasvedopapannānyasthīni
+                        bandhanapīḍanābhyāṃ bhṛśamupācaret, yatra saṃrambho vedanā bhavati tatra
+                        śalyaṃ vijānīyāt ; sandhipranaṣṭe snehasvedopapannān sandhīn
+                        prasaraṇākuñcanabandhanapīḍanaiḥ bhṛśamupācaret, yatra saṃrambho vedanā vā
+                        bhavati tatra śalyaṃ vijānīyāt , sandhipranaṣṭe snehasvedopapannān sandhīn
+                        prasaraṇākuñcanabandhanapīḍanairbhṛśamupācaret; yatra saṃrambho vedanā vā
+                        bhavati tatra śalyaṃ vijānīyāt , marmapranaṣṭe tvananyabhāvānmarmaṇāmuktaṃ
+                        parīkṣaṇaṃ bhavati ||12|| </l>
 
                     <l xml:id="SS.1.26.13">
                         <label>1938 ed. 1.26.13</label>
@@ -5909,50 +5933,50 @@
                          sāmānyalakṣam api ca
                         hastiskandhāśvapṛṣṭhaparvatadrumārohaṇadhanurvyāyāmadrutayānaniyuddhādhvagamanalaṅghanaplavanaprataraṇa-
                         vyāyāmairjṛmbhodgārakāsakṣavathuṣṭhīvanahasanaprāṇāyāmair
-                        vātamūtrapurīṣaśukrotsargair vā yatra saṃrambho vedanā vā bhavati
-                        tatra śalyaṃ vijānīyāt ||13|| </l>
+                        vātamūtrapurīṣaśukrotsargair vā yatra saṃrambho vedanā vā bhavati tatra
+                        śalyaṃ vijānīyāt ||13|| </l>
 
                     <l xml:id="SS.1.26.14">
                         <label>1938 ed. 1.26.14</label>
                         <caesura/>
-                         bhavanti cātra - yasmiṃstodādayo deśe suptatā gurutā'pi ca |
-                        ghaṭṭate bahuśo yatra śūyate rujyate 'pi ca ||14|| </l>
+                         bhavanti cātra - yasmiṃstodādayo deśe suptatā gurutā'pi ca | ghaṭṭate
+                        bahuśo yatra śūyate rujyate 'pi ca ||14|| </l>
 
                     <l xml:id="SS.1.26.15">
                         <label>1938 ed. 1.26.15</label>
                         <caesura/>
-                         āturaś cāpi yaṃ deśamabhīkṣṇaṃ parirakṣati | saṃvāhyamāno bahuśas
-                        tatra śalyaṃ vinirdiśet ||15||</l>
+                         āturaś cāpi yaṃ deśamabhīkṣṇaṃ parirakṣati | saṃvāhyamāno bahuśas tatra
+                        śalyaṃ vinirdiśet ||15||</l>
 
                     <l xml:id="SS.1.26.16">
                         <label>1938 ed. 1.26.16</label>
                         <caesura/>
-                         alpābādhamaśūnaṃ ca nīrujaṃ nirupadravam | prasannaṃ
-                        mṛduparyantaṃ nirāghaṭṭamanunnatam ||16|| </l>
+                         alpābādhamaśūnaṃ ca nīrujaṃ nirupadravam | prasannaṃ mṛduparyantaṃ
+                        nirāghaṭṭamanunnatam ||16|| </l>
 
                     <l xml:id="SS.1.26.17">
                         <label>1938 ed. 1.26.17</label>
                         <caesura/>
-                         eṣaṇyā sarvato dṛṣṭvā yathāmārgaṃ cikitsakaḥ |
-                        prasārākuñcanānnūnaṃ niḥśalyam iti nirdiśet ||17||</l>
+                         eṣaṇyā sarvato dṛṣṭvā yathāmārgaṃ cikitsakaḥ | prasārākuñcanānnūnaṃ
+                        niḥśalyam iti nirdiśet ||17||</l>
 
                     <l xml:id="SS.1.26.18">
                         <label>1938 ed. 1.26.18</label>
                         <caesura/>
-                         asthyātmakaṃ bhajyate tu śalyamantaś ca śīryate | prāyo
-                        nirbhujyate śārṅgamāyasaṃ ceti niścayaḥ ||18|| </l>
+                         asthyātmakaṃ bhajyate tu śalyamantaś ca śīryate | prāyo nirbhujyate
+                        śārṅgamāyasaṃ ceti niścayaḥ ||18|| </l>
 
                     <l xml:id="SS.1.26.19">
                         <label>1938 ed. 1.26.19</label>
                         <caesura/>
-                         vārkṣavaiṇavatārṇāni nirhriyante tu no yadi | pacanti raktaṃ
-                        māṃsaṃ ca kṣiprametāni dehinām ||19|| </l>
+                         vārkṣavaiṇavatārṇāni nirhriyante tu no yadi | pacanti raktaṃ māṃsaṃ ca
+                        kṣiprametāni dehinām ||19|| </l>
 
                     <l xml:id="SS.1.26.20">
                         <label>1938 ed. 1.26.20</label>
                         <caesura/>
-                         kānakaṃ rājataṃ tāmraṃ raitikaṃ trapu sīsakam |
-                        cirasthānādvilīyante pittatejaḥpratāpanāt ||20|| </l>
+                         kānakaṃ rājataṃ tāmraṃ raitikaṃ trapu sīsakam | cirasthānādvilīyante
+                        pittatejaḥpratāpanāt ||20|| </l>
 
                     <l xml:id="SS.1.26.21">
                         <label>1938 ed. 1.26.21</label>
@@ -5963,14 +5987,14 @@
                     <l xml:id="SS.1.26.22">
                         <label>1938 ed. 1.26.22</label>
                         <caesura/>
-                         viṣāṇadantakeśāsthiveṇudārupalāni tu | śalyāni na viśīryante
-                        śarīre mṛnmayāni ca ||22|| </l>
+                         viṣāṇadantakeśāsthiveṇudārupalāni tu | śalyāni na viśīryante śarīre
+                        mṛnmayāni ca ||22|| </l>
 
                     <l xml:id="SS.1.26.23">
                         <label>1938 ed. 1.26.23</label>
                         <caesura/>
-                         dvividhaṃ pañcagatimattvagādivraṇavastuṣu | yo vetti viṣṭitaṃ
-                        śalyaṃ sa rājñaḥ kartumarhati ||23|| </l>
+                         dvividhaṃ pañcagatimattvagādivraṇavastuṣu | yo vetti viṣṭitaṃ śalyaṃ sa
+                        rājñaḥ kartumarhati ||23|| </l>
 
 
                     <l xml:id="SS.1.26.trailer">
@@ -5986,35 +6010,32 @@
                     <l xml:id="SS.1.27.4">
                         <label>1938 ed. 1.27.4</label>
                         <caesura/>
-                         tatra samāsenānavabaddhaśalyoddharaṇārthaṃ pañcadaśa hetūn
-                        vakṣyāmaḥ | tad yathā- svabhāvaḥ, pācanaṃ, bhedanaṃ, dāraṇaṃ,
-                        pīḍanaṃ, pramārjanaṃ, nirdhmāpanaṃ, vamanaṃ, virecanaṃ,
-                        prakṣālanaṃ, pratimarśaḥ, pravāhaṇam, ācūṣaṇam, ayaskānto,
-                        harṣaśceti ||4|| </l>
+                         tatra samāsenānavabaddhaśalyoddharaṇārthaṃ pañcadaśa hetūn vakṣyāmaḥ | tad
+                        yathā- svabhāvaḥ, pācanaṃ, bhedanaṃ, dāraṇaṃ, pīḍanaṃ, pramārjanaṃ,
+                        nirdhmāpanaṃ, vamanaṃ, virecanaṃ, prakṣālanaṃ, pratimarśaḥ, pravāhaṇam,
+                        ācūṣaṇam, ayaskānto, harṣaśceti ||4|| </l>
 
                     <l xml:id="SS.1.27.5">
                         <label>1938 ed. 1.27.5</label>
                         <caesura/>
                          tatrāśrukṣavathūdgārakāsamūtrapurīṣānilaiḥ
                         svabhāvabalapravṛttairnayanādibhyaḥ patati | māṃsāvagāḍhaṃ
-                        śalyamavidahyamānaṃ pācayitvā prakothāttasya pūyaśoṇitavegād
-                        gauravādvā patati | pakvamabhidyamānaṃ bhedayed dārayed vā |
-                        bhinnamanirasyamānaṃ pīḍanīyaiḥ pīḍayet pāṇibhir vā |
-                        aṇūnyakṣaśalyāni pariṣecanādhmāpanairbālavastrapāṇibhiḥ
-                        pramārjayet | āhāraśeṣaśleṣmahīnāṇuśalyāni
-                        śvasanotkāsanapradhamanairnirdhamet | annaśalyāni
-                        vamanāṅgulipratimarśaprabhṛtibhiḥ | virecanaiḥ pakvāśayagatāni |
+                        śalyamavidahyamānaṃ pācayitvā prakothāttasya pūyaśoṇitavegād gauravādvā
+                        patati | pakvamabhidyamānaṃ bhedayed dārayed vā | bhinnamanirasyamānaṃ
+                        pīḍanīyaiḥ pīḍayet pāṇibhir vā | aṇūnyakṣaśalyāni
+                        pariṣecanādhmāpanairbālavastrapāṇibhiḥ pramārjayet |
+                        āhāraśeṣaśleṣmahīnāṇuśalyāni śvasanotkāsanapradhamanairnirdhamet |
+                        annaśalyāni vamanāṅgulipratimarśaprabhṛtibhiḥ | virecanaiḥ pakvāśayagatāni |
                         vraṇadoṣāśayagatāni prakṣālanaiḥ | vātamūtrapurīṣagarbhasaṅgeṣu
-                        pravāhaṇamuktam |
-                        mārutodakasaviṣarudhiraduṣṭastanyeṣvācūṣaṇamāsyena viṣāṇair vā |
-                        anulomamanavabaddhamakarṇamanalpavraṇamukhamayaskāntena |
+                        pravāhaṇamuktam | mārutodakasaviṣarudhiraduṣṭastanyeṣvācūṣaṇamāsyena
+                        viṣāṇair vā | anulomamanavabaddhamakarṇamanalpavraṇamukhamayaskāntena |
                         hṛdyavasthitamanekakāraṇotpannaṃ śokaśalyaṃ harṣeṇeti ||5|| </l>
 
                     <l xml:id="SS.1.27.6">
                         <label>1938 ed. 1.27.6</label>
                         <caesura/>
-                         sarvaśalyānāṃ tu mahatāmaṇūnāṃ vā dvāvevāharaṇahetū bhavataḥ-
-                        pratilomo 'nulomaś ca ||6|| </l>
+                         sarvaśalyānāṃ tu mahatāmaṇūnāṃ vā dvāvevāharaṇahetū bhavataḥ- pratilomo
+                        'nulomaś ca ||6|| </l>
 
                     <l xml:id="SS.1.27.7">
                         <label>1938 ed. 1.27.7</label>
@@ -6029,8 +6050,8 @@
                     <l xml:id="SS.1.27.9">
                         <label>1938 ed. 1.27.9</label>
                         <caesura/>
-                         chedanīyamukhānyapi kukṣivakṣaḥkakṣāvaṅkṣaṇaparśukāntarapatitāni
-                        ca hastaśakyaṃ yathāmārgeṇa hastenaivāpahartuṃ prayateta ||9|| </l>
+                         chedanīyamukhānyapi kukṣivakṣaḥkakṣāvaṅkṣaṇaparśukāntarapatitāni ca
+                        hastaśakyaṃ yathāmārgeṇa hastenaivāpahartuṃ prayateta ||9|| </l>
 
                     <l xml:id="SS.1.27.10">
                         <label>1938 ed. 1.27.10</label>
@@ -6040,17 +6061,16 @@
                     <l xml:id="SS.1.27.11">
                         <label>1938 ed. 1.27.11</label>
                         <caesura/>
-                         bhavati cātra - śītalena jalenainaṃ mūrcchantamavasecayet |
-                        saṃrakṣedasya marmāṇi muhurāśvāsayec ca tam ||11|| </l>
+                         bhavati cātra - śītalena jalenainaṃ mūrcchantamavasecayet | saṃrakṣedasya
+                        marmāṇi muhurāśvāsayec ca tam ||11|| </l>
 
                     <l xml:id="SS.1.27.12">
                         <label>1938 ed. 1.27.12</label>
                         <caesura/>
-                         tataḥ śalyamuddhṛtya nirlohitaṃ vraṇaṃ kṛtvā
-                        svedārhamagnighṛtaprabhṛtibhiḥ saṃsvedyāvadahya pradihya
-                        sarpirmadhubhyāṃ baddhvā''cārikam upadiśet | (sirāsnāyuvilagnaṃ
-                        śalākādibhir vimocyāpanayet; śvayathugrastavāraṅgaṃ samavapīḍya
-                        śvayathuṃ; durbalavāraṅgaṃ kuśādibhir baddhvā|) ||12|| </l>
+                         tataḥ śalyamuddhṛtya nirlohitaṃ vraṇaṃ kṛtvā svedārhamagnighṛtaprabhṛtibhiḥ
+                        saṃsvedyāvadahya pradihya sarpirmadhubhyāṃ baddhvā''cārikam upadiśet |
+                        (sirāsnāyuvilagnaṃ śalākādibhir vimocyāpanayet; śvayathugrastavāraṅgaṃ
+                        samavapīḍya śvayathuṃ; durbalavāraṅgaṃ kuśādibhir baddhvā|) ||12|| </l>
 
                     <l xml:id="SS.1.27.13">
                         <label>1938 ed. 1.27.13</label>
@@ -6062,68 +6082,63 @@
                     <l xml:id="SS.1.27.14">
                         <label>1938 ed. 1.27.14</label>
                         <caesura/>
-                         asthivivarapraviṣṭamasthividaṣṭaṃ vā'vagṛhya pādābhyāṃ
-                        yantreṇāpaharet, aśakyamevaṃ vā balavadbhiḥ suparigṛhītasya
-                        yantreṇa grāhayitvā śalyavāraṅgaṃ pravibhujya
-                        dhanurguṇairbaddhvaikataś cāsya pañcāṅgyām
+                         asthivivarapraviṣṭamasthividaṣṭaṃ vā'vagṛhya pādābhyāṃ yantreṇāpaharet,
+                        aśakyamevaṃ vā balavadbhiḥ suparigṛhītasya yantreṇa grāhayitvā śalyavāraṅgaṃ
+                        pravibhujya dhanurguṇairbaddhvaikataś cāsya pañcāṅgyām
                         upasaṃyatasyāśvasyavaktrakavike badhnīyāt, athainaṃ kaśayā tāḍayed
-                        yathonnāmayañ śiro vegena śalyamuddharati; dṛḍhāṃ vā
-                        vṛkṣaśākhāmavanamya tasyāṃ pūrvavadbaddhvoddharet ||14|| </l>
+                        yathonnāmayañ śiro vegena śalyamuddharati; dṛḍhāṃ vā vṛkṣaśākhāmavanamya
+                        tasyāṃ pūrvavadbaddhvoddharet ||14|| </l>
 
                     <l xml:id="SS.1.27.15">
                         <label>1938 ed. 1.27.15</label>
                         <caesura/>
-                         adeśottuṇḍitamaṣṭhīlāśmamudgarāṇāmanyatamasya prahāreṇa vicālya
-                        yathāmārgam eva yantreṇa ||15|| </l>
+                         adeśottuṇḍitamaṣṭhīlāśmamudgarāṇāmanyatamasya prahāreṇa vicālya yathāmārgam
+                        eva yantreṇa ||15|| </l>
 
                     <l xml:id="SS.1.27.16">
                         <label>1938 ed. 1.27.16</label>
                         <caesura/>
-                         vimṛditakarṇāni karṇavantyanābādhakaradeśottuṇḍitāni purastādeva
-                        ||16|| </l>
+                         vimṛditakarṇāni karṇavantyanābādhakaradeśottuṇḍitāni purastādeva ||16|| </l>
 
                     <l xml:id="SS.1.27.17">
                         <label>1938 ed. 1.27.17</label>
                         <caesura/>
-                         jātuṣe kaṇṭhāsakte kaṇṭhe nāḍīṃ praveśyāgnitaptāṃ ca śalākāṃ,
-                        tayā'vagṛhya śītābhir adbhiḥ pariṣicya sthirībhūtaṃ śalyamuddharet
-                        ||17|| </l>
+                         jātuṣe kaṇṭhāsakte kaṇṭhe nāḍīṃ praveśyāgnitaptāṃ ca śalākāṃ, tayā'vagṛhya
+                        śītābhir adbhiḥ pariṣicya sthirībhūtaṃ śalyamuddharet ||17|| </l>
 
                     <l xml:id="SS.1.27.18">
                         <label>1938 ed. 1.27.18</label>
                         <caesura/>
-                         ajātuṣaṃ tu jatumadhūcchiṣṭapraliptayā śalākayā pūrvakalpenetyeke
-                        ||18|| </l>
+                         ajātuṣaṃ tu jatumadhūcchiṣṭapraliptayā śalākayā pūrvakalpenetyeke ||18|| </l>
 
                     <l xml:id="SS.1.27.19">
                         <label>1938 ed. 1.27.19</label>
                         <caesura/>
                          asthiśalyamanyadvā tiryakkaṇṭhāsaktam avekṣya keśoṇḍukaṃ
-                        dṛḍhaikadīrghasūtrabaddhaṃ dravabhaktopahitaṃ pāyayed ākaṇṭhāt
-                        pūrṇakoṣṭhaṃ ca vāmayet, vamataśca śalyaikadeśasaktaṃ jñātvā
-                        sūtraṃ sahasā tvākṣipet; mṛdunā vā dantadhāvanakūrcakenāpaharet
-                        praṇuded vā'ntaḥ | kṣatakaṇṭhāya ca madhusarpiṣī leḍhuṃ prayacchet
-                        triphalācūrṇaṃ vā madhuśarkarāmiśram ||19|| </l>
+                        dṛḍhaikadīrghasūtrabaddhaṃ dravabhaktopahitaṃ pāyayed ākaṇṭhāt pūrṇakoṣṭhaṃ
+                        ca vāmayet, vamataśca śalyaikadeśasaktaṃ jñātvā sūtraṃ sahasā tvākṣipet;
+                        mṛdunā vā dantadhāvanakūrcakenāpaharet praṇuded vā'ntaḥ | kṣatakaṇṭhāya ca
+                        madhusarpiṣī leḍhuṃ prayacchet triphalācūrṇaṃ vā madhuśarkarāmiśram ||19|| </l>
 
                     <l xml:id="SS.1.27.20">
                         <label>1938 ed. 1.27.20</label>
                         <caesura/>
-                         udakapūrṇodaram avākśirasam avapīḍayed dhunīyād vāmayed vā
-                        bhasmarāśau vā nikhaned āmukhāt ||20|| </l>
+                         udakapūrṇodaram avākśirasam avapīḍayed dhunīyād vāmayed vā bhasmarāśau vā
+                        nikhaned āmukhāt ||20|| </l>
 
                     <l xml:id="SS.1.27.21">
                         <label>1938 ed. 1.27.21</label>
                         <caesura/>
-                         grāsaśalye tu kaṇṭhāsakte niḥśaṅkam anavabuddhaṃ skandhe
-                        muṣṭinā'bhihanyāt, snehaṃ madyaṃ pānīyaṃ vā pāyayet ||21|| </l>
+                         grāsaśalye tu kaṇṭhāsakte niḥśaṅkam anavabuddhaṃ skandhe muṣṭinā'bhihanyāt,
+                        snehaṃ madyaṃ pānīyaṃ vā pāyayet ||21|| </l>
 
                     <l xml:id="SS.1.27.22">
                         <label>1938 ed. 1.27.22</label>
                         <caesura/>
-                         bāhurajjulatāpāśaiḥ kaṇṭhapīḍanād vāyuḥ prakupitaḥ śleṣmāṇaṃ
-                        kopayitvā sroto niruṇaddhi, lālāsrāvaṃ phenāgamanaṃ sañjñānāśaṃ
-                        cāpādayati; tam abhyajya saṃsvedya śirovirecanaṃ tasmai tīkṣṇaṃ
-                        vidadhyād rasaṃ ca vātaghnaṃ dadyād iti ||22|| </l>
+                         bāhurajjulatāpāśaiḥ kaṇṭhapīḍanād vāyuḥ prakupitaḥ śleṣmāṇaṃ kopayitvā
+                        sroto niruṇaddhi, lālāsrāvaṃ phenāgamanaṃ sañjñānāśaṃ cāpādayati; tam
+                        abhyajya saṃsvedya śirovirecanaṃ tasmai tīkṣṇaṃ vidadhyād rasaṃ ca vātaghnaṃ
+                        dadyād iti ||22|| </l>
 
                     <l xml:id="SS.1.27.23">
                         <label>1938 ed. 1.27.23</label>
@@ -6137,27 +6152,27 @@
                     <l xml:id="SS.1.27.24">
                         <label>1938 ed. 1.27.24</label>
                         <caesura/>
-                         karṇavanti tu śalyāni duḥkhāhāryāṇi yāni ca | ādadīta bhiṣak
-                        tasmāt tāni yuktyā samāhitaḥ ||24||</l>
+                         karṇavanti tu śalyāni duḥkhāhāryāṇi yāni ca | ādadīta bhiṣak tasmāt tāni
+                        yuktyā samāhitaḥ ||24||</l>
 
                     <l xml:id="SS.1.27.25">
                         <label>1938 ed. 1.27.25</label>
                         <caesura/>
-                         etair upāyaiḥ śalyaṃ tu naiva niryātyate yadi | matyā nipuṇayā
-                        vaidyo yantrayogaiś ca nirharet ||25|| </l>
+                         etair upāyaiḥ śalyaṃ tu naiva niryātyate yadi | matyā nipuṇayā vaidyo
+                        yantrayogaiś ca nirharet ||25|| </l>
 
                     <l xml:id="SS.1.27.26">
                         <label>1938 ed. 1.27.26</label>
                         <caesura/>
-                        śothapākau rujaścogrāḥ kuryāc chalyamanāhṛtam |
+                         śothapākau rujaścogrāḥ kuryāc chalyamanāhṛtam |
                         <caesura/>
-                        vaikalyaṃ maraṇaṃ cāpi tasmād yatnādvinirharet ||26|| </l>
+                         vaikalyaṃ maraṇaṃ cāpi tasmād yatnādvinirharet ||26|| </l>
 
                     <l xml:id="SS.1.27.trailer">
                         <label>1938 ed. 1.27.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne śalyāpanayanīyo nāma
-                        saptaviṃśatitamo 'dhyāyaḥ ||27|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne śalyāpanayanīyo nāma saptaviṃśatitamo
+                        'dhyāyaḥ ||27|| </l>
                 </div>
 
 
@@ -6178,75 +6193,75 @@
                     <l xml:id="SS.1.28.6">
                         <label>1938 ed. 1.28.6</label>
                         <caesura/>
-                         nakṣatrapīḍā bahudhā yathā kālaṃ vipacyate | tathaivāriṣṭapākaṃ
-                        ca bruvate bahavo janāḥ ||6|| </l>
+                         nakṣatrapīḍā bahudhā yathā kālaṃ vipacyate | tathaivāriṣṭapākaṃ ca bruvate
+                        bahavo janāḥ ||6|| </l>
 
                     <l xml:id="SS.1.28.7">
                         <label>1938 ed. 1.28.7</label>
                         <caesura/>
-                         asiddhimāpnuyālloke pratikurvan gatāyuṣaḥ | ato 'riṣṭāni yatnena
-                        lakṣayet kuśalo bhiṣak ||7|| </l>
+                         asiddhimāpnuyālloke pratikurvan gatāyuṣaḥ | ato 'riṣṭāni yatnena lakṣayet
+                        kuśalo bhiṣak ||7|| </l>
 
                     <l xml:id="SS.1.28.8">
                         <label>1938 ed. 1.28.8</label>
                         <caesura/>
-                         gandhavarṇarasādīnāṃ viśeṣāṇāṃ svabhāvataḥ | vaikṛtaṃ yat
-                        tadācaṣṭe vraṇinaḥ pakvalakṣaṇam ||8|| </l>
+                         gandhavarṇarasādīnāṃ viśeṣāṇāṃ svabhāvataḥ | vaikṛtaṃ yat tadācaṣṭe
+                        vraṇinaḥ pakvalakṣaṇam ||8|| </l>
 
                     <l xml:id="SS.1.28.9">
                         <label>1938 ed. 1.28.9</label>
                         <caesura/>
-                         kaṭustīkṣṇaś ca visraś ca gandhas tu pavanādibhiḥ | lohagandhis
-                        tu raktena vyāmiśraḥ sānnipātikaḥ ||9|| </l>
+                         kaṭustīkṣṇaś ca visraś ca gandhas tu pavanādibhiḥ | lohagandhis tu raktena
+                        vyāmiśraḥ sānnipātikaḥ ||9|| </l>
 
                     <l xml:id="SS.1.28.10">
                         <label>1938 ed. 1.28.10</label>
                         <caesura/>
-                         lājātasītailasamāḥ kiñcidvisrāś ca gandhataḥ | jñeyāḥ
-                        prakṛtigandhāḥ syuḥ |.. |.. rato 'nyadgandhavaikṛtam ||10|| </l>
+                         lājātasītailasamāḥ kiñcidvisrāś ca gandhataḥ | jñeyāḥ prakṛtigandhāḥ syuḥ
+                        |.. |.. rato 'nyadgandhavaikṛtam ||10|| </l>
 
                     <l xml:id="SS.1.28.11">
                         <label>1938 ed. 1.28.11</label>
                         <caesura/>
-                         madyāgurvājyasumanāpadmacandanacampakaiḥ | sagandhā divyagandhāś
-                        ca mumūrṣūṇāṃ vraṇāḥ smṛtāḥ ||11||</l>
+                         madyāgurvājyasumanāpadmacandanacampakaiḥ | sagandhā divyagandhāś ca
+                        mumūrṣūṇāṃ vraṇāḥ smṛtāḥ ||11||</l>
 
 
                     <l xml:id="SS.1.28.12">
                         <label>1938 ed. 1.28.12</label>
                         <caesura/>
-                         śvavājimūṣikadhvāṅkṣapūtivallūramatkuṇaiḥ | sagandhāḥ
-                        paṅkagandhāś ca bhūmigandhāś ca garhitāḥ ||12|| </l>
+                         śvavājimūṣikadhvāṅkṣapūtivallūramatkuṇaiḥ | sagandhāḥ paṅkagandhāś ca
+                        bhūmigandhāś ca garhitāḥ ||12|| </l>
 
                     <l xml:id="SS.1.28.13">
                         <label>1938 ed. 1.28.13</label>
                         <caesura/>
-                         kuṅkumadhyāmakaṅkuṣṭhasavarṇāḥ pittakopataḥ | na dahyante na
-                        cūṣyante bhiṣak tān parivarjayet ||13|| </l>
+                         kuṅkumadhyāmakaṅkuṣṭhasavarṇāḥ pittakopataḥ | na dahyante na cūṣyante
+                        bhiṣak tān parivarjayet ||13|| </l>
 
                     <l xml:id="SS.1.28.14">
                         <label>1938 ed. 1.28.14</label>
                         <caesura/>
-                         aṇḍūmantaḥ sthirāḥ śvetāḥ snigdhāḥ kaphanimittataḥ | dūyante
-                        vā'pi dahyante bhiṣak tān parivarjayet ||14||</l>
+                         aṇḍūmantaḥ sthirāḥ śvetāḥ snigdhāḥ kaphanimittataḥ | dūyante vā'pi dahyante
+                        bhiṣak tān parivarjayet ||14||</l>
 
                     <l xml:id="SS.1.28.15">
                         <label>1938 ed. 1.28.15</label>
                         <caesura/>
-                         kṛṣṇās tu ye tanusrāvā vātajā marmatāpinaḥ | svalpām api na
-                        kurvanti rujaṃ tān parivarjayet ||15||</l>
+                         kṛṣṇās tu ye tanusrāvā vātajā marmatāpinaḥ | svalpām api na kurvanti rujaṃ
+                        tān parivarjayet ||15||</l>
 
                     <l xml:id="SS.1.28.16">
                         <label>1938 ed. 1.28.16</label>
                         <caesura/>
-                         kṣveḍanti ghurghurāyante jvalantīva ca ye vraṇāḥ | tvaṅmāṃsasthāś
-                        ca pavanaṃ saśabdaṃ visṛjanti ye ||16|| </l>
+                         kṣveḍanti ghurghurāyante jvalantīva ca ye vraṇāḥ | tvaṅmāṃsasthāś ca
+                        pavanaṃ saśabdaṃ visṛjanti ye ||16|| </l>
 
                     <l xml:id="SS.1.28.17">
                         <label>1938 ed. 1.28.17</label>
                         <caesura/>
-                         ye ca marmasvasambhūtā bhavantyatyarthavedanāḥ dahyante
-                        cāntaratyarthaṃ bahiḥ śītāś ca ye vraṇāḥ ||17||</l>
+                         ye ca marmasvasambhūtā bhavantyatyarthavedanāḥ dahyante cāntaratyarthaṃ
+                        bahiḥ śītāś ca ye vraṇāḥ ||17||</l>
 
                     <l xml:id="SS.1.28.18">
                         <label>1938 ed. 1.28.18</label>
@@ -6264,14 +6279,14 @@
                     <l xml:id="SS.1.28.20">
                         <label>1938 ed. 1.28.20</label>
                         <caesura/>
-                         prāṇamāṃsakṣayaśvāsakāsārocakapīḍitāḥ | pravṛddhapūyarudhirā
-                        vraṇā yeṣāṃ ca marmasu ||20|| </l>
+                         prāṇamāṃsakṣayaśvāsakāsārocakapīḍitāḥ | pravṛddhapūyarudhirā vraṇā yeṣāṃ ca
+                        marmasu ||20|| </l>
 
                     <l xml:id="SS.1.28.21">
                         <label>1938 ed. 1.28.21</label>
                         <caesura/>
-                         kriyābhiḥ samyagārabdhā na siddhyanti ca ye vraṇāḥ |
-                        varjayettānapi prājñaḥ saṃrakṣannātmano yaśaḥ ||21|| </l>
+                         kriyābhiḥ samyagārabdhā na siddhyanti ca ye vraṇāḥ | varjayettānapi prājñaḥ
+                        saṃrakṣannātmano yaśaḥ ||21|| </l>
 
                     <l xml:id="SS.1.28.trailer">
                         <label>1938 ed. 1.28.trailer</label>
@@ -6287,44 +6302,44 @@
                     <l xml:id="SS.1.29.3">
                         <label>1938 ed. 1.29.3</label>
                         <caesura/>
-                         dūtadarśanasambhāṣā veṣāśceṣṭitam eva ca | ṛkṣaṃ velā tithiś
-                        caiva nimittaṃ śakuno 'nilaḥ ||3|| </l>
+                         dūtadarśanasambhāṣā veṣāśceṣṭitam eva ca | ṛkṣaṃ velā tithiś caiva nimittaṃ
+                        śakuno 'nilaḥ ||3|| </l>
 
                     <l xml:id="SS.1.29.4">
                         <label>1938 ed. 1.29.4</label>
                         <caesura/>
-                         deśo vaidyasya vāgdehamanasāṃ ca viceṣṭitam | kathayanty
-                        āturagataṃ śubhaṃ vā yadi vā'śubham ||4|| </l>
+                         deśo vaidyasya vāgdehamanasāṃ ca viceṣṭitam | kathayanty āturagataṃ śubhaṃ
+                        vā yadi vā'śubham ||4|| </l>
 
                     <l xml:id="SS.1.29.5">
                         <label>1938 ed. 1.29.5</label>
                         <caesura/>
-                         pākha(ṣa)ṇḍāśramavarṇānāṃ sapakṣāḥ karmasiddhaye | ta eva
-                        viparītāḥ syurdūtāḥ karmavipattaye ||5|| </l>
+                         pākha(ṣa)ṇḍāśramavarṇānāṃ sapakṣāḥ karmasiddhaye | ta eva viparītāḥ
+                        syurdūtāḥ karmavipattaye ||5|| </l>
 
                     <l xml:id="SS.1.29.6">
                         <label>1938 ed. 1.29.6</label>
                         <caesura/>
-                         napuṃsakaṃ strī bahavo naikakāryā asūyakāḥ |
-                        gardabhoṣṭrarathaprāptāḥ prāptā vā syuḥ paramparāḥ ||6||</l>
+                         napuṃsakaṃ strī bahavo naikakāryā asūyakāḥ | gardabhoṣṭrarathaprāptāḥ
+                        prāptā vā syuḥ paramparāḥ ||6||</l>
 
                     <l xml:id="SS.1.29.7">
                         <label>1938 ed. 1.29.7</label>
                         <caesura/>
-                         vaidyaṃ ya upasarpanti dūtāste cāpi garhitāḥ |
-                        pāśadaṇḍāyudhadharāḥ pāṇḍuretaravāsasaḥ ||7|| </l>
+                         vaidyaṃ ya upasarpanti dūtāste cāpi garhitāḥ | pāśadaṇḍāyudhadharāḥ
+                        pāṇḍuretaravāsasaḥ ||7|| </l>
 
                     <l xml:id="SS.1.29.8">
                         <label>1938 ed. 1.29.8</label>
                         <caesura/>
-                         ārdrajīrṇāpasavyaikamalinoddhvastavāsasaḥ | nyūnādhikāṅgā udvignā
-                        vikṛtā raudrarūpiṇaḥ ||8|| </l>
+                         ārdrajīrṇāpasavyaikamalinoddhvastavāsasaḥ | nyūnādhikāṅgā udvignā vikṛtā
+                        raudrarūpiṇaḥ ||8|| </l>
 
                     <l xml:id="SS.1.29.9">
                         <label>1938 ed. 1.29.9</label>
                         <caesura/>
-                         rūkṣaniṣṭhuravaktārastvamaṅgalyābhidhāyinaḥ |
-                        chindantastṛṇakāṣṭhāni spṛśanto nāsikāṃ stanam ||9|| </l>
+                         rūkṣaniṣṭhuravaktārastvamaṅgalyābhidhāyinaḥ | chindantastṛṇakāṣṭhāni
+                        spṛśanto nāsikāṃ stanam ||9|| </l>
 
                     <l xml:id="SS.1.29.10">
                         <label>1938 ed. 1.29.10</label>
@@ -6335,40 +6350,39 @@
                     <l xml:id="SS.1.29.11">
                         <label>1938 ed. 1.29.11</label>
                         <caesura/>
-                         kapālopalabhasmāsthituṣāṅgārakarāś ca ye | vilikhanto mahīṃ
-                        kiñcinmuñcanto loṣṭabhedinaḥ ||11|| </l>
+                         kapālopalabhasmāsthituṣāṅgārakarāś ca ye | vilikhanto mahīṃ kiñcinmuñcanto
+                        loṣṭabhedinaḥ ||11|| </l>
 
                     <l xml:id="SS.1.29.12">
                         <label>1938 ed. 1.29.12</label>
                         <caesura/>
-                         tailakardamadigdhāṅgā raktasraganulepanāḥ | phalaṃ pakvamasāraṃ
-                        vā gṛhītvā'nyac ca tadvidham ||12|| </l>
+                         tailakardamadigdhāṅgā raktasraganulepanāḥ | phalaṃ pakvamasāraṃ vā
+                        gṛhītvā'nyac ca tadvidham ||12|| </l>
 
                     <l xml:id="SS.1.29.13">
                         <label>1938 ed. 1.29.13</label>
                         <caesura/>
-                         nakhairnakhāntaraṃ vā'pi kareṇa caraṇaṃ tathā | upānaccarmahastā
-                        vā vikṛtavyādhipīḍitāḥ ||13|| </l>
+                         nakhairnakhāntaraṃ vā'pi kareṇa caraṇaṃ tathā | upānaccarmahastā vā
+                        vikṛtavyādhipīḍitāḥ ||13|| </l>
 
                     <l xml:id="SS.1.29.14">
                         <label>1938 ed. 1.29.14</label>
                         <caesura/>
-                         vāmācārā rudantaś ca śvāsino vikṛtekṣaṇāḥ | yāmyāṃ diśi
-                        prāñjalayo viṣamaikapade sthitāḥ ||14|| </l>
+                         vāmācārā rudantaś ca śvāsino vikṛtekṣaṇāḥ | yāmyāṃ diśi prāñjalayo
+                        viṣamaikapade sthitāḥ ||14|| </l>
 
                     <l xml:id="SS.1.29.15">
                         <label>1938 ed. 1.29.15</label>
                         <caesura/>
-                         vaidyaṃ ya upasarpanti dūtāste cāpi garhitāḥ | dakṣiṇābhimukhaṃ
-                        deśe tvaśucau vā hutāśanam | jvalayantaṃ pacantaṃ vā krūrakarmaṇi
-                        codyatam ||15|| </l>
+                         vaidyaṃ ya upasarpanti dūtāste cāpi garhitāḥ | dakṣiṇābhimukhaṃ deśe
+                        tvaśucau vā hutāśanam | jvalayantaṃ pacantaṃ vā krūrakarmaṇi codyatam ||15|| </l>
 
 
                     <l xml:id="SS.1.29.16">
                         <label>1938 ed. 1.29.16</label>
                         <caesura/>
-                         nagnaṃ bhūmau śayānaṃ vā vegotsargeṣu vā'śucim |
-                        prakīrṇakeśamabhyaktaṃ svinnaṃ viklavam eva vā ||16|| </l>
+                         nagnaṃ bhūmau śayānaṃ vā vegotsargeṣu vā'śucim | prakīrṇakeśamabhyaktaṃ
+                        svinnaṃ viklavam eva vā ||16|| </l>
 
                     <l xml:id="SS.1.29.17">
                         <label>1938 ed. 1.29.17</label>
@@ -6387,20 +6401,20 @@
                     <l xml:id="SS.1.29.19">
                         <label>1938 ed. 1.29.19</label>
                         <caesura/>
-                         caturthyāṃ vā navamyāṃ vā ṣaṣṭhyāṃ sandhidineṣu ca | vaidyaṃ ya
-                        upasarpanti dūtāste cāpi garhitāḥ ||19|| </l>
+                         caturthyāṃ vā navamyāṃ vā ṣaṣṭhyāṃ sandhidineṣu ca | vaidyaṃ ya upasarpanti
+                        dūtāste cāpi garhitāḥ ||19|| </l>
 
                     <l xml:id="SS.1.29.20">
                         <label>1938 ed. 1.29.20</label>
                         <caesura/>
-                         svinnābhitaptā madhyāhne jvalanasya samīpataḥ | garhitāḥ
-                        pittarogeṣu dūtā vaidyam upāgatāḥ ||20|| </l>
+                         svinnābhitaptā madhyāhne jvalanasya samīpataḥ | garhitāḥ pittarogeṣu dūtā
+                        vaidyam upāgatāḥ ||20|| </l>
 
                     <l xml:id="SS.1.29.21">
                         <label>1938 ed. 1.29.21</label>
                         <caesura/>
-                         ta eva kapharogeṣu karmasiddhikarāḥ smṛtāḥ | etena śeṣaṃ
-                        vyākhyātaṃ buddhvā saṃvibhajet tu tat ||21|| </l>
+                         ta eva kapharogeṣu karmasiddhikarāḥ smṛtāḥ | etena śeṣaṃ vyākhyātaṃ buddhvā
+                        saṃvibhajet tu tat ||21|| </l>
 
                     <l xml:id="SS.1.29.22">
                         <label>1938 ed. 1.29.22</label>
@@ -6418,34 +6432,33 @@
                     <l xml:id="SS.1.29.24">
                         <label>1938 ed. 1.29.24</label>
                         <caesura/>
-                         svasyāṃ jātau svagotro vā dūtaḥ kāryakaraḥ smṛtaḥ |
-                        goyānenāgatastuṣṭaḥ pādābhyāṃ śubhaceṣṭitaḥ ||24|| </l>
+                         svasyāṃ jātau svagotro vā dūtaḥ kāryakaraḥ smṛtaḥ | goyānenāgatastuṣṭaḥ
+                        pādābhyāṃ śubhaceṣṭitaḥ ||24|| </l>
 
                     <l xml:id="SS.1.29.25">
                         <label>1938 ed. 1.29.25</label>
                         <caesura/>
-                         smṛtimān vidhikālajñaḥ svatantraḥ pratipattimān | alaṅkṛto
-                        maṅgalavān dūtaḥ kāryakaraḥ smṛtaḥ ||25|| svasthaṃ
-                        prāṅmukhamāsīnaṃ same deśe śucau śucim | upasarpati yo vaidyaṃ sa
-                        ca kāryakaraḥ smṛtaḥ ||26|| </l>
+                         smṛtimān vidhikālajñaḥ svatantraḥ pratipattimān | alaṅkṛto maṅgalavān dūtaḥ
+                        kāryakaraḥ smṛtaḥ ||25|| svasthaṃ prāṅmukhamāsīnaṃ same deśe śucau śucim |
+                        upasarpati yo vaidyaṃ sa ca kāryakaraḥ smṛtaḥ ||26|| </l>
 
                     <l xml:id="SS.1.29.27">
                         <label>1938 ed. 1.29.27</label>
                         <caesura/>
-                         māṃsodakumbhātapatravipravāraṇagovṛṣāḥ | śuklavarṇāś ca pūjyante
-                        prasthāne darśanaṃ gatāḥ ||27|| </l>
+                         māṃsodakumbhātapatravipravāraṇagovṛṣāḥ | śuklavarṇāś ca pūjyante prasthāne
+                        darśanaṃ gatāḥ ||27|| </l>
 
                     <l xml:id="SS.1.29.28">
                         <label>1938 ed. 1.29.28</label>
                         <caesura/>
-                         strī putriṇī savatsā gaurvardhamānamalaṅkṛtā | kanyā matsyāḥ
-                        phalaṃ cāmaṃ svastikaṃ modakā dadhi ||28|| </l>
+                         strī putriṇī savatsā gaurvardhamānamalaṅkṛtā | kanyā matsyāḥ phalaṃ cāmaṃ
+                        svastikaṃ modakā dadhi ||28|| </l>
 
                     <l xml:id="SS.1.29.29">
                         <label>1938 ed. 1.29.29</label>
                         <caesura/>
-                         hiraṇyākṣatapātraṃ vā ratnāni sumano nṛpaḥ | apraśānto 'nalo vājī
-                        haṃsaś cāpaḥ śikhī tathā ||29|| </l>
+                         hiraṇyākṣatapātraṃ vā ratnāni sumano nṛpaḥ | apraśānto 'nalo vājī haṃsaś
+                        cāpaḥ śikhī tathā ||29|| </l>
 
                     <l xml:id="SS.1.29.30">
                         <label>1938 ed. 1.29.30</label>
@@ -6456,8 +6469,8 @@
                     <l xml:id="SS.1.29.31">
                         <label>1938 ed. 1.29.31</label>
                         <caesura/>
-                         śastaṃ haṃsarutaṃ nṝṇāṃ kauśikaṃ caiva vāmataḥ | prasthāne
-                        yāyinaḥ śreṣṭhā vācaś ca hṛdayaṅgamāḥ ||31|| </l>
+                         śastaṃ haṃsarutaṃ nṝṇāṃ kauśikaṃ caiva vāmataḥ | prasthāne yāyinaḥ śreṣṭhā
+                        vācaś ca hṛdayaṅgamāḥ ||31|| </l>
 
                     <l xml:id="SS.1.29.32">
                         <label>1938 ed. 1.29.32</label>
@@ -6468,8 +6481,8 @@
                     <l xml:id="SS.1.29.33">
                         <label>1938 ed. 1.29.33</label>
                         <caesura/>
-                         dikṣu śāntāsu vaktāro madhuraṃ pṛṣṭhato 'nugāḥ | vāmā vā dakṣiṇā
-                        vā'pi śakunāḥ karmasiddhaye ||33|| </l>
+                         dikṣu śāntāsu vaktāro madhuraṃ pṛṣṭhato 'nugāḥ | vāmā vā dakṣiṇā vā'pi
+                        śakunāḥ karmasiddhaye ||33|| </l>
 
                     <l xml:id="SS.1.29.34">
                         <label>1938 ed. 1.29.34</label>
@@ -6480,21 +6493,20 @@
                     <l xml:id="SS.1.29.35">
                         <label>1938 ed. 1.29.35</label>
                         <caesura/>
-                         caity avalmīkaviṣamasthitā dīptakharasvarāḥ | purato dikṣu
-                        dīptāsu vaktāro nārthasādhakāḥ ||35|| </l>
+                         caity avalmīkaviṣamasthitā dīptakharasvarāḥ | purato dikṣu dīptāsu vaktāro
+                        nārthasādhakāḥ ||35|| </l>
 
                     <l xml:id="SS.1.29.36">
                         <label>1938 ed. 1.29.36</label>
                         <caesura/>
-                         punnāmānaḥ khagā vāmāḥ strīsañjñā dakṣiṇāḥ śubhāḥ |
-                        dakṣiṇādvāmagamanaṃ praśastaṃ śvaśṛgālayoḥ | vāmaṃ nakulacāṣāṇāṃ
-                        nobhayaṃ śaśasarpayoḥ ||36|| </l>
+                         punnāmānaḥ khagā vāmāḥ strīsañjñā dakṣiṇāḥ śubhāḥ | dakṣiṇādvāmagamanaṃ
+                        praśastaṃ śvaśṛgālayoḥ | vāmaṃ nakulacāṣāṇāṃ nobhayaṃ śaśasarpayoḥ ||36|| </l>
 
                     <l xml:id="SS.1.29.37">
                         <label>1938 ed. 1.29.37</label>
                         <caesura/>
-                         bhāsakauśikayoś caiva na praśastaṃ kilobhayam | darśanaṃ vā rutaṃ
-                        vā'pi na godhākṛkalāsayoḥ ||37|| </l>
+                         bhāsakauśikayoś caiva na praśastaṃ kilobhayam | darśanaṃ vā rutaṃ vā'pi na
+                        godhākṛkalāsayoḥ ||37|| </l>
 
                     <l xml:id="SS.1.29.38">
                         <label>1938 ed. 1.29.38</label>
@@ -6505,8 +6517,8 @@
                     <l xml:id="SS.1.29.39">
                         <label>1938 ed. 1.29.39</label>
                         <caesura/>
-                         pātraṃ neṣṭaṃ tathā'ṅgāratailakardamapūritam |
-                        prasannetaramadyānāṃ pūrṇaṃ vā raktasarṣapaiḥ ||39|| </l>
+                         pātraṃ neṣṭaṃ tathā'ṅgāratailakardamapūritam | prasannetaramadyānāṃ pūrṇaṃ
+                        vā raktasarṣapaiḥ ||39|| </l>
 
                     <l xml:id="SS.1.29.40">
                         <label>1938 ed. 1.29.40</label>
@@ -6517,74 +6529,74 @@
                     <l xml:id="SS.1.29.41">
                         <label>1938 ed. 1.29.41</label>
                         <caesura/>
-                         mṛduḥ śīto 'nukūlaś ca sugandhiś cānilaḥ śubhaḥ | kharoṣṇo
-                        'niṣṭagandhaś ca pratilomaś ca garhitaḥ ||41|| </l>
+                         mṛduḥ śīto 'nukūlaś ca sugandhiś cānilaḥ śubhaḥ | kharoṣṇo 'niṣṭagandhaś ca
+                        pratilomaś ca garhitaḥ ||41|| </l>
 
                     <l xml:id="SS.1.29.42">
                         <label>1938 ed. 1.29.42</label>
                         <caesura/>
-                         granthyarbudādiṣu sadā chedaśabdas tu pūjitaḥ |
-                        vidradhyudaragulmeṣu bhedaśabdas tathaiva ca ||42|| </l>
+                         granthyarbudādiṣu sadā chedaśabdas tu pūjitaḥ | vidradhyudaragulmeṣu
+                        bhedaśabdas tathaiva ca ||42|| </l>
 
                     <l xml:id="SS.1.29.43">
                         <label>1938 ed. 1.29.43</label>
                         <caesura/>
-                         raktapittātisāreṣu ruddhaśabdaḥ praśasyate | evaṃ vyādhiviśeṣeṇa
-                        nimittam upadhārayet ||43|| </l>
+                         raktapittātisāreṣu ruddhaśabdaḥ praśasyate | evaṃ vyādhiviśeṣeṇa nimittam
+                        upadhārayet ||43|| </l>
 
                     <l xml:id="SS.1.29.44">
                         <label>1938 ed. 1.29.44</label>
                         <caesura/>
-                         tathaivākruṣṭahākaṣṭamākrandaruditasvanāḥ | chardyāṃ
-                        vātapurīṣāṇāṃ śabdo vai gardabhoṣṭrayoḥ ||44|| </l>
+                         tathaivākruṣṭahākaṣṭamākrandaruditasvanāḥ | chardyāṃ vātapurīṣāṇāṃ śabdo
+                        vai gardabhoṣṭrayoḥ ||44|| </l>
 
                     <l xml:id="SS.1.29.45">
                         <label>1938 ed. 1.29.45</label>
                         <caesura/>
-                         pratiṣiddhaṃ tathā bhagnaṃ kṣutaṃ skhalitamāhatam | daurmanasyaṃ
-                        ca vaidyasya yātrāyāṃ na praśasyate ||45|| </l>
+                         pratiṣiddhaṃ tathā bhagnaṃ kṣutaṃ skhalitamāhatam | daurmanasyaṃ ca
+                        vaidyasya yātrāyāṃ na praśasyate ||45|| </l>
 
                     <l xml:id="SS.1.29.46">
                         <label>1938 ed. 1.29.46</label>
                         <caesura/>
-                         praveśe 'pyetaduddeśādavekṣyaṃ ca tathā''ture | pratidvāraṃ gṛhe
-                        cāsya punaretanna gaṇyate ||46|| </l>
+                         praveśe 'pyetaduddeśādavekṣyaṃ ca tathā''ture | pratidvāraṃ gṛhe cāsya
+                        punaretanna gaṇyate ||46|| </l>
 
                     <l xml:id="SS.1.29.47">
                         <label>1938 ed. 1.29.47</label>
                         <caesura/>
-                         keśabhasmāsthikāṣṭhāśmatuṣakārpāsakaṇṭakāḥ | khaṭvordhvapādā
-                        madyāpo vasā tailaṃ tilāstṛṇam ||47|| </l>
+                         keśabhasmāsthikāṣṭhāśmatuṣakārpāsakaṇṭakāḥ | khaṭvordhvapādā madyāpo vasā
+                        tailaṃ tilāstṛṇam ||47|| </l>
 
                     <l xml:id="SS.1.29.48">
                         <label>1938 ed. 1.29.48</label>
                         <caesura/>
-                         napuṃsakavyaṅgabhagnanagnamuṇḍāsitāmbarāḥ | prasthāne vā praveśe
-                        vā neṣyante darśanaṃ gatāḥ ||48|| </l>
+                         napuṃsakavyaṅgabhagnanagnamuṇḍāsitāmbarāḥ | prasthāne vā praveśe vā
+                        neṣyante darśanaṃ gatāḥ ||48|| </l>
 
                     <l xml:id="SS.1.29.49">
                         <label>1938 ed. 1.29.49</label>
                         <caesura/>
-                         bhāṇḍānāṃ saṅkarasthānāṃ sthānāt sañcāraṇaṃ tathā |
-                        nikhātotpāṭanaṃ bhaṅgaḥ patanaṃ nirgamas tathā ||49|| </l>
+                         bhāṇḍānāṃ saṅkarasthānāṃ sthānāt sañcāraṇaṃ tathā | nikhātotpāṭanaṃ bhaṅgaḥ
+                        patanaṃ nirgamas tathā ||49|| </l>
 
                     <l xml:id="SS.1.29.50">
                         <label>1938 ed. 1.29.50</label>
                         <caesura/>
-                         vaidyāsanāvasādo vā rogī vā syādadhomukhaḥ | vaidyaṃ sambhāṣamāṇo
-                        'ṅgaṃ kuḍyamāstaraṇāni vā ||50||</l>
+                         vaidyāsanāvasādo vā rogī vā syādadhomukhaḥ | vaidyaṃ sambhāṣamāṇo 'ṅgaṃ
+                        kuḍyamāstaraṇāni vā ||50||</l>
 
                     <l xml:id="SS.1.29.51">
                         <label>1938 ed. 1.29.51</label>
                         <caesura/>
-                         pramṛjyādvā dhunīyādvā karau pṛṣṭhaṃ śiras tathā | hastaṃ cākṛṣya
-                        vaidyasya nyasecchirasi corasi ||51|| </l>
+                         pramṛjyādvā dhunīyādvā karau pṛṣṭhaṃ śiras tathā | hastaṃ cākṛṣya vaidyasya
+                        nyasecchirasi corasi ||51|| </l>
 
                     <l xml:id="SS.1.29.52">
                         <label>1938 ed. 1.29.52</label>
                         <caesura/>
-                         yo vaidyamunmukhaḥ paśyannunmārṣṭi svāṅgamāturaḥ | na sa sidhyati
-                        vaidyo vā gṛhe yasya na pūjyate ||52|| </l>
+                         yo vaidyamunmukhaḥ paśyannunmārṣṭi svāṅgamāturaḥ | na sa sidhyati vaidyo vā
+                        gṛhe yasya na pūjyate ||52|| </l>
 
                     <l xml:id="SS.1.29.53">
                         <label>1938 ed. 1.29.53</label>
@@ -6604,80 +6616,80 @@
                     <l xml:id="SS.1.29.55">
                         <label>1938 ed. 1.29.55</label>
                         <caesura/>
-                         suhṛdo yāṃś ca paśyanti vyādhito vā svayaṃ tathā |
-                        snehābhyaktaśarīras tu karabhavyālagardabhaiḥ ||55||</l>
+                         suhṛdo yāṃś ca paśyanti vyādhito vā svayaṃ tathā | snehābhyaktaśarīras tu
+                        karabhavyālagardabhaiḥ ||55||</l>
 
                     <l xml:id="SS.1.29.56">
                         <label>1938 ed. 1.29.56</label>
                         <caesura/>
-                         varāhair mahiṣair vā'pi yo yāyād dakṣiṇāmukhaḥ | raktāmbaradharā
-                        kṛṣṇā hasantī muktamūrdhajā ||56|| </l>
+                         varāhair mahiṣair vā'pi yo yāyād dakṣiṇāmukhaḥ | raktāmbaradharā kṛṣṇā
+                        hasantī muktamūrdhajā ||56|| </l>
 
                     <l xml:id="SS.1.29.57">
                         <label>1938 ed. 1.29.57</label>
                         <caesura/>
-                         yaṃ cākarṣati baddhvā strī nṛtyantī dakṣiṇāmukham |
-                        antāvasāyibhir yo vā''kṛṣyate dakṣiṇāmukhaḥ ||57||</l>
+                         yaṃ cākarṣati baddhvā strī nṛtyantī dakṣiṇāmukham | antāvasāyibhir yo
+                        vā''kṛṣyate dakṣiṇāmukhaḥ ||57||</l>
 
                     <l xml:id="SS.1.29.58">
                         <label>1938 ed. 1.29.58</label>
                         <caesura/>
-                         pariṣvajeran yaṃ vā'pi pretāḥ pravrajitā(na)s tathā |
-                        muhurāghrāyate yas tu śvāpadairvikṛtānanaiḥ ||58||</l>
+                         pariṣvajeran yaṃ vā'pi pretāḥ pravrajitā(na)s tathā | muhurāghrāyate yas tu
+                        śvāpadairvikṛtānanaiḥ ||58||</l>
 
                     <l xml:id="SS.1.29.59">
                         <label>1938 ed. 1.29.59</label>
                         <caesura/>
-                         pibenmadhu ca tailaṃ ca yo vā paṅke 'vasīdati |
-                        paṅkapradigdhagātro vā pranṛtyet prahasettathā ||59||</l>
+                         pibenmadhu ca tailaṃ ca yo vā paṅke 'vasīdati | paṅkapradigdhagātro vā
+                        pranṛtyet prahasettathā ||59||</l>
 
                     <l xml:id="SS.1.29.60">
                         <label>1938 ed. 1.29.60</label>
                         <caesura/>
-                         nirambaraś ca yo raktāṃ dhārayecchirasā srajam | yasya vaṃśo nalo
-                        vā'pi tālo vorasi jāyate ||60||</l>
+                         nirambaraś ca yo raktāṃ dhārayecchirasā srajam | yasya vaṃśo nalo vā'pi
+                        tālo vorasi jāyate ||60||</l>
 
                     <l xml:id="SS.1.29.61">
                         <label>1938 ed. 1.29.61</label>
                         <caesura/>
-                         yaṃ vā matsyo grasedyo vā jananīṃ praviśen naraḥ | parvatāgrāt
-                        patedyo vā śvabhre vā tamasā''vṛte ||61||</l>
+                         yaṃ vā matsyo grasedyo vā jananīṃ praviśen naraḥ | parvatāgrāt patedyo vā
+                        śvabhre vā tamasā''vṛte ||61||</l>
 
                     <l xml:id="SS.1.29.62">
                         <label>1938 ed. 1.29.62</label>
                         <caesura/>
-                         hriyeta srotasā yo vā yo vā mauṇḍyamavāpnuyāt | parājīyeta
-                        badhyeta kākādyair vā'bhibhūyate ||62|| </l>
+                         hriyeta srotasā yo vā yo vā mauṇḍyamavāpnuyāt | parājīyeta badhyeta
+                        kākādyair vā'bhibhūyate ||62|| </l>
 
                     <l xml:id="SS.1.29.63">
                         <label>1938 ed. 1.29.63</label>
                         <caesura/>
-                         patanaṃ tārakādīnāṃ praṇāśaṃ dīpacakṣuṣoḥ | yaḥ paśyeddevatānāṃ
-                        vā prakampamavanes tathā ||63||</l>
+                         patanaṃ tārakādīnāṃ praṇāśaṃ dīpacakṣuṣoḥ | yaḥ paśyeddevatānāṃ vā
+                        prakampamavanes tathā ||63||</l>
 
                     <l xml:id="SS.1.29.64">
                         <label>1938 ed. 1.29.64</label>
                         <caesura/>
-                         yasya chardirvireko vā daśanāḥ prapatanti vā | śālmalīṃ kiṃśukaṃ
-                        yūpaṃ valmīkaṃ pāribhadrakam ||64|| </l>
+                         yasya chardirvireko vā daśanāḥ prapatanti vā | śālmalīṃ kiṃśukaṃ yūpaṃ
+                        valmīkaṃ pāribhadrakam ||64|| </l>
 
                     <l xml:id="SS.1.29.65">
                         <label>1938 ed. 1.29.65</label>
                         <caesura/>
-                         puṣpāḍhyaṃ kovidāraṃ vā citāṃ vā yo 'dhirohati |
-                        kārpāsatailapiṇyākalohāni lavaṇaṃ tilān ||65||</l>
+                         puṣpāḍhyaṃ kovidāraṃ vā citāṃ vā yo 'dhirohati | kārpāsatailapiṇyākalohāni
+                        lavaṇaṃ tilān ||65||</l>
 
                     <l xml:id="SS.1.29.66">
                         <label>1938 ed. 1.29.66</label>
                         <caesura/>
-                         labhetāśnīta vā pakvamannaṃ yaś ca pibet surām | svasthaḥ sa
-                        labhate vyādhiṃ vyādhito mṛtyumṛcchati ||66||</l>
+                         labhetāśnīta vā pakvamannaṃ yaś ca pibet surām | svasthaḥ sa labhate
+                        vyādhiṃ vyādhito mṛtyumṛcchati ||66||</l>
 
                     <l xml:id="SS.1.29.67">
                         <label>1938 ed. 1.29.67</label>
                         <caesura/>
-                         yathāsvaṃ prakṛtisvapno vismṛto vihatas tathā | cintākṛto divā
-                        dṛṣṭo bhavantyaphaladās tu te ||67|| </l>
+                         yathāsvaṃ prakṛtisvapno vismṛto vihatas tathā | cintākṛto divā dṛṣṭo
+                        bhavantyaphaladās tu te ||67|| </l>
 
                     <l xml:id="SS.1.29.68">
                         <label>1938 ed. 1.29.68</label>
@@ -6688,8 +6700,8 @@
                     <l xml:id="SS.1.29.69">
                         <label>1938 ed. 1.29.69</label>
                         <caesura/>
-                         mehātisāriṇāṃ toyapānaṃ snehasya kuṣṭhinām | gulmeṣu
-                        sthāvarotpattiḥ koṣṭhe, mūrdhni śiroruji ||69|| </l>
+                         mehātisāriṇāṃ toyapānaṃ snehasya kuṣṭhinām | gulmeṣu sthāvarotpattiḥ
+                        koṣṭhe, mūrdhni śiroruji ||69|| </l>
 
                     <l xml:id="SS.1.29.70">
                         <label>1938 ed. 1.29.70</label>
@@ -6699,48 +6711,47 @@
                          hāridraṃ bhojanaṃ vā'pi yasya syāt pāṇḍurogiṇaḥ ||70|| </l>
 
                     <l xml:id="SS.1.29.71">
-                        <label>1938 ed. 1.29.71</label>
-                         raktapittī pibedyas tu śoṇitaṃ sa vinaśyati
+                        <label>1938 ed. 1.29.71</label> raktapittī pibedyas tu śoṇitaṃ sa vinaśyati
                         <caesura/>
                          svapnānevaṃvidhān dṛṣṭvā prātarutthāya yatnavān ||71|| </l>
 
                     <l xml:id="SS.1.29.72">
                         <label>1938 ed. 1.29.72</label>
                         <caesura/>
-                         dadyānmāṣāṃstilāṃllohaṃ viprebhyaḥ kāñcanaṃ tathā | japec cāpi
-                        śubhān mantrān gāyatrīṃ tripadāṃ tathā ||72|| </l>
+                         dadyānmāṣāṃstilāṃllohaṃ viprebhyaḥ kāñcanaṃ tathā | japec cāpi śubhān
+                        mantrān gāyatrīṃ tripadāṃ tathā ||72|| </l>
 
                     <l xml:id="SS.1.29.73">
                         <label>1938 ed. 1.29.73</label>
                         <caesura/>
-                         dṛṣṭvā tu prathame yāme svapyād dhyātvā punaḥ śubham |
-                        japedvā'nyatamaṃ vedaṃ brahmacārī samāhitaḥ ||73|| </l>
+                         dṛṣṭvā tu prathame yāme svapyād dhyātvā punaḥ śubham | japedvā'nyatamaṃ
+                        vedaṃ brahmacārī samāhitaḥ ||73|| </l>
 
                     <l xml:id="SS.1.29.74">
                         <label>1938 ed. 1.29.74</label>
                         <caesura/>
-                         na cācakṣīta kasmaiciddṛṣṭvā svapnamaśobhanam | devatāyatane
-                        caiva vasedrātritrayaṃ tathā | viprāṃśca pūjayennityaṃ duḥsvapnāt
-                        pravimucyate ||74|| </l>
+                         na cācakṣīta kasmaiciddṛṣṭvā svapnamaśobhanam | devatāyatane caiva
+                        vasedrātritrayaṃ tathā | viprāṃśca pūjayennityaṃ duḥsvapnāt pravimucyate
+                        ||74|| </l>
 
                     <l xml:id="SS.1.29.75">
                         <label>1938 ed. 1.29.75</label>
                         <caesura/>
-                         ata ūrdhvaṃ pravakṣyāmi praśastaṃ svapnadarśanam | devān
-                        dvijāngovṛṣabhān jīvataḥ suhṛdo nṛpān ||75|| </l>
+                         ata ūrdhvaṃ pravakṣyāmi praśastaṃ svapnadarśanam | devān dvijāngovṛṣabhān
+                        jīvataḥ suhṛdo nṛpān ||75|| </l>
 
 
                     <l xml:id="SS.1.29.76">
                         <label>1938 ed. 1.29.76</label>
                         <caesura/>
-                         samiddhamagniṃ sādhūṃś ca nirmalāni jalāni ca | paśyet
-                        kalyāṇalābhāya vyādherapagamāya ca ||76|| </l>
+                         samiddhamagniṃ sādhūṃś ca nirmalāni jalāni ca | paśyet kalyāṇalābhāya
+                        vyādherapagamāya ca ||76|| </l>
 
                     <l xml:id="SS.1.29.77">
                         <label>1938 ed. 1.29.77</label>
                         <caesura/>
-                         māṃsaṃ matsyān srajaḥ śvetā vāsāṃsi ca phalāni ca | labheta
-                        dhanalābhāya vyādherapagamāya ca ||77||</l>
+                         māṃsaṃ matsyān srajaḥ śvetā vāsāṃsi ca phalāni ca | labheta dhanalābhāya
+                        vyādherapagamāya ca ||77||</l>
 
                     <l xml:id="SS.1.29.78">
                         <label>1938 ed. 1.29.78</label>
@@ -6757,21 +6768,20 @@
                     <l xml:id="SS.1.29.80">
                         <label>1938 ed. 1.29.80</label>
                         <caesura/>
-                         urago vā jalauko vā bhramaro vā'pi yaṃ daśet | ārogyaṃ
-                        nirdiśettasya dhanalābhaṃ ca buddhimān ||80||</l>
+                         urago vā jalauko vā bhramaro vā'pi yaṃ daśet | ārogyaṃ nirdiśettasya
+                        dhanalābhaṃ ca buddhimān ||80||</l>
 
                     <l xml:id="SS.1.29.81">
                         <label>1938 ed. 1.29.81</label>
                         <caesura/>
-                         evaṃ rūpāñ śubhān svapnān yaḥ paśyedvyādhito naraḥ | sa
-                        dīrghāyuriti jñeyastasmai karma samācaret ||81||</l>
+                         evaṃ rūpāñ śubhān svapnān yaḥ paśyedvyādhito naraḥ | sa dīrghāyuriti
+                        jñeyastasmai karma samācaret ||81||</l>
 
                     <l xml:id="SS.1.29.trailer">
                         <label>1938 ed. 1.29.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne
-                        viparītāviparītasvapnanidarśanīyo nāmaikonatriṃśattamo 'dhyāyaḥ
-                        ||29|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne viparītāviparītasvapnanidarśanīyo
+                        nāmaikonatriṃśattamo 'dhyāyaḥ ||29|| </l>
                 </div>
 
 
@@ -6780,44 +6790,44 @@
                     <l xml:id="SS.1.30.3">
                         <label>1938 ed. 1.30.3</label>
                         <caesura/>
-                         śarīraśīlayor yasya prakṛtervikṛtirbhavet | tattvariṣṭaṃ
-                        samāsena, vyāsatas tu nibodha me ||3|| </l>
+                         śarīraśīlayor yasya prakṛtervikṛtirbhavet | tattvariṣṭaṃ samāsena, vyāsatas
+                        tu nibodha me ||3|| </l>
 
                     <l xml:id="SS.1.30.4">
                         <label>1938 ed. 1.30.4</label>
                         <caesura/>
-                         śṛṇoti vividhāñ śabdān yo divyānāmabhāvataḥ |
-                        samudrapurameghānāmasampattau ca niḥsvanān ||4|| </l>
+                         śṛṇoti vividhāñ śabdān yo divyānāmabhāvataḥ | samudrapurameghānāmasampattau
+                        ca niḥsvanān ||4|| </l>
 
                     <l xml:id="SS.1.30.5">
                         <label>1938 ed. 1.30.5</label>
                         <caesura/>
-                         tān svanānnāvagṛhṇāti manyate cānyaśabdavat | grāmyāraṇyasvanāṃś
-                        cāpi viparītāñ śṛṇoti ca ||5||</l>
+                         tān svanānnāvagṛhṇāti manyate cānyaśabdavat | grāmyāraṇyasvanāṃś cāpi
+                        viparītāñ śṛṇoti ca ||5||</l>
 
                     <l xml:id="SS.1.30.6">
                         <label>1938 ed. 1.30.6</label>
                         <caesura/>
-                         dviṣacchabdeṣu ramate suhṛcchabdeṣu kupyati | na śṛṇoti ca yo
-                        'kasmāttaṃ bruvanti gatāyuṣam ||6|| </l>
+                         dviṣacchabdeṣu ramate suhṛcchabdeṣu kupyati | na śṛṇoti ca yo 'kasmāttaṃ
+                        bruvanti gatāyuṣam ||6|| </l>
 
                     <l xml:id="SS.1.30.7">
                         <label>1938 ed. 1.30.7</label>
                         <caesura/>
-                         yastūṣṇam iva gṛhṇāti śītamuṣṇaṃ ca śītavat | sañjātaśītapiḍako
-                        yaś ca dāhena pīḍyate ||7|| </l>
+                         yastūṣṇam iva gṛhṇāti śītamuṣṇaṃ ca śītavat | sañjātaśītapiḍako yaś ca
+                        dāhena pīḍyate ||7|| </l>
 
                     <l xml:id="SS.1.30.8">
                         <label>1938 ed. 1.30.8</label>
                         <caesura/>
-                         uṣṇagātro 'timātraṃ ca yaḥ śītena pravepate | prahārānnābhijānāti
-                        yo 'ṅgacchedamathāpi vā ||8|| </l>
+                         uṣṇagātro 'timātraṃ ca yaḥ śītena pravepate | prahārānnābhijānāti yo
+                        'ṅgacchedamathāpi vā ||8|| </l>
 
                     <l xml:id="SS.1.30.9">
                         <label>1938 ed. 1.30.9</label>
                         <caesura/>
-                         pāṃśunevāvakīrṇāni yaś ca gātrāṇi manyate | varṇānyatā vā rājyo
-                        vā yasya gātre bhavanti hi ||9|| </l>
+                         pāṃśunevāvakīrṇāni yaś ca gātrāṇi manyate | varṇānyatā vā rājyo vā yasya
+                        gātre bhavanti hi ||9|| </l>
 
                     <l xml:id="SS.1.30.10">
                         <label>1938 ed. 1.30.10</label>
@@ -6829,26 +6839,26 @@
                     <l xml:id="SS.1.30.11">
                         <label>1938 ed. 1.30.11</label>
                         <caesura/>
-                         viparītena gṛhṇāti rasān yaścopayojitān | upayuktāḥ kramādyasya
-                        rasā doṣābhivṛddhaye ||11|| </l>
+                         viparītena gṛhṇāti rasān yaścopayojitān | upayuktāḥ kramādyasya rasā
+                        doṣābhivṛddhaye ||11|| </l>
 
                     <l xml:id="SS.1.30.12">
                         <label>1938 ed. 1.30.12</label>
                         <caesura/>
-                         yasya doṣāgnisāmyaṃ ca kuryurmithyopayojitāḥ | yo vā rasānna
-                        saṃvetti gatāsuṃ taṃ pracakṣate ||12|| </l>
+                         yasya doṣāgnisāmyaṃ ca kuryurmithyopayojitāḥ | yo vā rasānna saṃvetti
+                        gatāsuṃ taṃ pracakṣate ||12|| </l>
 
                     <l xml:id="SS.1.30.13">
                         <label>1938 ed. 1.30.13</label>
                         <caesura/>
-                         sugandhaṃ vetti durgandhaṃ durgandhasya sugandhitām | gṛhṇīte
-                        vā'nyathā gandhaṃ śānte dīpe ca nīrujaḥ ||13|| </l>
+                         sugandhaṃ vetti durgandhaṃ durgandhasya sugandhitām | gṛhṇīte vā'nyathā
+                        gandhaṃ śānte dīpe ca nīrujaḥ ||13|| </l>
 
                     <l xml:id="SS.1.30.14">
                         <label>1938 ed. 1.30.14</label>
                         <caesura/>
-                         yo vā gandhaṃ na jānāti gatāsuṃ taṃ vinirdiśet |14|
-                        dvandvānyuṣṇahimādīni kālāvasthā diśas tathā ||14|| </l>
+                         yo vā gandhaṃ na jānāti gatāsuṃ taṃ vinirdiśet |14| dvandvānyuṣṇahimādīni
+                        kālāvasthā diśas tathā ||14|| </l>
 
                     <l xml:id="SS.1.30.15">
                         <label>1938 ed. 1.30.15</label>
@@ -6902,20 +6912,20 @@
                     <l xml:id="SS.1.30.22">
                         <label>1938 ed. 1.30.22</label>
                         <caesura/>
-                         śvakākakaṅkagṛdhrāṇāṃ pretānāṃ yakṣarakṣasām | piśācoraganāgānāṃ
-                        bhūtānāṃ vikṛtām api ||22||</l>
+                         śvakākakaṅkagṛdhrāṇāṃ pretānāṃ yakṣarakṣasām | piśācoraganāgānāṃ bhūtānāṃ
+                        vikṛtām api ||22||</l>
 
                     <l xml:id="SS.1.30.23">
                         <label>1938 ed. 1.30.23</label>
                         <caesura/>
-                         yo vā mayūrakaṇṭhābhaṃ vidhūmaṃ vahnimīkṣate | āturasya
-                        bhavenmṛtyuḥ svastho vyādhimavāpnuyāt ||23||</l>
+                         yo vā mayūrakaṇṭhābhaṃ vidhūmaṃ vahnimīkṣate | āturasya bhavenmṛtyuḥ
+                        svastho vyādhimavāpnuyāt ||23||</l>
 
                     <l xml:id="SS.1.30.trailer">
                         <label>1938 ed. 1.30.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne
-                        pañcendriyārthavipratipattirnāma triṃśo 'dhyāyaḥ ||30|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne pañcendriyārthavipratipattirnāma triṃśo
+                        'dhyāyaḥ ||30|| </l>
                 </div>
 
 
@@ -6924,14 +6934,14 @@
                     <l xml:id="SS.1.31.3">
                         <label>1938 ed. 1.31.3</label>
                         <caesura/>
-                         śyāvā lohitikā nīlā pītikā vā'pi mānavam | abhidravanti yaṃ
-                        chāyāḥ sa parāsurasaṃśayam ||3|| </l>
+                         śyāvā lohitikā nīlā pītikā vā'pi mānavam | abhidravanti yaṃ chāyāḥ sa
+                        parāsurasaṃśayam ||3|| </l>
 
                     <l xml:id="SS.1.31.4">
                         <label>1938 ed. 1.31.4</label>
                         <caesura/>
-                         hrīrapakramate yasya prabhāsmṛtidhṛtiśriyaḥ | akasmādyaṃ bhajante
-                        vā sa gatāsurasaṃśayam ||4|| </l>
+                         hrīrapakramate yasya prabhāsmṛtidhṛtiśriyaḥ | akasmādyaṃ bhajante vā sa
+                        gatāsurasaṃśayam ||4|| </l>
 
                     <l xml:id="SS.1.31.5">
                         <label>1938 ed. 1.31.5</label>
@@ -6942,32 +6952,32 @@
                     <l xml:id="SS.1.31.6">
                         <label>1938 ed. 1.31.6</label>
                         <caesura/>
-                         āraktā daśanā yasya śyāvā vā syuḥ patanti vā | khañjanapratimā
-                        vā'pi taṃ gatāyuṣam ādiśet ||6|| </l>
+                         āraktā daśanā yasya śyāvā vā syuḥ patanti vā | khañjanapratimā vā'pi taṃ
+                        gatāyuṣam ādiśet ||6|| </l>
 
                     <l xml:id="SS.1.31.7">
                         <label>1938 ed. 1.31.7</label>
                         <caesura/>
-                         kṛṣṇā stabdhā'valiptā vā jihvā śūnā ca yasya vai | karkaśā vā
-                        bhavedyasya so 'cirādvijahātyasūn ||7||</l>
+                         kṛṣṇā stabdhā'valiptā vā jihvā śūnā ca yasya vai | karkaśā vā bhavedyasya
+                        so 'cirādvijahātyasūn ||7||</l>
 
                     <l xml:id="SS.1.31.8">
                         <label>1938 ed. 1.31.8</label>
                         <caesura/>
-                         kuṭilā sphuṭitā vā'pi śuṣkā vā yasya nāsikā | avasphūrjati magnā
-                        vā na sa jīvati mānavaḥ ||8|| </l>
+                         kuṭilā sphuṭitā vā'pi śuṣkā vā yasya nāsikā | avasphūrjati magnā vā na sa
+                        jīvati mānavaḥ ||8|| </l>
 
                     <l xml:id="SS.1.31.9">
                         <label>1938 ed. 1.31.9</label>
                         <caesura/>
-                         saṅkṣipte viṣame stabdhe rakte sraste ca locane | syātāṃ vā
-                        prasrute yasya sa gatāyurnaro dhruvam ||9||</l>
+                         saṅkṣipte viṣame stabdhe rakte sraste ca locane | syātāṃ vā prasrute yasya
+                        sa gatāyurnaro dhruvam ||9||</l>
 
                     <l xml:id="SS.1.31.10">
                         <label>1938 ed. 1.31.10</label>
                         <caesura/>
-                         keśāḥ sīmantino yasya saṅkṣipte vinate bhruvau | luṇḍanti
-                        cākṣipakṣmāṇi so 'cirādyāti mṛtyave ||10||</l>
+                         keśāḥ sīmantino yasya saṅkṣipte vinate bhruvau | luṇḍanti cākṣipakṣmāṇi so
+                        'cirādyāti mṛtyave ||10||</l>
 
                     <l xml:id="SS.1.31.11">
                         <label>1938 ed. 1.31.11</label>
@@ -6979,32 +6989,32 @@
                     <l xml:id="SS.1.31.12">
                         <label>1938 ed. 1.31.12</label>
                         <caesura/>
-                         balavān durbalo vā'pi sammohaṃ yo 'dhigacchati | utthāpyamāno
-                        bahuśastaṃ pakvaṃ bhiṣagādiśet ||12||</l>
+                         balavān durbalo vā'pi sammohaṃ yo 'dhigacchati | utthāpyamāno bahuśastaṃ
+                        pakvaṃ bhiṣagādiśet ||12||</l>
 
                     <l xml:id="SS.1.31.13">
                         <label>1938 ed. 1.31.13</label>
                         <caesura/>
-                         uttānaḥ sarvadā śete pādau vikurute ca yaḥ | viprasāraṇaśīlo vā
-                        na sa jīvati mānavaḥ ||13||</l>
+                         uttānaḥ sarvadā śete pādau vikurute ca yaḥ | viprasāraṇaśīlo vā na sa
+                        jīvati mānavaḥ ||13||</l>
 
                     <l xml:id="SS.1.31.14">
                         <label>1938 ed. 1.31.14</label>
                         <caesura/>
-                         śītapādakarocchvāsaśchinnocchvāsaś ca yo bhavet | kākocchvāsaś ca
-                        yo martyastaṃ dhīraḥ parivarjayet ||14|| </l>
+                         śītapādakarocchvāsaśchinnocchvāsaś ca yo bhavet | kākocchvāsaś ca yo
+                        martyastaṃ dhīraḥ parivarjayet ||14|| </l>
 
                     <l xml:id="SS.1.31.15">
                         <label>1938 ed. 1.31.15</label>
                         <caesura/>
-                         nidrā na chidyate yasya yo vā jāgarti sarvadā | muhyedvā
-                        vaktukāmaś ca pratyākhyeyaḥ sa jānatā ||15||</l>
+                         nidrā na chidyate yasya yo vā jāgarti sarvadā | muhyedvā vaktukāmaś ca
+                        pratyākhyeyaḥ sa jānatā ||15||</l>
 
                     <l xml:id="SS.1.31.16">
                         <label>1938 ed. 1.31.16</label>
                         <caesura/>
-                         uttarauṣṭhaṃ ca yo lihyādutkārāṃś ca karoti yaḥ | pretair vā
-                        bhāṣate sārdhaṃ pretarūpaṃ tam ādiśet ||16|| </l>
+                         uttarauṣṭhaṃ ca yo lihyādutkārāṃś ca karoti yaḥ | pretair vā bhāṣate
+                        sārdhaṃ pretarūpaṃ tam ādiśet ||16|| </l>
 
                     <l xml:id="SS.1.31.17">
                         <label>1938 ed. 1.31.17</label>
@@ -7016,20 +7026,20 @@
                     <l xml:id="SS.1.31.18">
                         <label>1938 ed. 1.31.18</label>
                         <caesura/>
-                         vātāṣṭhīlā tu hṛdaye yasyor dhvamanuyāyinī | rujānnavidveṣakarī
-                        sa parāsurasaṃśayam ||18||</l>
+                         vātāṣṭhīlā tu hṛdaye yasyor dhvamanuyāyinī | rujānnavidveṣakarī sa
+                        parāsurasaṃśayam ||18||</l>
 
                     <l xml:id="SS.1.31.19">
                         <label>1938 ed. 1.31.19</label>
                         <caesura/>
-                         ananyopadravakṛtaḥ śophaḥ pādasamutthitaḥ | puruṣaṃ hanti, nārīṃ
-                        tu mukhajo guhyajo dvayam ||19|| </l>
+                         ananyopadravakṛtaḥ śophaḥ pādasamutthitaḥ | puruṣaṃ hanti, nārīṃ tu mukhajo
+                        guhyajo dvayam ||19|| </l>
 
                     <l xml:id="SS.1.31.20">
                         <label>1938 ed. 1.31.20</label>
                         <caesura/>
-                         atisāro jvaro hikkā chardiḥ śūnāṇḍameḍhratā | śvāsinaḥ kāsino
-                        vā'pi yasya taṃ kṣīṇam ādiśet ||20||</l>
+                         atisāro jvaro hikkā chardiḥ śūnāṇḍameḍhratā | śvāsinaḥ kāsino vā'pi yasya
+                        taṃ kṣīṇam ādiśet ||20||</l>
 
                     <l xml:id="SS.1.31.21">
                         <label>1938 ed. 1.31.21</label>
@@ -7040,77 +7050,77 @@
                     <l xml:id="SS.1.31.22">
                         <label>1938 ed. 1.31.22</label>
                         <caesura/>
-                         śyāvā jihvā bhavedyasya savyaṃ cākṣi nimajjati | mukhaṃ ca jāyate
-                        pūti yasya taṃ parivarjayet ||22||</l>
+                         śyāvā jihvā bhavedyasya savyaṃ cākṣi nimajjati | mukhaṃ ca jāyate pūti
+                        yasya taṃ parivarjayet ||22||</l>
 
                     <l xml:id="SS.1.31.23">
                         <label>1938 ed. 1.31.23</label>
                         <caesura/>
-                         vaktramāpūryate 'śrūṇāṃ svidyataścaraṇāvubhau | cakṣuś cākulatāṃ
-                        yāti yamarāṣṭraṃ gamiṣyataḥ ||23|| </l>
+                         vaktramāpūryate 'śrūṇāṃ svidyataścaraṇāvubhau | cakṣuś cākulatāṃ yāti
+                        yamarāṣṭraṃ gamiṣyataḥ ||23|| </l>
 
                     <l xml:id="SS.1.31.24">
                         <label>1938 ed. 1.31.24</label>
                         <caesura/>
-                         atimātraṃ laghūni syurgātrāṇi gurukāṇi vā | yasyākasmāt sa
-                        vijñeyo gantā vaivasvatālayam ||24||</l>
+                         atimātraṃ laghūni syurgātrāṇi gurukāṇi vā | yasyākasmāt sa vijñeyo gantā
+                        vaivasvatālayam ||24||</l>
 
                     <l xml:id="SS.1.31.25">
                         <label>1938 ed. 1.31.25</label>
                         <caesura/>
-                         paṅkamatsyavasātailaghṛtagandhāṃś ca ye narāḥ | mṛṣṭagandhāṃś ca
-                        ye vānti gantāraste yamālayam ||25||</l>
+                         paṅkamatsyavasātailaghṛtagandhāṃś ca ye narāḥ | mṛṣṭagandhāṃś ca ye vānti
+                        gantāraste yamālayam ||25||</l>
 
                     <l xml:id="SS.1.31.26">
                         <label>1938 ed. 1.31.26</label>
                         <caesura/>
-                         yūkā lalāṭamāyānti baliṃ nāśnanti vāyasāḥ | yeṣāṃ cāpi ratirnāsti
-                        yātāraste yamālayam ||26||</l>
+                         yūkā lalāṭamāyānti baliṃ nāśnanti vāyasāḥ | yeṣāṃ cāpi ratirnāsti yātāraste
+                        yamālayam ||26||</l>
 
 
                     <l xml:id="SS.1.31.27">
                         <label>1938 ed. 1.31.27</label>
                         <caesura/>
-                         jvarātisāraśophāḥ syuryasyānyonyāvasādinaḥ | prakṣīṇabalamāṃsasya
-                        nāsau śakyaścikitsitam ||27||</l>
+                         jvarātisāraśophāḥ syuryasyānyonyāvasādinaḥ | prakṣīṇabalamāṃsasya nāsau
+                        śakyaścikitsitam ||27||</l>
 
 
                     <l xml:id="SS.1.31.28">
                         <label>1938 ed. 1.31.28</label>
                         <caesura/>
-                         kṣīṇasya yasya kṣuttṛṣṇe hṛdyairmiṣṭairhitais tathā | na śāmyato
-                        'nnapānaiś ca tasya mṛtyurupasthitaḥ ||28||</l>
+                         kṣīṇasya yasya kṣuttṛṣṇe hṛdyairmiṣṭairhitais tathā | na śāmyato 'nnapānaiś
+                        ca tasya mṛtyurupasthitaḥ ||28||</l>
 
 
                     <l xml:id="SS.1.31.29">
                         <label>1938 ed. 1.31.29</label>
                         <caesura/>
-                         pravāhikā śiraḥśūlaṃ koṣṭhaśūlaṃ ca dāruṇam | pipāsā balahāniś ca
-                        tasya mṛtyurupasthitaḥ ||29|| </l>
+                         pravāhikā śiraḥśūlaṃ koṣṭhaśūlaṃ ca dāruṇam | pipāsā balahāniś ca tasya
+                        mṛtyurupasthitaḥ ||29|| </l>
 
                     <l xml:id="SS.1.31.30">
                         <label>1938 ed. 1.31.30</label>
                         <caesura/>
-                         viṣameṇopacāreṇa karmabhiś ca purākṛtaiḥ | anity atvāc ca
-                        jantūnāṃ jīvitaṃ nidhanaṃ vrajet ||30|| </l>
+                         viṣameṇopacāreṇa karmabhiś ca purākṛtaiḥ | anity atvāc ca jantūnāṃ jīvitaṃ
+                        nidhanaṃ vrajet ||30|| </l>
 
                     <l xml:id="SS.1.31.31">
                         <label>1938 ed. 1.31.31</label>
                         <caesura/>
-                         pretā bhūtāḥ piśācāś ca rakṣāṃsi vividhāni ca | maraṇābhimukhaṃ
-                        nityam upasarpanti mānavam ||31|| </l>
+                         pretā bhūtāḥ piśācāś ca rakṣāṃsi vividhāni ca | maraṇābhimukhaṃ nityam
+                        upasarpanti mānavam ||31|| </l>
 
                     <l xml:id="SS.1.31.32">
                         <label>1938 ed. 1.31.32</label>
                         <caesura/>
-                         tāni bheṣajavīryāṇi pratighnanti jighāṃsayā | tasmānmoghāḥ kriyāḥ
-                        sarvā bhavanty eva gatāyuṣām ||32||</l>
+                         tāni bheṣajavīryāṇi pratighnanti jighāṃsayā | tasmānmoghāḥ kriyāḥ sarvā
+                        bhavanty eva gatāyuṣām ||32||</l>
 
                     <l xml:id="SS.1.31.trailer">
                         <label>1938 ed. 1.31.trailer</label>
                         <caesura/>
-                         iti suśrutasaṃhitāyāṃ sūtrasthāne
-                        chāyāvipratipattirnāmaikatriṃśattamo 'dhyāyaḥ ||31|| </l>
+                         iti suśrutasaṃhitāyāṃ sūtrasthāne chāyāvipratipattirnāmaikatriṃśattamo
+                        'dhyāyaḥ ||31|| </l>
                 </div>
 
             </div>

--- a/01-su.su-1-31/kl_699_sutrasthana-1-31.txt
+++ b/01-su.su-1-31/kl_699_sutrasthana-1-31.txt
@@ -1696,26 +1696,41 @@
 
 
 
-                    <l xml:id="SS.1.12.3">kṣārād agnir garīyāṃ kriyāsu
-                            vyākhyāta<del>ā</del>s taddagdhā<cb n="2"/>nāṃ rogāṇām
+                    <l xml:id="SS.1.12.3a">kṣārād agnir garīyāṃ kriyāsu
+                            vyākhyāta<del>ā</del>s </l>
+                    
+                    <l xml:id="SS.1.12.3b">taddagdhā<cb n="2"/>nāṃ rogāṇām
                         apunarbhavāt | svedaśastrakṣārair asakyānāṃ tatsādhanāc ca |</l>
 
-                    <l xml:id="SS.1.12.4">athaimāni daha<lb n="4"/>nopakaraṇāni bhavanti |
+                    
+                    <l xml:id="SS.1.12.4a">athaimāni daha<lb n="4"/>nopakaraṇāni bhavanti |
                             pippalyajāśakṛdgodantaśaraśalākājamvvoṣṭhetaralohakṣaudraguḍa<cb
-                            n="1"/>snehādīni | tatra pippalyajāśakṛdgodantaśaraśalākāḥ
-                        stvaggatānāṃ | jamvvoṣṭhetaralohāḥ māṃsagatānāṃ | kṣaudraguḍa<cb
+                            n="1"/>snehādīni |</l>
+                    
+                    <l xml:id="SS.1.12.4b">tatra pippalyajāśakṛdgodantaśaraśalākāḥ
+                        stvaggatānāṃ |</l>
+                    
+                    <l xml:id="SS.1.12.4c">jamvvoṣṭhetaralohāḥ māṃsagatānāṃ |</l>
+                    
+                    <l xml:id="SS.1.12.4d">kṣaudraguḍa<cb
                             n="2"/>snehāḥ sirāsnāyusandhyasthigatānā |</l>
+                    
+                    
 
                     <l xml:id="SS.1.12.5">tatrāgnikarma sarvartuṣu kuryād anyatra
                         śaradgrīṣmābhyāṃ |<lb n="5"/> tatrāpyātyayikegnisādhye vyādhau
                         tatpratyanīkaṃ vidhiṃ kṛtvā</l>
 
-                    <l xml:id="SS.1.12.6">sarvavyādhiṣvṛtuṣu ca picchilamannambhu<cb n="1"
+                    <l xml:id="SS.1.12.6a">sarvavyādhiṣvṛtuṣu ca picchilamannambhu<cb n="1"
                         />ktavataḥ |</l>
+                    
+                    <l xml:id="SS.1.12.6b"/>
+                    
+                    
 
                     <l xml:id="SS.1.12.7">tatra dvividhamagnidagdhamāhureke | tvagdagdhaṃ
                         māṃsadagdhañ ca | iha tu sirāsnāyuṣu sandhyasthiṣv api na
-                            pratiṣiddhogniḥ<cb n="2"/> |</l>
+                            pratiṣiddho gniḥ<cb n="2"/> |</l>
 
                     <l xml:id="SS.1.12.8">tatra śabdaprādurbhāvo durgandhatā tvaksaṃkocaś
                         ca tvagdagdhe | kapotavarṇṇatālpaśvayathuvedanatā<lb n="6"/>
@@ -1723,8 +1738,10 @@
                         srāvasannirodhaśca sirāsnāyudagdhe<cb n="1"/>
                         rūkṣatāruṇatākarkaśasthiravraṇatā ca sandhyasthidagdhe ||</l>
 
-                    <l xml:id="SS.1.12.9">tatra śirorogādhimanthayorbhrūlalāṭaśaṅkhadeśeṣu
-                            dahedva<unclear>rtma</unclear>ro<cb n="2"
+                    <l xml:id="SS.1.12.9a">tatra śirorogādhimanthayorbhrūlalāṭaśaṅkhadeśeṣu
+                            dahed</l>
+                    
+                    <l xml:id="SS.1.12.9b">va<unclear>rtma</unclear>ro<cb n="2"
                         />geṣvārdranaktakapraticchannāndṛṣṭiṃ kṛtvā
                             va<unclear>rtma</unclear>romakūpāṃ |</l>
 

--- a/01-su.su-1-31/nak_1-1079_sutrasthana-1-31.txt
+++ b/01-su.su-1-31/nak_1-1079_sutrasthana-1-31.txt
@@ -1858,23 +1858,32 @@
 
                     <l xml:id="SS.1.12.2"> </l>
 
-                    <l xml:id="SS.1.12.3"> kṣārād agnir garīyāṃ kriyāsu vyākhyātās
+                    <l xml:id="SS.1.12.3a"> kṣārād agnir garīyāṃ kriyāsu vyākhyātās</l>
+                    
+                    <l xml:id="SS.1.12.3b">
                             tu<milestone facs=" number unclear to me" unit="folio"
                             /><unclear>dṛgcā</unclear>nāṃ rogāṇām apunarbhāvāt
                             sve<unclear>da</unclear>sastrakṣārair asakṣānāṃ
                             ta<unclear>tsā</unclear>dhanāc ca || </l>
+                    
 
-                    <l xml:id="SS.1.12.4"> athaimāni dahanopakaraṇāni <cb n="2"/> bhavnti
+                    <l xml:id="SS.1.12.4a"> athaimāni dahanopakaraṇāni <cb n="2"/> bhavnti
                         |
                             pippalyajāsakṣa<unclear>tse</unclear>dantasarasalākājāṃ<unclear>vo</unclear>ṣṭhautaraloha<unclear>kṣau</unclear>draguḍasnehādīni
-                        | tatra
+                        |</l>
+                    
+                    <l xml:id="SS.1.12.4b">tatra
                                 pippalyajāsakṣa<unclear>dse</unclear>dantaśarasalā<unclear>kā<cb
-                                n="3"/></unclear>ḥstvaggatānāṃ |
-                            ja<unclear>stvoṣṭhe</unclear>taralohāḥ māṃsagatānāṃ |
-                        kṣaudraguḍasnehāḥ sirā<unclear reason="faded"
+                                n="3"/></unclear>ḥstvaggatānāṃ |</l>
+                    
+                    <l xml:id="SS.1.12.4c">
+                            ja<unclear>stvoṣṭhe</unclear>taralohāḥ māṃsagatānāṃ |</l>
+                    
+                    <l xml:id="SS.1.12.4d">kṣaudraguḍasnehāḥ sirā<unclear reason="faded"
                             >snāyu</unclear>sandhya<unclear reason="faded"
                             >sthigatānām</unclear> || </l>
 
+                    
                     <l xml:id="SS.1.12.5">
                         <lb n="2"/> tatrāgnikarma sarvartuṣu <unclear>ku</unclear>yād
                         anyatra sara<unclear>dgrī</unclear>ṣmābhyām | tatrāpyātyayike
@@ -1882,12 +1891,15 @@
                         />nīkamvidhiṃ <unclear>kṣatvā</unclear>
                     </l>
 
-                    <l xml:id="SS.1.12.6"> sarvavyādhiṣvṛtuṣu ca picchilamannam
+                    <l xml:id="SS.1.12.6a"> sarvavyādhiṣvṛtuṣu ca picchilamannam
                         bhuktavataḥ | </l>
+                    
+                    <l xml:id="SS.1.12.6b"/>
+                    
 
                     <l xml:id="SS.1.12.7"> tatra dvividhamagnidagdhamādbhareke |
                         tvagdagdhaṃ mānsadagdhaṃ ca | iha tu <cb n="3"/>
-                        śirāsnāyusandhyasthiṣv api na pratiṣiddhogniḥ </l>
+                        śirāsnāyusandhyasthiṣv api na pratiṣiddho gniḥ </l>
 
                     <l xml:id="SS.1.12.8"> tatra śabdaprādurbhāvo durgandhatā
                             tva<unclear>ksaṃ</unclear>kocas camtvagda |<lb n="3"/>gdhe |
@@ -1897,9 +1909,10 @@
                             srā<cb n="2"/>vasannirodhas ca sirāsnāyudagdhe rūkṣāruṇatā
                         karkasasthiravraṇatā ca sandhyasthidagdhe || </l>
 
-                    <l xml:id="SS.1.12.9"> tatra sirorogā<unclear>thi</unclear>manthayor
-                        bhrūlalāṭā ¦<cb n="3"/> saṅkhade<unclear>śe</unclear>ṣu dahed
-                            carmarogeṣvārdranaktakapraticchannā<unclear>dṛ</unclear>ṣṭiṃ
+                    <l xml:id="SS.1.12.9a"> tatra sirorogā<unclear>thi</unclear>manthayor
+                        bhrūlalāṭā ¦<cb n="3"/> saṅkhade<unclear>śe</unclear>ṣu dahed</l>
+                            
+                    <l xml:id="SS.1.12.9b">carmarogeṣvārdranaktakapraticchannā<unclear>dṛ</unclear>ṣṭiṃ
                             <unclear>kṣa</unclear>tvā varmaromakūpāṃ | </l>
 
                     <l xml:id="SS.1.12.10"> tva<unclear>ṅma</unclear>ṃsasirāsnā<lb n="4"

--- a/01-su.su-1-31/nak_5-333_sutrasthana-1-31.txt
+++ b/01-su.su-1-31/nak_5-333_sutrasthana-1-31.txt
@@ -2001,27 +2001,41 @@
 
 
 
-                    <l xml:id="SS.1.12.3"> kṣārād agnir ggarīyān kriyāsu vyākhyātās
-                            taddagdhā<pb facs="dscn2995 fol 019.jpg lower" n="20r"/><lb
+                    <l xml:id="SS.1.12.3a"> kṣārād agnir ggarīyān kriyāsu vyākhyātās</l>
+                            
+                            
+                        <l xml:id="SS.1.12.3b">taddagdhā<pb facs="dscn2995 fol 019.jpg lower" n="20r"/><lb
                             n="1"/>nāṃ rogāṇām apunar<unclear>bha</unclear>vāt |
                             svedaśastra<add place="top margin"
                             >ta<!-- place of insertion not known --></add>kṣārair
                         aśakyānān tatsādhanāc ca || </l>
 
-                    <l xml:id="SS.1.12.4"> a<unclear>thai</unclear>māni dahanopakaraṇāni
+                    
+                    <l xml:id="SS.1.12.4a"> a<unclear>thai</unclear>māni dahanopakaraṇāni
                         bhavanti | pippalyajāsakṛdgodantaśaraśalākājaṃbboṣṭhetaralā<lb
-                            n="2"/>ha kṣaudraguḍa<unclear>s</unclear>nehādīni | tatra
+                            n="2"/>ha kṣaudraguḍa<unclear>s</unclear>nehādīni |</l>
+                    
+                    <l xml:id="SS.1.12.4b">tatra
                             pippalyajāśakṛdgo<unclear extent="3" unit="char"
-                        /><cb/>dantaśaraśalākāstvaggatānāṃ | jaṃbboṣṭhetaralāhā
-                        mānsagatānāṃ | kṣaudraguḍasnehāḥ sirā<unclear>s</unclear>nāyu<lb
+                        /><cb/>dantaśaraśalākāstvaggatānāṃ |</l>
+                    
+                    <l xml:id="SS.1.12.4c">jaṃbboṣṭhetaralāhā
+                        mānsagatānāṃ |</l>
+                    
+                    <l xml:id="SS.1.12.4d">kṣaudraguḍasnehāḥ sirā<unclear>s</unclear>nāyu<lb
                             n="3"/>sandhya<unclear>s</unclear>thigatānāṃ | </l>
+                    
 
                     <l xml:id="SS.1.12.5"> tatrāgnikarmma sarvvar<unclear>ttu</unclear>ṣu
                         kuryād anyatra śara<cb/>dgrīṣmābhyāṃ | tatrāpyātyayike 'gnisādhye
                         vyādhau tatpratyanīkaṃ vidhiṃ kṛtvā </l>
+                    
 
-                    <l xml:id="SS.1.12.6"> sarvvavyādhiṣv ṛtuṣu ca picchi<lb n="4"/>lam
-                        annaṃ <unclear>bhu</unclear>ktavataḥ | </l>
+                    <l xml:id="SS.1.12.6a"> sarvvavyādhiṣv ṛtuṣu ca picchi<lb n="4"/>lam
+                        annaṃ <unclear>bhu</unclear>ktavataḥ | </l>                    
+                    
+                    <l xml:id="SS.1.12.6b"/>
+                    
 
                     <l xml:id="SS.1.12.7"> tatra dvividhamagnidagdhamāhureke | tvagdagdhaṃ
                         mā<cb/>nsadagdhañ ca | iha tu
@@ -2040,8 +2054,10 @@
                             /><lb n="1"/>śa<unclear>s</unclear>thiravraṇatā ca
                             sandhya<unclear>s</unclear>thidagdhe || </l>
 
-                    <l xml:id="SS.1.12.9"> tatra śirorogādhimanthayor<unclear extent="1"
-                            unit="char"/>lalāṭaśaṃkhadeśeṣu dahed
+                    <l xml:id="SS.1.12.9a"> tatra śirorogādhimanthayor<unclear extent="1"
+                            unit="char"/>lalāṭaśaṃkhadeśeṣu dahed</l>
+                    
+                    <l xml:id="SS.1.12.9b">
                         <unclear>va</unclear>rtmmarogeṣvārddranaktakapraticchannān dṛṣṭiṃ
                         kṛtvā vartmmaromakūpāṃ | </l>
 

--- a/01-su.su-1-31/provisional-edition_sutrasthana-1-31.txt
+++ b/01-su.su-1-31/provisional-edition_sutrasthana-1-31.txt
@@ -2,8 +2,8 @@
     <teiHeader xmlns="http://www.tei-c.org/ns/1.0">
         <fileDesc>
             <titleStmt>
-                <title>The Nepalese Version of the Suśrutasaṃhitā, Sūtrasthāna 1-31, based
-                    on the Nepalese MSS</title>
+                <title>The Nepalese Version of the Suśrutasaṃhitā, Sūtrasthāna 1-31, based on the
+                    Nepalese MSS</title>
             </titleStmt>
 
             <publicationStmt>
@@ -13,33 +13,30 @@
                     <p>Copyright Notice</p>
                     <p>Copyright (C) Dominik Wujastyk</p>
                     <p>
-                        <ref target="http://creativecommons.org/licenses/by-sa/3.0/"
-                            type="licence">Distributed by <ref
-                                target="http://sarit.indology.info" type="url">SARIT</ref>
-                            under a Creative Commons Attribution-ShareAlike 3.0 Unported
-                            License. </ref>
+                        <ref target="http://creativecommons.org/licenses/by-sa/3.0/" type="licence"
+                            >Distributed by <ref target="http://sarit.indology.info" type="url"
+                                >SARIT</ref> under a Creative Commons Attribution-ShareAlike 3.0
+                            Unported License. </ref>
                     </p>
                     <p>Under this licence, you are free <list>
-                            <item>to Share — to copy, distribute and transmit the
-                                work</item>
+                            <item>to Share — to copy, distribute and transmit the work</item>
                             <item>to Remix — to adapt the work </item>
                         </list></p>
                     <p>Under the following conditions:</p>
                     <p>
                         <list>
-                            <item>Attribution — You must attribute the work in the manner
-                                specified by the author or licensor (but not in any way
-                                that suggests that they endorse you or your use of the
-                                work).</item>
-                            <item>Share Alike — If you alter, transform, or build upon
-                                this work, you may distribute the resulting work only
-                                under the same or similar license to this one.</item>
+                            <item>Attribution — You must attribute the work in the manner specified
+                                by the author or licensor (but not in any way that suggests that
+                                they endorse you or your use of the work).</item>
+                            <item>Share Alike — If you alter, transform, or build upon this work,
+                                you may distribute the resulting work only under the same or similar
+                                license to this one.</item>
                         </list>
                     </p>
-                    <p>More information and fuller details of this license are given on
-                        the Creative Commons website.</p>
-                    <p>SARIT assumes no responsibility for unauthorised use that infringes
-                        the rights of any copyright owners, known or unknown.</p>
+                    <p>More information and fuller details of this license are given on the Creative
+                        Commons website.</p>
+                    <p>SARIT assumes no responsibility for unauthorised use that infringes the
+                        rights of any copyright owners, known or unknown.</p>
                 </availability>
                 <address>
                     <name>University of Alberta.</name>
@@ -47,8 +44,8 @@
                 <authority>
                     <name>The Suśruta Project</name></authority>
                 <date>2020-2024</date>
-                <pubPlace>The University of Alberta. <note>The vulgate edition of 1931 was
-                        used for the collation of this sthāna</note>
+                <pubPlace>The University of Alberta. <note>The vulgate edition of 1931 was used for
+                        the collation of this sthāna</note>
                 </pubPlace>
                 <publisher>The Suśruta Project.<ptr target="http://sushrutaproject.org"/>
                 </publisher>
@@ -64,15 +61,15 @@
                 </msDesc>
 
                 <listWit>
-                    <witness xml:id="MN">The <title>Mādhavanidāna</title>, <abbr
-                            type="siglum">MN</abbr>
+                    <witness xml:id="MN">The <title>Mādhavanidāna</title>, <abbr type="siglum"
+                            >MN</abbr>
                         <idno type="siglum">Mādhavanidāna</idno></witness>
 
-                    <witness xml:id="NAK_1-1146">MS Kathmandu NAK 1-1146 <abbr
-                            type="siglum">1-1146</abbr>
-                        <idno type="siglum">MS NAK 1-1146</idno> A paper manuscript in
-                        Devanāgarī. 67 ff. Filmed as reel no A 224-9. Covers 1.8.3 -
-                        1.44.24 of the Sūtrasthāna. </witness>
+                    <witness xml:id="NAK_1-1146">MS Kathmandu NAK 1-1146 <abbr type="siglum"
+                            >1-1146</abbr>
+                        <idno type="siglum">MS NAK 1-1146</idno> A paper manuscript in Devanāgarī.
+                        67 ff. Filmed as reel no A 224-9. Covers 1.8.3 - 1.44.24 of the Sūtrasthāna.
+                    </witness>
                 </listWit>
             </sourceDesc>
 
@@ -107,24 +104,22 @@
 
         <revisionDesc>
             <change when="2020-11-04" who="Dominik Wujastyk">Began this file.</change>
-            <change when="2023-11-04" who="Dominik Wujastyk"> added 1.41, based on MS
-                N</change>
-            <change when="2023-06-26" who="Dominik Wujastyk">Separated the file into two
-                parts, 1-31 and 32-end, because of processing limits at Saktumiva</change>
-            <change when="2023-10-25" who="Dominik Wujastyk">Added all remaining adhyāyas
-                from K (from H for 19 and 20) and stripped out transcription codes to make
-                draft provisional edition files.</change>
-            <change when="2024-02-05" who="Lisa Brooks">The numbering and text of SS.1.13
-                are collated against the 1938 edition, not the 1931 edition.</change>
+            <change when="2023-11-04" who="Dominik Wujastyk"> added 1.41, based on MS N</change>
+            <change when="2023-06-26" who="Dominik Wujastyk">Separated the file into two parts, 1-31
+                and 32-end, because of processing limits at Saktumiva</change>
+            <change when="2023-10-25" who="Dominik Wujastyk">Added all remaining adhyāyas from K
+                (from H for 19 and 20) and stripped out transcription codes to make draft
+                provisional edition files.</change>
+            <change when="2024-02-05" who="Lisa Brooks">The numbering and text of SS.1.13 are
+                collated against the 1938 edition, not the 1931 edition.</change>
             <change when="2024-06-24" who="Deepro Chakraborty">Finalized the edition of
                 SS.1.8</change>
             <change when="2024-03-27" who="Dominik Wujastyk">Completed a major overhaul
-                ("meta-edit") of the all Sūtrasthāna files. I checked all passages and
-                made sure that xml:id tags matched correctly across all files, unifying
-                and separating text-portions as needed. I separated words ad hoc. I
-                corrected readings and checked against the MSS in many cases, but again ad
-                hoc. There is much remaining to be done, but the Sūtrasthāna is now in a
-                coherent format at the macro scale.</change>
+                ("meta-edit") of the all Sūtrasthāna files. I checked all passages and made sure
+                that xml:id tags matched correctly across all files, unifying and separating
+                text-portions as needed. I separated words ad hoc. I corrected readings and checked
+                against the MSS in many cases, but again ad hoc. There is much remaining to be done,
+                but the Sūtrasthāna is now in a coherent format at the macro scale.</change>
         </revisionDesc>
 
     </teiHeader>
@@ -153,18 +148,18 @@
                     <l xml:id="SS.1.1.3">
                         <label>1938 ed. 1.1.3</label>
                         <caesura/>
-                         atha khalu bhagavantam amaravaram ṛṣigaṇaparivṛttam āśramasthaṃ
-                        kāśirājaṃ divodāsam<anchor n="SS.1.1.3-n1"/> aupadhenava<pc
-                            > </pc>vaitaraṇaurabhra<pc> </pc>puṣkalāvata<pc
-                            > </pc>karavīra<pc> </pc>gopurarakṣita<pc
-                            > </pc>bhoja<pc> </pc>suśruta<pc> </pc>prabhṛtaya ūcuḥ |</l>
+                         atha khalu bhagavantam amaravaram ṛṣigaṇaparivṛttam āśramasthaṃ kāśirājaṃ
+                            divodāsam<anchor n="SS.1.1.3-n1"/> aupadhenava<pc
+                            > </pc>vaitaraṇaurabhra<pc> </pc>puṣkalāvata<pc> </pc>karavīra<pc
+                            > </pc>gopurarakṣita<pc> </pc>bhoja<pc> </pc>suśruta<pc> </pc>prabhṛtaya
+                        ūcuḥ |</l>
 
                     <ab corresp="#SS.1.1.3" type="apparatus">
                         <list type="Notes">
-                            <item corresp="#SS.1.1.3-n1">The scribe of the earliest MS, K,
-                                added the name <foreign>dhanvantari</foreign> in the
-                                margin; the scribe of N did not have the name; the scribe
-                                of H included it in the text.</item>
+                            <item corresp="#SS.1.1.3-n1">The scribe of the earliest MS, K, added the
+                                name <foreign>dhanvantari</foreign> in the margin; the scribe of N
+                                did not have the name; the scribe of H included it in the
+                                text.</item>
                         </list>
                     </ab>
 
@@ -172,31 +167,30 @@
                     <l xml:id="SS.1.1.4">
                         <label>1938 ed. 1.1.4</label>
                         <caesura/>
-                         bhagavañ śārīramānasāgantubhir vyādhibhir
-                        vividhavedanābhighātopadrutān sanāthān anāthavad viceṣṭamānān
-                        vikrośataś ca mānavān abhisamīkṣya manasi naḥ pīḍābhavat |</l>
+                         bhagavañ śārīramānasāgantubhir vyādhibhir vividhavedanābhighātopadrutān
+                        sanāthān anāthavad viceṣṭamānān vikrośataś ca mānavān abhisamīkṣya manasi
+                        naḥ pīḍābhavat |</l>
 
 
                     <l xml:id="SS.1.1.4b">
                         <label>1938 ed. 1.1.4b</label>
                         <caesura/>
-                         teṣāṃ sukhaiṣiṇāṃ rogopaśamārtham ātmanaś ca prāṇayātrārtham
-                        āyurvedaṃ icchāma upadiśyamānam | atrāyattam aihikam āmuṣmikañ ca
-                        śreyas tad bhagavantam upasannāḥ smaḥ śiṣyatveneti |</l>
+                         teṣāṃ sukhaiṣiṇāṃ rogopaśamārtham ātmanaś ca prāṇayātrārtham āyurvedaṃ
+                        icchāma upadiśyamānam | atrāyattam aihikam āmuṣmikañ ca śreyas tad
+                        bhagavantam upasannāḥ smaḥ śiṣyatveneti |</l>
 
                     <l xml:id="SS.1.1.5">
                         <label>1938 ed. 1.1.5</label>
                         <caesura/>
-                         tān uvāca bhagavān svāgatam vaḥ sarva evāmīmāṃsyā adhyāpyāś ca
-                        bhavanto vatsāḥ |</l>
+                         tān uvāca bhagavān svāgatam vaḥ sarva evāmīmāṃsyā adhyāpyāś ca bhavanto
+                        vatsāḥ |</l>
 
                     <l xml:id="SS.1.1.6">
                         <label>1938 ed. 1.1.6</label>
                         <caesura/>
-                         iha khalv āyurvedo nāma yad upāṅgam atharvavedasyoktam
-                        anutpādyaiva ca prajāḥ ślokaśatasahasram adhyāyasahasrañ ca
-                        kṛtavān svayambhūr alpāyuṣkālpamedhastvañ cālokya narāṇām bhūyo
-                        'ṣṭadhā praṇītavān | </l>
+                         iha khalv āyurvedo nāma yad upāṅgam atharvavedasyoktam anutpādyaiva ca
+                        prajāḥ ślokaśatasahasram adhyāyasahasrañ ca kṛtavān svayambhūr
+                        alpāyuṣkālpamedhastvañ cālokya narāṇām bhūyo 'ṣṭadhā praṇītavān | </l>
 
                     <l xml:id="SS.1.1.7">
                         <label>1938 ed. 1.1.7</label>
@@ -214,21 +208,18 @@
                         <caesura/>
                          tatra śalyan nāma
                         vividhatṛṇakāṣṭhapāṣāṇapāṃsulohaloṣṭāsthibālanakhapūyāsrāvaduṣṭavraṇāntargarbhaśalyoddharaṇārthaṃ
-                        yantraśastrakṣārāgnipraṇidhānaviniścayārthañ ca ṣaṣṭyābhidhānair
-                        iti | </l>
+                        yantraśastrakṣārāgnipraṇidhānaviniścayārthañ ca ṣaṣṭyābhidhānair iti | </l>
 
                     <l xml:id="SS.1.1.8.2">
                         <label>1938 ed. 1.1.8.2</label>
                         <caesura/>
                          śālākyatantran nāmorddhvajatrugatānāṃ vikārāṇāṃ
-                        śravaṇanayanavadanaghrāṇādisaṃśritānāṃ vikārāṇām
-                        upaśamakaraṇārtham |</l>
+                        śravaṇanayanavadanaghrāṇādisaṃśritānāṃ vikārāṇām upaśamakaraṇārtham |</l>
 
                     <l xml:id="SS.1.1.8.3">
                         <label>1938 ed. 1.1.8.3</label>
                         <caesura/>
-                         kāyacikītsā nāma sarvaśarīrāvasthitānāṃ vyādhīnām
-                        upaśamakaraṇārthaṃ
+                         kāyacikītsā nāma sarvaśarīrāvasthitānāṃ vyādhīnām upaśamakaraṇārthaṃ
                         jvaraśophagulmaraktapittonmādāpasmārapramehātisārādīnāñ ca |</l>
 
                     <l xml:id="SS.1.1.8.4">
@@ -242,8 +233,7 @@
                         <label>1938 ed. 1.1.8.5</label>
                         <caesura/>
                          kaumārabhṛtyan nāma kumārabharaṇadhātrīkṣīradoṣasaṃśodhanārthaṃ
-                        duṣṭastanyagrahasamutthitānāñ ca vyādhīnām upaśamakaraṇārtham
-                        |</l>
+                        duṣṭastanyagrahasamutthitānāñ ca vyādhīnām upaśamakaraṇārtham |</l>
 
                     <l xml:id="SS.1.1.8.6">
                         <label>1938 ed. 1.1.8.6</label>
@@ -261,36 +251,32 @@
                         <label>1938 ed. 1.1.8.8</label>
                         <caesura/>
                          vājīkaraṇatantran nāma svalpaduṣṭakṣīṇaviśuṣkaretasāṃ
-                        śukrāpyāyanaprasādopacayajanananimittaṃ praharṣajananārthañ ca
-                        |</l>
+                        śukrāpyāyanaprasādopacayajanananimittaṃ praharṣajananārthañ ca |</l>
 
                     <l xml:id="SS.1.1.9">
                         <label>1938 ed. 1.1.9</label>
                         <caesura/>
-                         evam ayam āyurvedo 'ṣṭāṅga upadiśyate | atra kasmai kiṃ varṇyatām
-                        iti |</l>
+                         evam ayam āyurvedo 'ṣṭāṅga upadiśyate | atra kasmai kiṃ varṇyatām iti |</l>
 
                     <l xml:id="SS.1.1.10">
                         <label>1938 ed. 1.1.10</label>
                         <caesura/>
-                         ta ūcur asmākaṃ sarvam eva śalyajñānam alaṅkṛtvopadiśatu bhagavān
-                        iti |<anchor n="SS.1.1.10-n1"/>
+                         ta ūcur asmākaṃ sarvam eva śalyajñānam alaṅkṛtvopadiśatu bhagavān iti
+                            |<anchor n="SS.1.1.10-n1"/>
                     </l>
 
                     <ab corresp="#SS.1.1.10" type="apparatus">
                         <list type="notes">
-                            <item corresp="#SS.1.1.10-n1">We follow the reading of MSS H
-                                and N, pace Harimoto 2013, in spite of the fact that
-                                    <foreign>alaṃkṛ[tvā]</foreign> is a marginal addition
-                                in K. K is badly damaged at this point, so it is not
-                                completely clear what happend to the manuscript, although
-                                it does look as if the word was not included in the text
-                                and was added by a different hand. But H is usually a
-                                faithful witness to the same text as K, and in this case
-                                even N concurs. The use of <foreign>alaṅkṛtvā</foreign> in
-                                the sense "make accessible" is slightly unusual and
-                                probably explains the later banalization to
-                                    <foreign>mūla</foreign>. </item>
+                            <item corresp="#SS.1.1.10-n1">We follow the reading of MSS H and N, pace
+                                Harimoto 2013, in spite of the fact that
+                                    <foreign>alaṃkṛ[tvā]</foreign> is a marginal addition in K. K is
+                                badly damaged at this point, so it is not completely clear what
+                                happend to the manuscript, although it does look as if the word was
+                                not included in the text and was added by a different hand. But H is
+                                usually a faithful witness to the same text as K, and in this case
+                                even N concurs. The use of <foreign>alaṅkṛtvā</foreign> in the sense
+                                "make accessible" is slightly unusual and probably explains the
+                                later banalization to <foreign>mūla</foreign>. </item>
                         </list>
                     </ab>
 
@@ -302,9 +288,8 @@
                     <l xml:id="SS.1.1.12">
                         <label>1938 ed. 1.1.12</label>
                         <caesura/>
-                         ta ūcur bhūyo 'smākaṃ sarveṣām evaikamatīnāṃ matam abhisamīkṣya
-                        suśruto bhagavantaṃ prakṣyati | asyopadiśyamānaṃ vayam apy
-                        upadhārayiṣyāmaḥ |</l>
+                         ta ūcur bhūyo 'smākaṃ sarveṣām evaikamatīnāṃ matam abhisamīkṣya suśruto
+                        bhagavantaṃ prakṣyati | asyopadiśyamānaṃ vayam apy upadhārayiṣyāmaḥ |</l>
 
                     <l xml:id="SS.1.1.13">
                         <label>1938 ed. 1.1.13</label>
@@ -331,9 +316,9 @@
                     <l xml:id="SS.1.1.17">
                         <label>1938 ed. 1.1.17</label>
                         <caesura/>
-                         etad dhy aṅgaṃ prathamaṃ pradhānaṃ prāg abhihitatvād
-                        vraṇasaṃrohaṇakaratvād yajñaśiraḥpradhānasandhānāc ca | śrūyate hi
-                        yathā purā rudreṇa śiraś chinnam aśvibhyāṃ punaḥ sandhitam iti | </l>
+                         etad dhy aṅgaṃ prathamaṃ pradhānaṃ prāg abhihitatvād vraṇasaṃrohaṇakaratvād
+                        yajñaśiraḥpradhānasandhānāc ca | śrūyate hi yathā purā rudreṇa śiraś chinnam
+                        aśvibhyāṃ punaḥ sandhitam iti | </l>
 
 
 
@@ -346,15 +331,13 @@
                     <l xml:id="SS.1.1.19">
                         <label>1938 ed. 1.1.19</label>
                         <caesura/>
-                         tad idaṃ śāśvataṃ puṇyaṃ svargyaṃ yaśasyam āyuṣyaṃ vṛttikarañ ca
-                        | </l>
+                         tad idaṃ śāśvataṃ puṇyaṃ svargyaṃ yaśasyam āyuṣyaṃ vṛttikarañ ca | </l>
 
                     <l xml:id="SS.1.1.20">
                         <label>1938 ed. 1.1.20</label>
                         <caesura/>
-                         tad brahmā provāca tat prajāpatir adhijage tasmād aśvināv
-                        aśvibhyām indra indrād ahaṃ mayā tv iha pradeyam arthibhyaḥ
-                        prajāhitahetoḥ |</l>
+                         tad brahmā provāca tat prajāpatir adhijage tasmād aśvināv aśvibhyām indra
+                        indrād ahaṃ mayā tv iha pradeyam arthibhyaḥ prajāhitahetoḥ |</l>
 
                     <l xml:id="SS.1.1.21">
                         <label>1938 ed. 1.1.21</label>
@@ -363,27 +346,24 @@
                         <caesura/>
                          ahaṃ hi dhanvantarir ādidevo jarārujāmṛtyuharo marāṇāṃ |
                         <caesura/>
-                         śalyam mahac chāstravaraṃ gṛhītvā prāpto 'smi gāṃ bhūya
-                        ihopadeṣṭuṃ | </l>
+                         śalyam mahac chāstravaraṃ gṛhītvā prāpto 'smi gāṃ bhūya ihopadeṣṭuṃ | </l>
 
                     <ab corresp="#SS.1.1.21" type="apparatus">
                         <list type="notes">
-                            <item corresp="#SS.1.1.21-n1">The Nepalese witnesses commonly
-                                use the abbreviation "<foreign>bha</foreign>" for
-                                    "<foreign>bhavati cātra</foreign>", introducing the
-                                next verse.</item>
+                            <item corresp="#SS.1.1.21-n1">The Nepalese witnesses commonly use the
+                                abbreviation "<foreign>bha</foreign>" for "<foreign>bhavati
+                                    cātra</foreign>", introducing the next verse.</item>
                         </list>
                     </ab>
                     <l xml:id="SS.1.1.22">
                         <label>1938 ed. 1.1.22</label>
                         <caesura/>
-                         tatrāsmiñ śāstre pañcamahābhūtaśarīrisamavāyaḥ puruṣa ity ucyate
-                        | tasmiḥ kriyā so 'dhiṣṭhānaṃ | kasmāl | lokadvaividhyāl | loko hi
-                            dvividhaḥ<anchor n="SS.1.1.22-n1"/> sthāvaro jaṅgamaś ca |
-                        dvividhātmaka evāgneyaḥ saumyaś ca tadbhūyastvāt pañcātmako vā |
-                        tatra caturvidho bhūtagrāmaḥ saṃsvedajādrijajarāyujāṇḍajasaṃjñaḥ |
-                        tasmin puruṣaḥ pradhānas tasyopakaraṇam anyat | tasmāt puruṣo
-                        'dhiṣṭhānaṃ | </l>
+                         tatrāsmiñ śāstre pañcamahābhūtaśarīrisamavāyaḥ puruṣa ity ucyate | tasmiḥ
+                        kriyā so 'dhiṣṭhānaṃ | kasmāl | lokadvaividhyāl | loko hi dvividhaḥ<anchor
+                            n="SS.1.1.22-n1"/> sthāvaro jaṅgamaś ca | dvividhātmaka evāgneyaḥ
+                        saumyaś ca tadbhūyastvāt pañcātmako vā | tatra caturvidho bhūtagrāmaḥ
+                        saṃsvedajādrijajarāyujāṇḍajasaṃjñaḥ | tasmin puruṣaḥ pradhānas
+                        tasyopakaraṇam anyat | tasmāt puruṣo 'dhiṣṭhānaṃ | </l>
 
 
                     <ab corresp="#SS.1.1.22" type="apparatus">
@@ -417,8 +397,8 @@
                          śārīrās tv annamūlā vātapittakaphaśoṇitavaiṣamyanimittāḥ | </l>
 
                     <l xml:id="SS.1.1.25.3"> mānasās tu
-                        krodhaśokadainyaharṣakāmaviṣāderṣyāsūyāmātsaryalobhādaya
-                        icchādveṣanimittāḥ | </l>
+                        krodhaśokadainyaharṣakāmaviṣāderṣyāsūyāmātsaryalobhādaya icchādveṣanimittāḥ
+                        | </l>
                     <l xml:id="SS.1.1.25.4">
                         <label>1938 ed. 1.1.25.4</label>
                         <caesura/>
@@ -438,37 +418,35 @@
                     <l xml:id="SS.1.1.28">
                         <label>1938 ed. 1.1.28</label>
                         <caesura/>
-                         prāṇināṃ punar mūlam āhāro balavarṇaujasāñ ca | sa ṣaṭsu raseṣv
-                        āyattaḥ | rasāḥ punar dravyāśrayinaḥ | dravyāṇi punar oṣadhyaḥ |
-                        tā dvividhā | sthāvarā jaṅgamāś ca | </l>
+                         prāṇināṃ punar mūlam āhāro balavarṇaujasāñ ca | sa ṣaṭsu raseṣv āyattaḥ |
+                        rasāḥ punar dravyāśrayinaḥ | dravyāṇi punar oṣadhyaḥ | tā dvividhā |
+                        sthāvarā jaṅgamāś ca | </l>
 
                     <l xml:id="SS.1.1.29">
                         <label>1938 ed. 1.1.29</label>
                         <caesura/>
-                         tāsāṃ sthāvarāś caturvidhā vanaspatayo vṛkṣā oṣadhyo vīrudha iti
-                        | tāsv apuṣpā phalavantyo vanaspatayaḥ | puṣpaphalo ye tā vṛkṣāḥ |
-                        phalapākaniṣṭhās tv oṣadhyaḥ | pratānavatyo vīrudha iti |</l>
+                         tāsāṃ sthāvarāś caturvidhā vanaspatayo vṛkṣā oṣadhyo vīrudha iti | tāsv
+                        apuṣpā phalavantyo vanaspatayaḥ | puṣpaphalo ye tā vṛkṣāḥ | phalapākaniṣṭhās
+                        tv oṣadhyaḥ | pratānavatyo vīrudha iti |</l>
 
                     <l xml:id="SS.1.1.30">
                         <label>1938 ed. 1.1.30</label>
                         <caesura/>
-                         jaṅgamāḥ khalv api caturvidhāḥ | jarāyujāṇḍajasaṃsvedajodbhidā
-                        iti | teṣām paśumanuṣyavyālādayo jarāyujāḥ | khagasarīsṛpasarpās
-                        tv aṇḍajāḥ | kṛmi<pc> </pc>kuntha<pc> </pc>pipīlikā<pc
-                            > </pc>prabhṛtayaḥ<anchor n="SS.1.1.30-n1"/> saṃsvedajāḥ |
-                        indragopakamaṇḍūkaprabhṛtayaś codbhidāḥ | </l>
+                         jaṅgamāḥ khalv api caturvidhāḥ | jarāyujāṇḍajasaṃsvedajodbhidā iti | teṣām
+                        paśumanuṣyavyālādayo jarāyujāḥ | khagasarīsṛpasarpās tv aṇḍajāḥ |
+                            kṛmi<pc> </pc>kuntha<pc> </pc>pipīlikā<pc> </pc>prabhṛtayaḥ<anchor
+                            n="SS.1.1.30-n1"/> saṃsvedajāḥ | indragopakamaṇḍūkaprabhṛtayaś codbhidāḥ
+                        | </l>
 
                     <ab type="apparatus" corresp="#SS.1.1.30">
                         <list type="notes">
-                            <item corresp="#SS.1.1.30-n1"><foreign>kuṭṭha</foreign> is
-                                Prākṛta for "skin disease, leprosy," but this sense does
-                                not fit this passage; the word here must refer to an
-                                insect or similar creature. In our MSS,
-                                    <foreign>kuṭṭha</foreign> appears to be a transmitted
-                                form, possibly Sanskritized to <foreign>kuṣṭha</foreign>
-                                by the scribe of MS H. It is not obvious how it could be a
-                                scribal error for the Vulgate's "<foreign>kīṭa</foreign>."
-                                We read with K.</item>
+                            <item corresp="#SS.1.1.30-n1"><foreign>kuṭṭha</foreign> is Prākṛta for
+                                "skin disease, leprosy," but this sense does not fit this passage;
+                                the word here must refer to an insect or similar creature. In our
+                                MSS, <foreign>kuṭṭha</foreign> appears to be a transmitted form,
+                                possibly Sanskritized to <foreign>kuṣṭha</foreign> by the scribe of
+                                MS H. It is not obvious how it could be a scribal error for the
+                                Vulgate's "<foreign>kīṭa</foreign>." We read with K.</item>
                         </list>
                     </ab>
 
@@ -476,8 +454,8 @@
                         <label>1938 ed. 1.1.31</label>
                         <caesura/>
                          tatra sthāvarebhyas
-                        tvakpatrapuṣpaphalamūlakandakṣīraniryāsasārasnehasvarasāḥ
-                        prayojanavantaḥ | jaṅgamebhyaś carmaromanakharudhirādayaḥ | </l>
+                        tvakpatrapuṣpaphalamūlakandakṣīraniryāsasārasnehasvarasāḥ prayojanavantaḥ |
+                        jaṅgamebhyaś carmaromanakharudhirādayaḥ | </l>
 
                     <l xml:id="SS.1.1.32">
                         <label>1938 ed. 1.1.32</label>
@@ -487,16 +465,15 @@
                     <l xml:id="SS.1.1.33">
                         <label>1938 ed. 1.1.33</label>
                         <caesura/>
-                         kālakṛtās tu pravātanivātātapacchāyātamojyotsnāśītoṣṇavarṣāsu
-                        samplavāḥ | kālaviśeṣās tu
-                        nimeṣakāṣṭhākalāmuhūrtāhorātrapakṣamāsartvayanasamvatsarayugaviśeṣāḥ
-                        | </l>
+                         kālakṛtās tu pravātanivātātapacchāyātamojyotsnāśītoṣṇavarṣāsu samplavāḥ |
+                        kālaviśeṣās tu
+                        nimeṣakāṣṭhākalāmuhūrtāhorātrapakṣamāsartvayanasamvatsarayugaviśeṣāḥ | </l>
 
                     <l xml:id="SS.1.1.34">
                         <label>1938 ed. 1.1.34</label>
                         <caesura/>
-                         svabhāvata eva doṣāṇāṃ sañcayaprakopopaśamapratīkārahetavo
-                        bhavanti | prayojanavantaś ca | </l>
+                         svabhāvata eva doṣāṇāṃ sañcayaprakopopaśamapratīkārahetavo bhavanti |
+                        prayojanavantaś ca | </l>
 
                     <l xml:id="SS.1.1.35"> bhavanti cātra |
                         <caesura/>
@@ -523,15 +500,13 @@
                     <l xml:id="SS.1.1.38">
                         <label>1938 ed. 1.1.38</label>
                         <caesura/>
-                         evam etat puruṣo vyādhir auṣadhaṃ kriyā kāla iti samāsena
-                        catuṣṭayaṃ vyākhyātam bhavati | tatra puruṣagrahaṇāt
-                        tatsaṃbhavadravyasamūho bhūtādir uktaḥ tadaṅgapratyaṅgavikalpāś ca
-                        tvaṅmāṃsāsirāsnāyvasthisandhiprabhṛtayaḥ | vyādhigrahaṇād
-                        vātapittakaphaśoṇitasannipātāgantusvabhāvanimittāḥ sarva eva
-                        vyādhayo vyākhyātā bhavanti | oṣadhagrahaṇād
-                        dravyarasaguṇavīryavipākānām ādeśaḥ | kriyāgrahaṇāt snehādīni
-                        cchedyādīni ca karmāṇy upadiṣṭāni bhavanti | kālagrahaṇāt sarva
-                        eva kriyākālādeśaḥ | </l>
+                         evam etat puruṣo vyādhir auṣadhaṃ kriyā kāla iti samāsena catuṣṭayaṃ
+                        vyākhyātam bhavati | tatra puruṣagrahaṇāt tatsaṃbhavadravyasamūho bhūtādir
+                        uktaḥ tadaṅgapratyaṅgavikalpāś ca tvaṅmāṃsāsirāsnāyvasthisandhiprabhṛtayaḥ |
+                        vyādhigrahaṇād vātapittakaphaśoṇitasannipātāgantusvabhāvanimittāḥ sarva eva
+                        vyādhayo vyākhyātā bhavanti | oṣadhagrahaṇād dravyarasaguṇavīryavipākānām
+                        ādeśaḥ | kriyāgrahaṇāt snehādīni cchedyādīni ca karmāṇy upadiṣṭāni bhavanti
+                        | kālagrahaṇāt sarva eva kriyākālādeśaḥ | </l>
 
 
 
@@ -548,8 +523,8 @@
                         <label>1938 ed. 1.1.40</label>
                         <caesura/>
                          tac ca viṃśam adhyāyaśataṃ pañcasu sthāneṣu ceti | tatra
-                        ślokasthānanidānaśārīracikitsitakalpeṣv arthavaśād vibhajya uttare
-                        vakṣyāmaḥ | </l>
+                        ślokasthānanidānaśārīracikitsitakalpeṣv arthavaśād vibhajya uttare vakṣyāmaḥ
+                        | </l>
 
 
 
@@ -584,38 +559,35 @@
                     <l xml:id="SS.1.2.3">
                         <label>1938 ed. 1.2.3</label>
                         <caesura/>
-                         brāhmaṇakṣatriyavaiśyānām anyatamam anvaya<pc
-                            > </pc>vayaḥ<pc> </pc>śaurya<pc> </pc>śaucācāra<pc
-                            > </pc>vinaya<pc> </pc>śakti<pc> </pc>bala<pc
-                            > </pc>medhā<pc> </pc>dhṛti<pc> </pc>smṛti<pc
-                            > </pc>pratipattiyuktaṃ<anchor n="SS.1.2.3-n1"/>
+                         brāhmaṇakṣatriyavaiśyānām anyatamam anvaya<pc> </pc>vayaḥ<pc
+                            > </pc>śaurya<pc> </pc>śaucācāra<pc> </pc>vinaya<pc
+                            > </pc>śakti<pc> </pc>bala<pc> </pc>medhā<pc> </pc>dhṛti<pc
+                            > </pc>smṛti<pc> </pc>pratipattiyuktaṃ<anchor n="SS.1.2.3-n1"/>
                             tanu<pc> </pc>jihvauṣṭha<pc> </pc>dantāgram ṛjuvaktrākṣināsaṃ
-                        prasannacittavākceṣṭaṃ kleśasahañ ca śiṣyam upanayet | sa hi
-                        guṇavān tasmai deyam ato|| viparītaguṇaṃ nopanayet | </l>
+                        prasannacittavākceṣṭaṃ kleśasahañ ca śiṣyam upanayet | sa hi guṇavān tasmai
+                        deyam ato|| viparītaguṇaṃ nopanayet | </l>
 
 
                     <ab corresp="#SS.1.2.3" type="apparatus">
                         <list type="Notes">
                             <item corresp="#SS.1.2.3-n1"> Emending <foreign xml:lang="sa"
-                                    >anvaya</foreign> against the Nepalese MSS is required
-                                to make syntactic sense of the passage. Dr. P. Maas
-                                pointed out the parallel with the mention of
-                                    <foreign>kula</foreign> ``family'' as one of the
-                                qualifiers for a student, in
-                                    <foreign>Carakasaṃhitā</foreign> 3.8.8. </item>
+                                    >anvaya</foreign> against the Nepalese MSS is required to make
+                                syntactic sense of the passage. Dr. P. Maas pointed out the parallel
+                                with the mention of <foreign>kula</foreign> ``family'' as one of the
+                                qualifiers for a student, in <foreign>Carakasaṃhitā</foreign> 3.8.8.
+                            </item>
                         </list>
                     </ab>
 
                     <l xml:id="SS.1.2.4">
                         <label>1938 ed. 1.2.4</label>
                         <caesura/>
-                         śūdram api guṇavantam anupanītam adhyāpayed ity eke |
-                        upanayanīyan tu brāhmaṇam praśasteṣu tithikaraṇamuhūrttanakṣatreṣu
-                        praśastāyān diśi śucau deśe gocarmamātraṃ sthaṇḍilam upalipya
-                        darbhasaṃstaraṇam ahitaṃ kṛtvā puṣpair dhūpair janvair bhankais ca
-                        pūjayitvā palāśodumvarabilvānāṃ samidbhir ghṛtam aktābhir
-                        dārvīhaumikenāgnim upasamādhāyājyañ juhuyāt | pratidevatam
-                        ṛṣibhyaḥ śiṣyaṃ svāhākāraṃṅ kārayet | </l>
+                         śūdram api guṇavantam anupanītam adhyāpayed ity eke | upanayanīyan tu
+                        brāhmaṇam praśasteṣu tithikaraṇamuhūrttanakṣatreṣu praśastāyān diśi śucau
+                        deśe gocarmamātraṃ sthaṇḍilam upalipya darbhasaṃstaraṇam ahitaṃ kṛtvā
+                        puṣpair dhūpair janvair bhankais ca pūjayitvā palāśodumvarabilvānāṃ
+                        samidbhir ghṛtam aktābhir dārvīhaumikenāgnim upasamādhāyājyañ juhuyāt |
+                        pratidevatam ṛṣibhyaḥ śiṣyaṃ svāhākāraṃṅ kārayet | </l>
 
                     <l xml:id="SS.1.2.5">
                         <label>1938 ed. 1.2.5</label>
@@ -626,13 +598,12 @@
                         <label>1938 ed. 1.2.6</label>
                         <caesura/>
                          tato 'gniṃ pariṇīyāgnisākṣikaṃ śiṣyaṃ brūyāt |
-                            kāmakrodhalobhamohamānāhaṃkārerṣyāmātsarya<pc
-                            > </pc>pārūṣya<pc> </pc>paiśunyānṛtālasyāsyayaśasyāni hitvā
-                        kāṣāyavāsasā nīcanakharomṇā trirātraṃ śucinā
-                        satyabrahmacaryābhivādanapareṇa bhavitavyaṃ |
-                        mamānumatasthānagamanaśayanāsanabhojanādhyayanapareṇa bhūtvā
-                        matpriyahiteṣu varttitavyam ato 'nyathā varttamānasyādharmmo
-                        bhavaty aphalā ca vidyā na ca prākāśyaṃ prāpnuyāt | </l>
+                            kāmakrodhalobhamohamānāhaṃkārerṣyāmātsarya<pc> </pc>pārūṣya<pc
+                        > </pc>paiśunyānṛtālasyāsyayaśasyāni hitvā kāṣāyavāsasā nīcanakharomṇā
+                        trirātraṃ śucinā satyabrahmacaryābhivādanapareṇa bhavitavyaṃ |
+                        mamānumatasthānagamanaśayanāsanabhojanādhyayanapareṇa bhūtvā matpriyahiteṣu
+                        varttitavyam ato 'nyathā varttamānasyādharmmo bhavaty aphalā ca vidyā na ca
+                        prākāśyaṃ prāpnuyāt | </l>
 
                     <l xml:id="SS.1.2.7">
                         <label>1938 ed. 1.2.7</label>
@@ -648,11 +619,10 @@
                     <l xml:id="SS.1.2.8">
                         <label>1938 ed. 1.2.8</label>
                         <caesura/>
-                         tasmād dvijadaridrasādhvanāthābhyupagatapāśaṇḍasthitānām
-                        ātmabāndhavānām ivātmabheṣajaiḥ | pratikartavyam evaṃ sādhu
-                        bhavati | vyādhaśākunikapatitapāpakarttṝṇāñ ca na pratikarttavyam
-                        evaṃ vidyā prakāśate | mitra<pc> </pc>dharma<pc
-                            > </pc>kāma<pc> </pc>yaśāṃsi cāvāpnoti || </l>
+                         tasmād dvijadaridrasādhvanāthābhyupagatapāśaṇḍasthitānām ātmabāndhavānām
+                        ivātmabheṣajaiḥ | pratikartavyam evaṃ sādhu bhavati |
+                        vyādhaśākunikapatitapāpakarttṝṇāñ ca na pratikarttavyam evaṃ vidyā prakāśate
+                        | mitra<pc> </pc>dharma<pc> </pc>kāma<pc> </pc>yaśāṃsi cāvāpnoti || </l>
 
 
                     <l xml:id="SS.1.2.9">
@@ -685,8 +655,8 @@
 
                 <div n="3" type="adhyāya">
 
-                    <head xml:lang="en">[Adhyāya 3, collation based on MSS K (to 1.3.23)
-                        and H (to 1.3.24-end)]</head>
+                    <head xml:lang="en">[Adhyāya 3, collation based on MSS K (to 1.3.23) and H (to
+                        1.3.24-end)]</head>
 
                     <l xml:id="SS.1.3.1">
                         <label>1.3.1</label>
@@ -699,9 +669,8 @@
                         <label>1.3.3</label>
                         <caesura/>
                          prāgabhihitaṃ saviṃśamadhyāyaśataṃ pañcasu sthāneṣu ceti || tatra
-                        ślokasthāne adhyāyāḥ ṣaṭcatvāriṃśat | ṣoḍaśanidānāni | daśa
-                        śārīrāṇi | catvāriśac cikitsitāni | aṣṭau kalpāḥ || bhavanti cātra
-                        ||</l>
+                        ślokasthāne adhyāyāḥ ṣaṭcatvāriṃśat | ṣoḍaśanidānāni | daśa śārīrāṇi |
+                        catvāriśac cikitsitāni | aṣṭau kalpāḥ || bhavanti cātra ||</l>
 
                     <l xml:id="SS.1.3.4">
                         <label>1.3.4</label>
@@ -852,8 +821,7 @@
                         <caesura/>
                          tayor vyāpaccikitsā ca netrabastivibhāgikaḥ |
                         <caesura/>
-                         netrabastivibhāgikaṃ | netrabastivipatsiddhis tathā
-                        cottarabastikaṃ || </l>
+                         netrabastivibhāgikaṃ | netrabastivipatsiddhis tathā cottarabastikaṃ || </l>
 
                     <l xml:id="SS.1.3.25">
                         <label>1.3.25</label>
@@ -1014,8 +982,8 @@
                     <l xml:id="SS.1.3.47">
                         <label>1.3.47</label>
                         <caesura/>
-                         etad avasyam adhyeyaṃ adhītya ca karmmāpy avasyam upāsitavyaṃ
-                        ubhayajño hi bhiṣagrājārho bhavati || </l>
+                         etad avasyam adhyeyaṃ adhītya ca karmmāpy avasyam upāsitavyaṃ ubhayajño hi
+                        bhiṣagrājārho bhavati || </l>
 
                     <l xml:id="SS.1.3.48">
                         <label>1.3.48</label>
@@ -1064,14 +1032,13 @@
                     <l xml:id="SS.1.3.54">
                         <label>1.3.54</label>
                         <caesura/>
-                         vatsa yathā adhyeyaṃ tathopadhāraya svocyamānaṃ | atha śucaye
-                        kṛtaṃ aṅgalāya kṛtottarāsaṅgāyopasthitāyādhyayanakāle śiṣyāya |
-                        yathāśaktito gurur upadiśet padaṃ padaṃ pādaṃ pādaṃ ślokaṃ vā te
-                        ca krame yaśa bhūyaḥ sandheyāḥ | evam ekaikaśo ghaṭayed ātmānañ
-                        cātra paṭhed adrutam avilaṃbitam ananunāsikaṃ
-                        nāvyaktātinipīḍitavarṇṇam akṣibhruvauṣṭhahasttair anataṃ
-                        susaṃskṛtaṃ nātyuccair nnātinīcaiḥ sva paṭhet tayor adhīyānayor
-                        nna cāntareṇa kaścid vrajed iti || </l>
+                         vatsa yathā adhyeyaṃ tathopadhāraya svocyamānaṃ | atha śucaye kṛtaṃ
+                        aṅgalāya kṛtottarāsaṅgāyopasthitāyādhyayanakāle śiṣyāya | yathāśaktito gurur
+                        upadiśet padaṃ padaṃ pādaṃ pādaṃ ślokaṃ vā te ca krame yaśa bhūyaḥ sandheyāḥ
+                        | evam ekaikaśo ghaṭayed ātmānañ cātra paṭhed adrutam avilaṃbitam
+                        ananunāsikaṃ nāvyaktātinipīḍitavarṇṇam akṣibhruvauṣṭhahasttair anataṃ
+                        susaṃskṛtaṃ nātyuccair nnātinīcaiḥ sva paṭhet tayor adhīyānayor nna
+                        cāntareṇa kaścid vrajed iti || </l>
 
 
 
@@ -1119,36 +1086,34 @@
                     <l xml:id="SS.1.4.5">
                         <label>1.4.5</label>
                         <caesura/>
-                         tasmāt saviṃśam adhyāyaśatam anupadapādaślokam avasyam
-                        anuvarṇitavyaṃ | kasmāt sūkṣmā hi
+                         tasmāt saviṃśam adhyāyaśatam anupadapādaślokam avasyam anuvarṇitavyaṃ |
+                        kasmāt sūkṣmā hi
                         dravyarasaguṇavīryavipākadoṣadhātumalāśayamarmmasirāsnāyusandhyasthivibhāgāḥ
                         | garbhasaṃbhavadravyasamūhavibhāgāś ca | tathā
                         pranaṣṭaśalyoddharaṇavraṇaviniścayabhagnavikalpāḥ | sādhyayāpy
-                        apratyākhyeyatā ca vikārāṇām evam ādayaś ca sahasraśo 'nye viśeṣāḥ
-                        | ye cintyamānā vimalavipulabuddher api buddhim ākulīkuryuḥ kiṃ
-                        punar alpabuddhes tasmād avaśyam anuvarṇayitavyaṃ || </l>
+                        apratyākhyeyatā ca vikārāṇām evam ādayaś ca sahasraśo 'nye viśeṣāḥ | ye
+                        cintyamānā vimalavipulabuddher api buddhim ākulīkuryuḥ kiṃ punar alpabuddhes
+                        tasmād avaśyam anuvarṇayitavyaṃ || </l>
 
                     <l xml:id="SS.1.4.6">
                         <label>1.4.6</label>
                         <caesura/>
-                         anyaśāstra<pc> </pc>viṣayopapannānām cārthānām ihopanītānām
-                        arthavaśāt teṣān tad vidyebhya eva vyākhyānam anuśrotavyaṃ || na
-                        hy ekasmiñ cchāstre sarvaśāstrāṇām avarodhaḥ karttuṃ śakya iti ||
-                        6 ||</l>
+                         anyaśāstra<pc> </pc>viṣayopapannānām cārthānām ihopanītānām arthavaśāt
+                        teṣān tad vidyebhya eva vyākhyānam anuśrotavyaṃ || na hy ekasmiñ cchāstre
+                        sarvaśāstrāṇām avarodhaḥ karttuṃ śakya iti || 6 ||</l>
 
                     <l xml:id="SS.1.4.7">
                         <label>1.4.7</label>
                         <caesura/>
-                         śāstram ekam adhīyāno na vidyāc chāstraniścayaṃ |<anchor
-                            n="SS.1.4.7-n1"/>
+                         śāstram ekam adhīyāno na vidyāc chāstraniścayaṃ |<anchor n="SS.1.4.7-n1"/>
                         <caesura/>
                          tasmād bahuśrutaḥ śāstraṃ vijānīyāc cikitsakaḥ |</l>
 
                     <ab corresp="#SS.1.4.7" type="apparatus">
                         <list type="Testimonia">
                             <item corresp="#SS.1.4.7-n1">Parallel to the
-                                    <title>Kātyāyanasmṛtisāroddhāraḥ</title>, Rājaguṇāḥ
-                                v.66 (Kane 1933: 11).</item>
+                                    <title>Kātyāyanasmṛtisāroddhāraḥ</title>, Rājaguṇāḥ v.66 (Kane
+                                1933: 11).</item>
                         </list>
                     </ab>
 
@@ -1185,8 +1150,8 @@
                     <l xml:id="SS.1.5.3">
                         <label>1.5.3</label>
                         <caesura/>
-                         trividhaṃ karmma pūrvakarma pradhānakamma paścātkarmeti |
-                        tadvyādhim pratyupadekṣyāmaḥ |</l>
+                         trividhaṃ karmma pūrvakarma pradhānakamma paścātkarmeti | tadvyādhim
+                        pratyupadekṣyāmaḥ |</l>
 
                     <l xml:id="SS.1.5.4">
                         <label>1.5.4</label>
@@ -1197,27 +1162,24 @@
                     <l xml:id="SS.1.5.5">
                         <label>1.5.5</label>
                         <caesura/>
-                         tac ca śastrakarmāṣṭavidham bhavati | tad yathā | chedyaṃ bhedyaṃ
-                        lekhyaṃ vedhyam eṣyam āhāryaṃ visrāvyaṃ sīvyam iti</l>
+                         tac ca śastrakarmāṣṭavidham bhavati | tad yathā | chedyaṃ bhedyaṃ lekhyaṃ
+                        vedhyam eṣyam āhāryaṃ visrāvyaṃ sīvyam iti</l>
 
                     <l xml:id="SS.1.5.6">
                         <label>1.5.6</label>
                         <caesura/>
-                         yato 'nyatkarmacikīrṣuṇā pūrvam evopakalpayitavyāni bhavanti |
-                        tad yathā
+                         yato 'nyatkarmacikīrṣuṇā pūrvam evopakalpayitavyāni bhavanti | tad yathā
                         yantraśastrakṣārāgniśalākāpicuplotapatrasūtraghṛtamadhupayastailatarpaṇakaṣāyālepanakalkaśītodakavyajanakaṭāhādīni
                         parikarmiṇaś ca snigdhā sthirā balavantaḥ |</l>
 
                     <l xml:id="SS.1.5.7">
                         <label>1.5.7</label>
                         <caesura/>
-                         tataḥ praśasteṣu tithikaraṇamuhūrttanakṣatreṣu
-                        dadhyakṣatānnapānaratnair viprāṃś cārcayitvā
-                        kṛtabalimaṅgalasvastivācanaṃ bhuktavantamāturaṃ prāṅmukham
-                        upaveśya yantrayitvā marmasirāsnāyusandhyasthidhamanīḥ pariharan
-                        nanu lomaṃ śastrannidadhyād āpūyadarśanāt sakṛdevopaharec chastram
-                        āśu ca | mahatsv api ca pākeṣu dvyaṅgulatryaṅgulāntaram vā
-                        śastrapadam uktaṃ ||</l>
+                         tataḥ praśasteṣu tithikaraṇamuhūrttanakṣatreṣu dadhyakṣatānnapānaratnair
+                        viprāṃś cārcayitvā kṛtabalimaṅgalasvastivācanaṃ bhuktavantamāturaṃ
+                        prāṅmukham upaveśya yantrayitvā marmasirāsnāyusandhyasthidhamanīḥ pariharan
+                        nanu lomaṃ śastrannidadhyād āpūyadarśanāt sakṛdevopaharec chastram āśu ca |
+                        mahatsv api ca pākeṣu dvyaṅgulatryaṅgulāntaram vā śastrapadam uktaṃ ||</l>
 
                     <l xml:id="SS.1.5.8">
                         <label>1.5.8</label>
@@ -1227,8 +1189,8 @@
                     <l xml:id="SS.1.5.8a">
                         <label>1.5.8a</label>
                         <caesura/>
-                         ekena vā vraṇena na viśuddhyati tatoparāṃ buddhyāpekṣāntaraṃ
-                        vraṇāṅkuryāt ||</l>
+                         ekena vā vraṇena na viśuddhyati tatoparāṃ buddhyāpekṣāntaraṃ vraṇāṅkuryāt
+                        ||</l>
 
                     <l xml:id="SS.1.5.9">
                         <label>1.5.9</label>
@@ -1267,26 +1229,23 @@
                     <l xml:id="SS.1.5.15">
                         <label>1.5.15</label>
                         <caesura/>
-                         anyathā tu sirāsnāyukṣaṇanād atimātraṃ | vedanācirācca
-                        vraṇasaṃroho māṃsakandīprādurbhāvaś ca bhavati |</l>
+                         anyathā tu sirāsnāyukṣaṇanād atimātraṃ | vedanācirācca vraṇasaṃroho
+                        māṃsakandīprādurbhāvaś ca bhavati |</l>
 
-                    <l xml:id="SS.1.5.16"
-                        >mūḍhagarbhodarāśmarībhagandaramukharāgeṣvabhuktavatāṃ
+                    <l xml:id="SS.1.5.16">mūḍhagarbhodarāśmarībhagandaramukharāgeṣvabhuktavatāṃ
                         kurvītaḥ</l>
 
                     <l xml:id="SS.1.5.17">
                         <label>1.5.17</label>
                         <caesura/>
-                         tataḥ śastram avacārya śītābhir adbhi pariṣicyar āturam āśvāsya
-                        ca samantāt paripīḍyāṃgulyā vraṇam abhimṛjya prakṣālya kaṣāyeṇa
-                        plotenodakam ādāya tilakalkamadhugāḍhāṃ varttim praṇidhāya
-                        patreṇācchādya kavalikān datvā bandhanopapādayet |
-                        vedanaārakṣoghnair dhūpayitvā</l>
+                         tataḥ śastram avacārya śītābhir adbhi pariṣicyar āturam āśvāsya ca samantāt
+                        paripīḍyāṃgulyā vraṇam abhimṛjya prakṣālya kaṣāyeṇa plotenodakam ādāya
+                        tilakalkamadhugāḍhāṃ varttim praṇidhāya patreṇācchādya kavalikān datvā
+                        bandhanopapādayet | vedanaārakṣoghnair dhūpayitvā</l>
 
-                    <l xml:id="SS.1.5.18">guggulva<pc> </pc>garu<pc
-                            > </pc>sarjjarasa<pc> </pc>vacā<pc> </pc>gaurasarpa<pc
-                            > </pc>lavaṇa<pc> </pc>nimba<pc> </pc>patrājya<pc> </pc>śeṣeṇa
-                        cāsya prāṇāṃ samālabheta |</l>
+                    <l xml:id="SS.1.5.18">guggulva<pc> </pc>garu<pc> </pc>sarjjarasa<pc
+                            > </pc>vacā<pc> </pc>gaurasarpa<pc> </pc>lavaṇa<pc> </pc>nimba<pc
+                            > </pc>patrājya<pc> </pc>śeṣeṇa cāsya prāṇāṃ samālabheta |</l>
 
                     <l xml:id="SS.1.5.19">
                         <label>1.5.19</label>
@@ -1398,14 +1357,13 @@
                     <l xml:id="SS.1.5.36">
                         <label>1.5.36</label>
                         <caesura/>
-                         dvitīyadivasamokṣaṇād vigrathito vraṇaḥ cirād
-                        upasaṃrohatyugrarukta bhavati ||</l>
+                         dvitīyadivasamokṣaṇād vigrathito vraṇaḥ cirād upasaṃrohatyugrarukta bhavati
+                        ||</l>
 
                     <l xml:id="SS.1.5.37">
                         <label>1.5.37</label>
                         <caesura/>
-                         ata urdhvaṃ doṣakālabalādīn avekṣya kaṣāyālepanabandhāhārād
-                        vidadhyān</l>
+                         ata urdhvaṃ doṣakālabalādīn avekṣya kaṣāyālepanabandhāhārād vidadhyān</l>
 
                     <l xml:id="SS.1.5.38">
                         <label>1.5.38</label>
@@ -1463,10 +1421,9 @@
                     <l xml:id="SS.1.6.3">
                         <label>1938 ed. 1.6.3</label>
                         <caesura/>
-                         kālo hi bhagavān svayambhur anādimadhyanidhano 'tra
-                        rasavyāpatsampattayo jīvitamaraṇe ca manuṣyāṇām āyatte sa sūkṣmām
-                        api kalān na līyata iti kālaḥ | saṅkalayati kalayati vā bhūtānīti
-                        kālaḥ |</l>
+                         kālo hi bhagavān svayambhur anādimadhyanidhano 'tra rasavyāpatsampattayo
+                        jīvitamaraṇe ca manuṣyāṇām āyatte sa sūkṣmām api kalān na līyata iti kālaḥ |
+                        saṅkalayati kalayati vā bhūtānīti kālaḥ |</l>
 
                     <l xml:id="SS.1.6.4">
                         <label>1938 ed. 1.6.4</label>
@@ -1478,30 +1435,28 @@
                     <l xml:id="SS.1.6.5">
                         <label>1938 ed. 1.6.5</label>
                         <caesura/>
-                         tatra laghvakṣinipātamātro nimeṣaḥ | pañcadaśanimeṣā kāṣṭhā
-                        triṅśatkāṣṭhā kalā | viṅśatikalā muhūrttaḥ kalāyāḥ daśabhāgaś ca |
-                        triṃśatmuhūrttam ahorātraṃ | pañcadaśāhorātraḥ pakṣaḥ | sa
-                        dvividhaḥ kṛṣṇaḥ śuklaś ca tau māsaḥ | </l>
+                         tatra laghvakṣinipātamātro nimeṣaḥ | pañcadaśanimeṣā kāṣṭhā triṅśatkāṣṭhā
+                        kalā | viṅśatikalā muhūrttaḥ kalāyāḥ daśabhāgaś ca | triṃśatmuhūrttam
+                        ahorātraṃ | pañcadaśāhorātraḥ pakṣaḥ | sa dvividhaḥ kṛṣṇaḥ śuklaś ca tau
+                        māsaḥ | </l>
 
                     <l xml:id="SS.1.6.6">
                         <label>1938 ed. 1.6.6</label>
                         <caesura/>
-                         tatra māghādayo dvādaśa māsāḥ saṃvatsaraḥ | dvimāsikam ṛtuṅ kṛtvā
-                        ṣaḍṛtavo bhavanti || te ca śiśiravasantagrīṣmavarṣāśaraddhemantāḥ
-                        | teṣaṃ tapastapasyau śiśiraḥ | madhumādhavau vasantaḥ |
-                        śuciśukrau grīṣmaḥ nabhonabhasyau varṣā | iṣorjau śarat |
-                        sahassahasyau hemanta iti |</l>
+                         tatra māghādayo dvādaśa māsāḥ saṃvatsaraḥ | dvimāsikam ṛtuṅ kṛtvā ṣaḍṛtavo
+                        bhavanti || te ca śiśiravasantagrīṣmavarṣāśaraddhemantāḥ | teṣaṃ
+                        tapastapasyau śiśiraḥ | madhumādhavau vasantaḥ | śuciśukrau grīṣmaḥ
+                        nabhonabhasyau varṣā | iṣorjau śarat | sahassahasyau hemanta iti |</l>
 
                     <l xml:id="SS.1.6.7">
                         <label>1938 ed. 1.6.7</label>
                         <caesura/>
-                         ta ete śītoṣṇavarṣavātalakṣaṇāḥ | candrādityayoḥ
-                        kālavibhāgakaratvād ayane dve bhavataḥ | dakṣiṇam uttarañ ca |
-                        tayor dakṣiṇam varṣāśaraddhemantāḥ teṣu bhagavān āpyāyate somaḥ |
-                        amlalavaṇamadhurāś ca rasā balavanto bhavanti | uttarottarañ ca
-                        sarvaprāṇināṃ balam abhivarddhate | uttaraṃ śiśiravasantagrīṣmāḥ |
-                        teṣu bhagavān āpyāyate rkaḥ | kaṭutiktakaṣāyāś ca rasā balavattarā
-                        bhavanti | uttarottaraś ca prāṇinām balam parihīyate ||</l>
+                         ta ete śītoṣṇavarṣavātalakṣaṇāḥ | candrādityayoḥ kālavibhāgakaratvād ayane
+                        dve bhavataḥ | dakṣiṇam uttarañ ca | tayor dakṣiṇam varṣāśaraddhemantāḥ teṣu
+                        bhagavān āpyāyate somaḥ | amlalavaṇamadhurāś ca rasā balavanto bhavanti |
+                        uttarottarañ ca sarvaprāṇināṃ balam abhivarddhate | uttaraṃ
+                        śiśiravasantagrīṣmāḥ | teṣu bhagavān āpyāyate rkaḥ | kaṭutiktakaṣāyāś ca
+                        rasā balavattarā bhavanti | uttarottaraś ca prāṇinām balam parihīyate ||</l>
 
                     <l xml:id="SS.1.6.8">
                         <label>1938 ed. 1.6.8</label>
@@ -1515,11 +1470,10 @@
                     <l xml:id="SS.1.6.9">
                         <label>1938 ed. 1.6.9</label>
                         <caesura/>
-                         atha khalv ayane yugapat saṃvatsaro bhavati | te dve ayane
-                        varṣasaṃvatsaraḥ parivatsaraḥ iḍāvatsaraḥ vatsara ity evaṃ pañca
-                        pañca varṣāṇi || te pañca yugam iti saṃjñāṃ labhante sa eṣa
-                        nimeṣādir yugaparyantaḥ kālaś cakravat parivarttamānaḥ kālacakra
-                        ity ucyate | </l>
+                         atha khalv ayane yugapat saṃvatsaro bhavati | te dve ayane varṣasaṃvatsaraḥ
+                        parivatsaraḥ iḍāvatsaraḥ vatsara ity evaṃ pañca pañca varṣāṇi || te pañca
+                        yugam iti saṃjñāṃ labhante sa eṣa nimeṣādir yugaparyantaḥ kālaś cakravat
+                        parivarttamānaḥ kālacakra ity ucyate | </l>
 
                     <l xml:id="SS.1.6.9a">
                         <label>1938 ed. 1.6.9a</label>
@@ -1529,39 +1483,35 @@
                     <l xml:id="SS.1.6.10">
                         <label>1938 ed. 1.6.10</label>
                         <caesura/>
-                         iha tu varṣāśaraddhemantavasantagrīṣmaprāvṛṣaḥ ṣaḍṛtavo bhavanti
-                        | doṣopacayaprakopapraśamanimittaṃ | te tu bhādrapadādyair
-                        dvimāsike naivaṃ vyākhyātāḥ | tadyathā | bhadrapadāśvayujau varṣāḥ
-                        kārttikamārgaśīrṣau śarat | pauṣamāghau hemantaḥ | phālgunacaitrau
-                        vasantaḥ | vaiśākhajyeṣṭhau grīṣmaḥ | āṣāḍhaśrāvaṇau prāvṛḍ iti
-                        ||</l>
+                         iha tu varṣāśaraddhemantavasantagrīṣmaprāvṛṣaḥ ṣaḍṛtavo bhavanti |
+                        doṣopacayaprakopapraśamanimittaṃ | te tu bhādrapadādyair dvimāsike naivaṃ
+                        vyākhyātāḥ | tadyathā | bhadrapadāśvayujau varṣāḥ kārttikamārgaśīrṣau śarat
+                        | pauṣamāghau hemantaḥ | phālgunacaitrau vasantaḥ | vaiśākhajyeṣṭhau grīṣmaḥ
+                        | āṣāḍhaśrāvaṇau prāvṛḍ iti ||</l>
 
                     <l xml:id="SS.1.6.11">
                         <label>1938 ed. 1.6.11</label>
                         <caesura/>
-                         tatra varṣāsv auṣadhyas taruṇyo 'lpavīryā āhāratvam upagatā
-                        vidahyante | āpaś cāpraśāntāḥ kṣitimalaprāyās tās tūpayujyamānā
-                        nabhasi meghāvatate jalapraklinnāyāṃ bhūmau klinnadehānāṃ dehināṃ
-                            śīta<pc> </pc>vāta<pc> </pc>varṣa<pc> </pc>viṣṭambhitāgnīnāṃ
-                        vidahyante | sa vidāhāt pittasañcayam āpādayanti | sa sañcayaḥ
-                        śaradi praviralameghe viyaty upaśuṣyati paṅke 'rka<pc
-                            > </pc>kiraṇa<pc> </pc>pravilāyitaḥ paittikāṃ vyādhīṃ janayati
-                        | tā evauṣadhayaḥ kālapariṇāmāt pariṇatavīryā balavatyo hemante
-                        bhavanti | āpaś ca praśāntāḥ snigdhā atyarthaṃ gurvyas tā
+                         tatra varṣāsv auṣadhyas taruṇyo 'lpavīryā āhāratvam upagatā vidahyante |
+                        āpaś cāpraśāntāḥ kṣitimalaprāyās tās tūpayujyamānā nabhasi meghāvatate
+                        jalapraklinnāyāṃ bhūmau klinnadehānāṃ dehināṃ śīta<pc> </pc>vāta<pc
+                            > </pc>varṣa<pc> </pc>viṣṭambhitāgnīnāṃ vidahyante | sa vidāhāt
+                        pittasañcayam āpādayanti | sa sañcayaḥ śaradi praviralameghe viyaty
+                        upaśuṣyati paṅke 'rka<pc> </pc>kiraṇa<pc> </pc>pravilāyitaḥ paittikāṃ
+                        vyādhīṃ janayati | tā evauṣadhayaḥ kālapariṇāmāt pariṇatavīryā balavatyo
+                        hemante bhavanti | āpaś ca praśāntāḥ snigdhā atyarthaṃ gurvyas tā
                         upayujyamānāḥ mandakiraṇatvād bhānos satuṣāraupa<pc
-                            > </pc>ṣṭambhita<pc> </pc>dehānāṃ dehinām avidagdhāḥ snehād
-                        gauravād upalepitvāc ca śleṣmaṇas sañcayam āpādayanti | sa saṃcayo
-                        vasante 'rka<pc> </pc>kiraṇa<pc> </pc>pravilāyitaḥ śleṣmikāṃ
-                        vyādhīṃ janayati | tā evauṣadhyau grīṣmaniḥsārā rūkṣā
-                        atimātralaghvyo bhavaty āpaś ca tā upayujyamānāḥ | tatra
-                        śaraddhemantayor madhyasamam ahorātraṃ yugapac cādhimāsakau
-                        bhavataḥ | viṃśatikāṣṭhāś caikanimeṣārdhaś ca dinaparivṛddhir
-                        uttarāyaṇe |<anchor n="SS.1.6.11.1-n1"/>
-                        sūryapratāpopaśoṣitadehānāṃ dehināṃ raukṣyāl laghavāc ca vāyoḥ
-                        sañcayam āpādayanti | sa sañcayaḥ prāvṛṣi cātyarthaṃñ
-                        jalopaklinnāyāṃ bhūmau cātiklinnadehānāṃ dehināṃ śītavātavarṣerito
-                        vātikān vyādhīn janayati | evam eṣāṃ doṣāṇāṃ sañcayaprakopahetur
-                        uktaḥ | </l>
+                            > </pc>ṣṭambhita<pc> </pc>dehānāṃ dehinām avidagdhāḥ snehād gauravād
+                        upalepitvāc ca śleṣmaṇas sañcayam āpādayanti | sa saṃcayo vasante
+                            'rka<pc> </pc>kiraṇa<pc> </pc>pravilāyitaḥ śleṣmikāṃ vyādhīṃ janayati |
+                        tā evauṣadhyau grīṣmaniḥsārā rūkṣā atimātralaghvyo bhavaty āpaś ca tā
+                        upayujyamānāḥ | tatra śaraddhemantayor madhyasamam ahorātraṃ yugapac
+                        cādhimāsakau bhavataḥ | viṃśatikāṣṭhāś caikanimeṣārdhaś ca dinaparivṛddhir
+                        uttarāyaṇe |<anchor n="SS.1.6.11.1-n1"/> sūryapratāpopaśoṣitadehānāṃ dehināṃ
+                        raukṣyāl laghavāc ca vāyoḥ sañcayam āpādayanti | sa sañcayaḥ prāvṛṣi
+                        cātyarthaṃñ jalopaklinnāyāṃ bhūmau cātiklinnadehānāṃ dehināṃ
+                        śītavātavarṣerito vātikān vyādhīn janayati | evam eṣāṃ doṣāṇāṃ
+                        sañcayaprakopahetur uktaḥ | </l>
 
                     <ab corresp="#SS.1.6.11" type="apparatus">
                         <list type="Notes">
@@ -1578,18 +1528,17 @@
                     <l xml:id="SS.1.6.12">
                         <label>1938 ed. 1.6.12</label>
                         <caesura/>
-                        <anchor n="SS.1.6.12-n1"/>tatra varṣāhemantagrīṣmeṣu sañcitānān
-                        doṣāṇāṃ śaradvasantaprāvṛṭsu ca prakupitānāṃ nirharaṇaṃ |</l>
+                        <anchor n="SS.1.6.12-n1"/>tatra varṣāhemantagrīṣmeṣu sañcitānān doṣāṇāṃ
+                        śaradvasantaprāvṛṭsu ca prakupitānāṃ nirharaṇaṃ |</l>
 
                     <ab corresp="#SS.1.6.12" type="apparatus">
                         <list type="Notes">
-                            <item corresp="#SS.1.6.12-n1">In the 1931 ed. of the vulgate,
-                                the text numbering skips from 1.61.11 to 1.6.13, omitting
-                                the number 1.6.12. In the 1938 ed. the vulgate
-                                    <foreign>tatra varṣāhemanta ... nirharaṇaṃ
-                                    kartavyam</foreign> is numbered 1.6.12 (not 1.6.13)
-                                and the numbers are one more than the 1931 ed. from there
-                                to the end of the <foreign>adhyāya</foreign>.</item>
+                            <item corresp="#SS.1.6.12-n1">In the 1931 ed. of the vulgate, the text
+                                numbering skips from 1.61.11 to 1.6.13, omitting the number 1.6.12.
+                                In the 1938 ed. the vulgate <foreign>tatra varṣāhemanta ...
+                                    nirharaṇaṃ kartavyam</foreign> is numbered 1.6.12 (not 1.6.13)
+                                and the numbers are one more than the 1931 ed. from there to the end
+                                of the <foreign>adhyāya</foreign>.</item>
                         </list>
                     </ab>
 
@@ -1597,16 +1546,15 @@
                     <l xml:id="SS.1.6.13">
                         <label>1938 ed. 1.6.13</label>
                         <caesura/>
-                         tatra paittikānāṃ vyādhīnāṃ hemante vyupaśamaḥ | śleṣmikāṇāṃ
-                        nidāghe vātikānāṃ śaradi | svabhāvatas tv ete sañcayaprakopaśamā
-                        vyākhyātāḥ ||</l>
+                         tatra paittikānāṃ vyādhīnāṃ hemante vyupaśamaḥ | śleṣmikāṇāṃ nidāghe
+                        vātikānāṃ śaradi | svabhāvatas tv ete sañcayaprakopaśamā vyākhyātāḥ ||</l>
 
                     <l xml:id="SS.1.6.14">
                         <label>1938 ed. 1.6.14</label>
                         <caesura/>
-                         tatra divasapūrvāhṇe vasantaliṅgaṃ | madhyāhne grīṣmasya |
-                        aparāhṇe prāvṛḍliṅgaṃ | pradoṣe vārṣikaṃ | śāradam ardharātre |
-                        pratyuṣasi haimanam upalakṣayet | evam ahorātram api varṣam iva
+                         tatra divasapūrvāhṇe vasantaliṅgaṃ | madhyāhne grīṣmasya | aparāhṇe
+                        prāvṛḍliṅgaṃ | pradoṣe vārṣikaṃ | śāradam ardharātre | pratyuṣasi haimanam
+                        upalakṣayet | evam ahorātram api varṣam iva
                         śītoṣṇavarṣadoṣopacayaprakopopaśamair jānīyāt</l>
 
                     <l xml:id="SS.1.6.15">
@@ -1618,8 +1566,8 @@
                     <l xml:id="SS.1.6.16">
                         <label>1938 ed. 1.6.16</label>
                         <caesura/>
-                         tāsām punar vyāpado 'dṛṣṭakāritāni śītoṣṇavātavarṣāṇi | khalu
-                        viparītāny auṣadhīr vyāpādayanty āpaś ca |</l>
+                         tāsām punar vyāpado 'dṛṣṭakāritāni śītoṣṇavātavarṣāṇi | khalu viparītāny
+                        auṣadhīr vyāpādayanty āpaś ca |</l>
 
                     <l xml:id="SS.1.6.17">
                         <label>1938 ed. 1.6.17</label>
@@ -1631,23 +1579,20 @@
                     <l xml:id="SS.1.6.19">
                         <label>1938 ed. 1.6.19</label>
                         <caesura/>
-                         kadācid avyāpanneṣv api kṛtyābhiśāparakṣaḥkrodhād adharmair
-                        uṣasyante janapadāḥ | viṣauṣadhipuṣpagandhena vā vāyunopanītena |
-                        kāsaśvāsapratiśyāyaśirorogajvarair upatapyante prajāḥ
-                        grahanakṣatracaritair vā |
-                        śayanāsanayānavāhanamaṇiratnopakaraṇagarhitalakṣaṇaprādurbhāvair
-                        vā</l>
+                         kadācid avyāpanneṣv api kṛtyābhiśāparakṣaḥkrodhād adharmair uṣasyante
+                        janapadāḥ | viṣauṣadhipuṣpagandhena vā vāyunopanītena |
+                        kāsaśvāsapratiśyāyaśirorogajvarair upatapyante prajāḥ grahanakṣatracaritair
+                        vā | śayanāsanayānavāhanamaṇiratnopakaraṇagarhitalakṣaṇaprādurbhāvair vā</l>
 
                     <l xml:id="SS.1.6.20">
                         <label>1938 ed. 1.6.20</label>
                         <caesura/>
-                         jāto 'tra | parityāga<pc> </pc>śānti<pc
-                            > </pc>prāyaścitta<pc> </pc>bali<pc> </pc>maṅgala<pc
-                            > </pc>japa<pc> </pc>homopahārejyāñjali<pc
-                            > </pc>namaskāra<pc> </pc>tapo<pc> </pc>niyama<pc
-                            > </pc>dayā<pc> </pc>dāna<pc> </pc>dīkṣābhyupagama<pc
-                            > </pc>devatā<pc> </pc>brāhmaṇa<pc> </pc>guru<pc> </pc>parair
-                        bhavitavyam evaṃ sādhu bhavati ||</l>
+                         jāto 'tra | parityāga<pc> </pc>śānti<pc> </pc>prāyaścitta<pc
+                            > </pc>bali<pc> </pc>maṅgala<pc> </pc>japa<pc
+                            > </pc>homopahārejyāñjali<pc> </pc>namaskāra<pc> </pc>tapo<pc
+                            > </pc>niyama<pc> </pc>dayā<pc> </pc>dāna<pc
+                            > </pc>dīkṣābhyupagama<pc> </pc>devatā<pc> </pc>brāhmaṇa<pc
+                            > </pc>guru<pc> </pc>parair bhavitavyam evaṃ sādhu bhavati ||</l>
 
 
                     <l xml:id="SS.1.6.21"/>
@@ -1695,20 +1640,19 @@
                     <l xml:id="SS.1.7.2a">
                         <label>1.7.2a</label>
                         <caesura/>
-                         tvahyaṃ sasandhiśrotaḥ snāyvasthikoṣṭhagataśalyāddharaṇārtham
-                        upadiśyate |</l>
+                         tvahyaṃ sasandhiśrotaḥ snāyvasthikoṣṭhagataśalyāddharaṇārtham upadiśyate
+                        |</l>
 
                     <l xml:id="SS.1.7.3">
                         <label>1.7.3</label>
                         <caesura/>
-                         yantraśatam ekottaram atra hastayantram eva pradhānatamaṃ
-                        yantrāṇām avagaccha tadadhīnatvād yantrakarmaṇāṃ |</l>
+                         yantraśatam ekottaram atra hastayantram eva pradhānatamaṃ yantrāṇām
+                        avagaccha tadadhīnatvād yantrakarmaṇāṃ |</l>
 
                     <l xml:id="SS.1.7.4">
                         <label>1.7.4</label>
                         <caesura/>
-                         tatra manaḥ śarīrābādhakarāṇi śalyāni teṣāmāharaṇopāyo
-                        yantrāṇi</l>
+                         tatra manaḥ śarīrābādhakarāṇi śalyāni teṣāmāharaṇopāyo yantrāṇi</l>
 
                     <l xml:id="SS.1.7.5">
                         <label>1.7.5</label>
@@ -1720,22 +1664,21 @@
                     <l xml:id="SS.1.7.6">
                         <label>1.7.6</label>
                         <caesura/>
-                         tatra caturvimśati svastikayantrāṇi | dve sandamśayantre | dve
-                        eva tāḍayayantre || viṃśatirnāḍyaḥ aṣṭāviṃśati śalākāḥ |
-                        pañcaviṃśati rupayantrāṇīti |</l>
+                         tatra caturvimśati svastikayantrāṇi | dve sandamśayantre | dve eva
+                        tāḍayayantre || viṃśatirnāḍyaḥ aṣṭāviṃśati śalākāḥ | pañcaviṃśati
+                        rupayantrāṇīti |</l>
 
                     <l xml:id="SS.1.7.7">
                         <label>1.7.7</label>
                         <caesura/>
-                         tāni prāyaśo lohāni bhavanti | tat pratirūpakāṇi vā tad
-                        alābhe</l>
+                         tāni prāyaśo lohāni bhavanti | tat pratirūpakāṇi vā tad alābhe</l>
 
                     <l xml:id="SS.1.7.8">
                         <label>1.7.8</label>
                         <caesura/>
-                         tatra nānāprakārāṇāṃ vyāḍānām mṛgapakṣiṇām mukhair mukhāni
-                        yantrāṇāṃ prāyaśaḥ sadṛśāni bhavanti | tasmāt sārūpyād āgamād
-                        upadeśād anyatra darśanāt | yuktitaś ca kārayet</l>
+                         tatra nānāprakārāṇāṃ vyāḍānām mṛgapakṣiṇām mukhair mukhāni yantrāṇāṃ
+                        prāyaśaḥ sadṛśāni bhavanti | tasmāt sārūpyād āgamād upadeśād anyatra
+                        darśanāt | yuktitaś ca kārayet</l>
 
                     <l xml:id="SS.1.7.9">
                         <label>1.7.9</label>
@@ -1750,8 +1693,8 @@
                          svastikayantrāṇyaṣṭādaśāṅgulāni |
                         siṃhavyāghratarakṣvṛkṣakadvīpimārjjāraśṛgālamṛgervārukākakaṅkakuraracāsabhāsa
                         śaśaghātyulūkacīrillaśyenagṛddhrotkrosabhṛṅgarājāñjalikakarṇṇāvabhañjananandīmukhamukhāni
-                        | masūrākṛtibhiḥ kīlair avabaddhāni | mūleṅkuśavadāvṛttavāraṅgāni
-                        | asthividaṣṭaśalyoddharaṇārtham upadiśyante |</l>
+                        | masūrākṛtibhiḥ kīlair avabaddhāni | mūleṅkuśavadāvṛttavāraṅgāni |
+                        asthividaṣṭaśalyoddharaṇārtham upadiśyante |</l>
 
                     <l xml:id="SS.1.7.11">
                         <label>1.7.11</label>
@@ -1768,11 +1711,10 @@
                     <l xml:id="SS.1.7.13">
                         <label>1.7.13</label>
                         <caesura/>
-                         nāḍīyantrāṇy anekaprakārāṇy anekaprayojanāny anekatomukhāny
-                        ubhayatomukhāni | srotogatagalaśalyoddharaṇārthaṃ
-                        kriyāsaukaryārtham ācūṣaṇārthaṃ rogadarśanārthañ ca | tāni
-                        srotodvārapariṇāhāni yathāyogadīrghāṇi bhavanti | tatra
-                        bhagandarārśor
+                         nāḍīyantrāṇy anekaprakārāṇy anekaprayojanāny anekatomukhāny ubhayatomukhāni
+                        | srotogatagalaśalyoddharaṇārthaṃ kriyāsaukaryārtham ācūṣaṇārthaṃ
+                        rogadarśanārthañ ca | tāni srotodvārapariṇāhāni yathāyogadīrghāṇi bhavanti |
+                        tatra bhagandarārśor
                         budavraṇabastyuttarabastimūtravṛddhidakodaradhūmaniruddhaprakaśasanniruddhagudayantrāṇy
                         alābūśṛṅgayantrāṇi copariṣṭād vakṣyāmaḥ |</l>
 
@@ -1780,15 +1722,14 @@
                         <label>1.7.14</label>
                         <caesura/>
                          śalākāyantrāṇy api nānāprakārāṇi nānāprayojanāni
-                        yathāyogapariṇāhapradīrghāṇi bhavanti | teṣāṅ gaṇḍūpadaśarapuṅkha
-                        | sarppahanu | baḍiśamukhe dve dve | eṣaṇavyūhanacālanāharaṇārtham
-                        upadiśyante | masūradalamātramukhe dve kiñcid ānatāgre
-                        srotogataśalyoddharaṇārtham ṣaṭkārppāsakṛtoṣṇīṣṇāṇi |
-                        pramārjanakriyāsu | kṣārauṣadhapraṇidhānārthantrīṇi darvyākṛtīni
-                        khallamukhāni | jāmbvaṃkuśavadanāny agnikarmāṇi trīṇi triṇi |
-                        nāsārbudaharaṇārthamekaṃ kolāsthidalamātraṃ khallatīkṣṇoṣṭhaṃ |
-                        añjanārthamekaṃ kalāyaparimaṇḍalamubhayato mukulāgraṃ |
-                        mūtramārgaviśuddhyarthamekaṃ
+                        yathāyogapariṇāhapradīrghāṇi bhavanti | teṣāṅ gaṇḍūpadaśarapuṅkha |
+                        sarppahanu | baḍiśamukhe dve dve | eṣaṇavyūhanacālanāharaṇārtham upadiśyante
+                        | masūradalamātramukhe dve kiñcid ānatāgre srotogataśalyoddharaṇārtham
+                        ṣaṭkārppāsakṛtoṣṇīṣṇāṇi | pramārjanakriyāsu |
+                        kṣārauṣadhapraṇidhānārthantrīṇi darvyākṛtīni khallamukhāni |
+                        jāmbvaṃkuśavadanāny agnikarmāṇi trīṇi triṇi | nāsārbudaharaṇārthamekaṃ
+                        kolāsthidalamātraṃ khallatīkṣṇoṣṭhaṃ | añjanārthamekaṃ
+                        kalāyaparimaṇḍalamubhayato mukulāgraṃ | mūtramārgaviśuddhyarthamekaṃ
                         mālatīpuṣpavṛntāgrapramāṇaparimaṇḍalamiti ||</l>
 
                     <l xml:id="SS.1.7.15">
@@ -1796,8 +1737,7 @@
                         <caesura/>
                          upayantrāṇy api
                         rajjuveṇikācarmāntarvalkalalatāvastrāṣṭhīlāṣmantakamudgarapāṇipādatalāṅgulijihvādantanakhamukhabālāśmaśākhā
-                        ṣṭhīvanapravāhaṇaharṣāmaskārttagatāni kṣārāgnibheṣajāni ceti
-                        ||</l>
+                        ṣṭhīvanapravāhaṇaharṣāmaskārttagatāni kṣārāgnibheṣajāni ceti ||</l>
 
                     <l xml:id="SS.1.7.16">
                         <label>1.7.16</label>
@@ -1824,8 +1764,7 @@
                         <label>1.7.19</label>
                         <caesura/>
                          tatrātisthūlam asāram atidīrgham atihrasvam agrāhivakraṃ śithilam
-                        atyunnataṃ mṛdukīlaṃ mṛdupāśaṃ mṛdumukham iti dvādaśayantradoṣāḥ
-                        ||</l>
+                        atyunnataṃ mṛdukīlaṃ mṛdupāśaṃ mṛdumukham iti dvādaśayantradoṣāḥ ||</l>
 
                     <l xml:id="SS.1.7.20">
                         <label>1.7.20</label>
@@ -1846,8 +1785,7 @@
                         <caesura/>
                          vivarttate sādhvavagāhate ca gṛhṇāti gṛhyoddharate ca yasmāt |
                         <caesura/>
-                         tasmāt smṛtaṅ kāṅkamukhaṃ pradhānaṃ sthāneṣu sarveṣv avikāri yac
-                        ceti || </l>
+                         tasmāt smṛtaṅ kāṅkamukhaṃ pradhānaṃ sthāneṣu sarveṣv avikāri yac ceti || </l>
 
                     <l xml:id="SS.1.7.trailer"> || ṅ ||</l>
 
@@ -1869,38 +1807,33 @@
                          ekaviṃśatiḥ śastrāṇi bhavanti | tad yathā |
                             maṇḍalāgrārdhamaṇḍalāgra<pc> </pc>karapatra<pc
                             > </pc>vṛddhipatra<pc> </pc>nakhaśastra<pc
-                            > </pc>mudrikotpalapatrakādhyardhadhāra<pc
-                            > </pc>sūcī<pc> </pc>kuśapatrāṭāmukha<pc
-                            > </pc>śarārīmukhāntarmukha<pc> </pc>trikurcaka<pc
-                            > </pc>kuṭhārikā<pc> </pc>vrīhimukhārā<pc
-                            > </pc>vetasapatra<pc> </pc>baḍiśa<pc> </pc>dantaśaṅkveṣaṇya
-                        iti |</l>
+                            > </pc>mudrikotpalapatrakādhyardhadhāra<pc> </pc>sūcī<pc
+                            > </pc>kuśapatrāṭāmukha<pc> </pc>śarārīmukhāntarmukha<pc
+                            > </pc>trikurcaka<pc> </pc>kuṭhārikā<pc> </pc>vrīhimukhārā<pc
+                            > </pc>vetasapatra<pc> </pc>baḍiśa<pc> </pc>dantaśaṅkveṣaṇya iti |</l>
 
                     <l xml:id="SS.1.8.4">
                         <label>1938 ed. 1.8.4</label>
                         <caesura/>
-                         tatra maṇḍalāgram ardhamaṇḍalāgrakarapatrāṇi cchedane lekhane
-                        copadiśyante | vṛddhipatra<pc> </pc>nakhaśastra<pc
-                        > </pc>mudrikotpalapatrakādhyardhadhārāṇi bhedane cchedane
-                        copayujyante | sūcī<pc> </pc>kuṭhārikā<pc
-                            > </pc>vrīhimukhārā<pc> </pc>vetasapatrāṇi vedhane | eṣaṇy
-                        eṣaṇe | anulomāḥ karīrāḥ śastravṛttāś ca | sūcī baḍiśadantaśaṅkuś
-                        cāharaṇe | kuśapatrāṭāmukhaśarārimukhāntarmukhatrikurcakāni
-                        visrāvaṇe | sūcī sīvyana ity aṣṭavidhaḥ śastrāṇāṃ karmaṇy upayogo
-                        vyākhyātaḥ | </l>
+                         tatra maṇḍalāgram ardhamaṇḍalāgrakarapatrāṇi cchedane lekhane copadiśyante
+                        | vṛddhipatra<pc> </pc>nakhaśastra<pc
+                        > </pc>mudrikotpalapatrakādhyardhadhārāṇi bhedane cchedane copayujyante |
+                            sūcī<pc> </pc>kuṭhārikā<pc> </pc>vrīhimukhārā<pc> </pc>vetasapatrāṇi
+                        vedhane | eṣaṇy eṣaṇe | anulomāḥ karīrāḥ śastravṛttāś ca | sūcī
+                        baḍiśadantaśaṅkuś cāharaṇe |
+                        kuśapatrāṭāmukhaśarārimukhāntarmukhatrikurcakāni visrāvaṇe | sūcī sīvyana
+                        ity aṣṭavidhaḥ śastrāṇāṃ karmaṇy upayogo vyākhyātaḥ | </l>
 
                     <l xml:id="SS.1.8.5">
                         <label>1938 ed. 1.8.5</label>
                         <caesura/>
-                         teṣāṃ yathāyogaṃ grahaṇam | karmasv eṣa śastragrahaṇasamāsaḥ |
-                        vṛddhipatran tu vṛntaphalasādhāraṇe bhāge gṛhṇīyāt | bhedanāny
-                        evaṃ sarvāṇi | vṛddhipatravad ardhamaṇḍalāgraṃ kiñcid uttānapāṇinā
-                        lekhane bahuśo 'vacārya vṛntāgreṇa visrāvaṇāni | viśeṣeṇa tu
-                        bālavṛddhasukumārabhīrunārīṇāṃ rājñāṃ rājamātrāṇāṃ vā trikurcakena
-                        visrāvayet | talapracchādita<pc> </pc>vṛntāgram
-                        aṅguṣṭhapradeśinībhyāṃ vrīhimukham | kuṭhārikāṃ
-                        vāmahastagṛhītapucchāṃ dakṣiṇahastāṅguṣṭhāvaṣṭabdhayā
-                        madhyamayāṅgulyā nihanyāt | tatra
+                         teṣāṃ yathāyogaṃ grahaṇam | karmasv eṣa śastragrahaṇasamāsaḥ | vṛddhipatran
+                        tu vṛntaphalasādhāraṇe bhāge gṛhṇīyāt | bhedanāny evaṃ sarvāṇi |
+                        vṛddhipatravad ardhamaṇḍalāgraṃ kiñcid uttānapāṇinā lekhane bahuśo 'vacārya
+                        vṛntāgreṇa visrāvaṇāni | viśeṣeṇa tu bālavṛddhasukumārabhīrunārīṇāṃ rājñāṃ
+                        rājamātrāṇāṃ vā trikurcakena visrāvayet | talapracchādita<pc> </pc>vṛntāgram
+                        aṅguṣṭhapradeśinībhyāṃ vrīhimukham | kuṭhārikāṃ vāmahastagṛhītapucchāṃ
+                        dakṣiṇahastāṅguṣṭhāvaṣṭabdhayā madhyamayāṅgulyā nihanyāt | tatra
                             karapatrārāvetasapatrabaḍiśadanta<pc> </pc>śaṅkveṣaṇīr mūle
                         pradeśinīprayuktam |</l>
 
@@ -1908,44 +1841,42 @@
                     <l xml:id="SS.1.8.6">
                         <label>1938 ed. 1.8.6</label>
                         <caesura/>
-                         mudrikāsadṛśaṃ nakhākāraśastramukhañ caturvedhanaṃ
-                            sūkṣma<pc> </pc>ḍorāvabaddhaṃ mudrikāśastraṃ teṣān nāmabhir
-                        evākṛtayaḥ prāyeṇa vyākhyātāḥ |</l>
+                         mudrikāsadṛśaṃ nakhākāraśastramukhañ caturvedhanaṃ sūkṣma<pc
+                        > </pc>ḍorāvabaddhaṃ mudrikāśastraṃ teṣān nāmabhir evākṛtayaḥ prāyeṇa
+                        vyākhyātāḥ |</l>
 
                     <l xml:id="SS.1.8.7-8">
                         <label>1938 ed. 1.8.7-8</label>
                         <caesura/>
-                         tatra nakhavardhanaiṣaṇyāv aṣṭāṅgulyau sūcyo vakṣyante | śeṣāṇi
-                        tu ṣaḍaṅgulāni tāni sugrahāṇi sudhārāṇi surūpāṇi sulohāni
-                        sudhautāni samāñcitamukhāni ceti śastrasampat |</l>
+                         tatra nakhavardhanaiṣaṇyāv aṣṭāṅgulyau sūcyo vakṣyante | śeṣāṇi tu
+                        ṣaḍaṅgulāni tāni sugrahāṇi sudhārāṇi surūpāṇi sulohāni sudhautāni
+                        samāñcitamukhāni ceti śastrasampat |</l>
 
                     <l xml:id="SS.1.8.10">
                         <label>1938 ed. 1.8.10</label>
                         <caesura/>
-                         tatra dhārā bhedanānāṃ māsūrī | lekhanānām ardhamāsūrī |
-                        vedhyānāṃ visrāvaṇānāñ ca kaiśikī | chedanānām ardhakaiśikī |</l>
+                         tatra dhārā bhedanānāṃ māsūrī | lekhanānām ardhamāsūrī | vedhyānāṃ
+                        visrāvaṇānāñ ca kaiśikī | chedanānām ardhakaiśikī |</l>
 
                     <l xml:id="SS.1.8.11">
                         <label>1938 ed. 1.8.11</label>
                         <caesura/>
-                         baḍiśadantaśaṅku cānatāgre | tīkṣṇakaṇṭakaprathamayavapatramukhī
-                        yavapatrā eṣaṇī gaṇḍūpadākāramukhī ceti |</l>
+                         baḍiśadantaśaṅku cānatāgre | tīkṣṇakaṇṭakaprathamayavapatramukhī yavapatrā
+                        eṣaṇī gaṇḍūpadākāramukhī ceti |</l>
 
                     <l xml:id="SS.1.8.9">
                         <label>1938 ed. 1.8.9</label>
                         <caesura/>
-                         tatra vakraṃ kuṇṭhaṃ khaṇḍaṃ kharadhārātisthūlam atyalpam
-                        atidīrgham atihrasvam ity aṣṭau śastradoṣāḥ | ato viparītaguṇam
-                        ādadyād anyatra karapatrāt | tad dhi kharadhāram
-                        asthicchedanārtham |</l>
+                         tatra vakraṃ kuṇṭhaṃ khaṇḍaṃ kharadhārātisthūlam atyalpam atidīrgham
+                        atihrasvam ity aṣṭau śastradoṣāḥ | ato viparītaguṇam ādadyād anyatra
+                        karapatrāt | tad dhi kharadhāram asthicchedanārtham |</l>
 
                     <l xml:id="SS.1.8.12"/>
 
                     <l xml:id="SS.1.8.13">
                         <label>1938 ed. 1.8.13</label>
                         <caesura/>
-                         teṣān niśānī ślakṣṇaśilikā dhārāsampādanārthaṃ śālmalīphalakaṃ
-                        ceti || </l>
+                         teṣān niśānī ślakṣṇaśilikā dhārāsampādanārthaṃ śālmalīphalakaṃ ceti || </l>
 
                     <l xml:id="SS.1.8.14">
                         <label>1938 ed. 1.8.14</label>
@@ -1960,8 +1891,7 @@
                         <label>1938 ed. 1.8.15</label>
                         <caesura/>
                          anuśastrāṇi tvakkṣāra<pc> </pc>sphaṭika<pc> </pc>kāca<pc
-                            > </pc>kuravinda<pc> </pc>jalaukāgni<pc> </pc>nakhapatrāṇi
-                        ||</l>
+                            > </pc>kuravinda<pc> </pc>jalaukāgni<pc> </pc>nakhapatrāṇi ||</l>
 
                     <l xml:id="SS.1.8.16">
                         <label>1938 ed. 1.8.16</label>
@@ -1984,8 +1914,7 @@
                         <caesura/>
                          ye syur mukhagatā rogā netravarmagatāś ca ye |
                         <caesura/>
-                         gojī<pc> </pc>śephālikā<pc> </pc>śākapatrair visrāvayet tu tān
-                        ||</l>
+                         gojī<pc> </pc>śephālikā<pc> </pc>śākapatrair visrāvayet tu tān ||</l>
 
 
                     <l xml:id="SS.1.8.19">
@@ -2015,17 +1944,15 @@
                     <l xml:id="SS.1.9.3">
                         <label>1938 ed., 1.9.3</label>
                         <caesura/>
-                         adhigatasarvaśāstram api śiṣyaṃ yogyāṃ kārayet | cchedyādiṣu
-                        snehādiṣu karmapatham upadiśet | bahuśruto py akṛtayogaḥ karmasv
-                        ayogyo bhavati |</l>
+                         adhigatasarvaśāstram api śiṣyaṃ yogyāṃ kārayet | cchedyādiṣu snehādiṣu
+                        karmapatham upadiśet | bahuśruto py akṛtayogaḥ karmasv ayogyo bhavati |</l>
 
                     <l xml:id="SS.1.9.4">
                         <label>1938 ed., 1.9.4</label>
                         <caesura/>
-                         tatra puṣpaphalālāvutrapuservārukaprabhṛtiṣu cchedyaśeṣāṃ
-                        darśayet | utkartanāpakarttanāni copadiśet |
-                        dṛtibastiprasevakapūrṇeṣu bhedyayogyāṃ | saromṇi carmātate
-                        lekhyasya | mṛtapaśumahiṣāsvaśirāsūtpalanāleṣu vedhyasya |
+                         tatra puṣpaphalālāvutrapuservārukaprabhṛtiṣu cchedyaśeṣāṃ darśayet |
+                        utkartanāpakarttanāni copadiśet | dṛtibastiprasevakapūrṇeṣu bhedyayogyāṃ |
+                        saromṇi carmātate lekhyasya | mṛtapaśumahiṣāsvaśirāsūtpalanāleṣu vedhyasya |
                         ghuṇopahatakāṣṭhaveṇunalanāḍīśuṣkālābumukheṣveṣyasya |
                         panasabimbīphalamajjāmṛtapaśudanteṣvāhāryasya
                         sūkṣmaghanavastrāntamṛducarmāntayoḥ sīvyasya |
@@ -2040,13 +1967,12 @@
                         <caesura/>
                          bhavati cātra ||
                         <caesura/>
-                        evam ādiṣu medhāvī yogyākarmaṇy aśeṣataḥ |</l>
+                         evam ādiṣu medhāvī yogyākarmaṇy aśeṣataḥ |</l>
 
                     <l xml:id="SS.1.9.5cd"/>
                     <l xml:id="SS.1.9.6ab"/>
 
-                    <l xml:id="SS.1.9.6cd"> yasya yasyeha sādharmyaṃ tatra yogyāñ ca
-                        kārayet || </l>
+                    <l xml:id="SS.1.9.6cd"> yasya yasyeha sādharmyaṃ tatra yogyāñ ca kārayet || </l>
 
 
                     <!-- begin chunk-->
@@ -2070,34 +1996,30 @@
                         <label>1938 ed., 1.10.3</label>
                         <caesura/>
                          adhigatatantreṇopāsitatantrārthena dṛṣṭakarmaṇā kṛtayogyena
-                        śāstrārthannigadatā rājānujñātena vaidyena viśikhācaritavyā |
-                        nīcanakharomṇā śucinā śucivastraparihitena chatravatā
-                        sopānatkenānuddhataveṣeṇa sumanasā kalyāṇābhivyāhāreṇākuhakena
-                        bandhubhūtena bhūtānāṃ sahāyavatā |</l>
+                        śāstrārthannigadatā rājānujñātena vaidyena viśikhācaritavyā | nīcanakharomṇā
+                        śucinā śucivastraparihitena chatravatā sopānatkenānuddhataveṣeṇa sumanasā
+                        kalyāṇābhivyāhāreṇākuhakena bandhubhūtena bhūtānāṃ sahāyavatā |</l>
 
                     <l xml:id="SS.1.10.4.1">
                         <label>1938 ed., 1.10.4</label>
                         <caesura/>
                          tato dūtanimittaśakunamaṅgalānulomyenātura<pc> </pc>gṛham
-                        āgamyopaviśyāturam abhipaśyet spṛśet pṛcchec ca tribhir etair
-                        vijñānopāyaiḥ | dīrgham āyuṣo 'lpāyuṣo veditavyāḥ |<anchor
-                            n="SS.1.10.4.1-n1"/>
+                        āgamyopaviśyāturam abhipaśyet spṛśet pṛcchec ca tribhir etair vijñānopāyaiḥ
+                        | dīrgham āyuṣo 'lpāyuṣo veditavyāḥ |<anchor n="SS.1.10.4.1-n1"/>
                     </l>
 
                     <ab corresp="#SS.1.10.4.1" type="apparatus">
                         <list type="Notes">
                             <item corresp="#SS.1.10.4.1-n1">MS K seems to have
-                                    <foreign>veditavyāḥ</foreign> although the final
-                                visarga isn't clear and the manuscript is damaged at this
-                                point. It was read as a visarga by Ācārya (1939: 77, note
-                                2).</item>
-                            <item corresp="#SS.1.10.4.1-n1">The vulgate here adds a
-                                passage that is taken to be a reference to the doctrines
-                                of the <title>Carakasaṃhitā</title>. See HIML 1A, 351-352.
-                                The commentary <title>Bhānumatī</title> by Cakrapāṇidatta
-                                does not support this added passage (<foreign>ayaṃ pāṭhaś
-                                    cakrāsaṃmataḥ</foreign>: Ācārya 1939: 77, note 2).
-                            </item>
+                                    <foreign>veditavyāḥ</foreign> although the final visarga isn't
+                                clear and the manuscript is damaged at this point. It was read as a
+                                visarga by Ācārya (1939: 77, note 2).</item>
+                            <item corresp="#SS.1.10.4.1-n1">The vulgate here adds a passage that is
+                                taken to be a reference to the doctrines of the
+                                    <title>Carakasaṃhitā</title>. See HIML 1A, 351-352. The
+                                commentary <title>Bhānumatī</title> by Cakrapāṇidatta does not
+                                support this added passage (<foreign>ayaṃ pāṭhaś
+                                    cakrāsaṃmataḥ</foreign>: Ācārya 1939: 77, note 2). </item>
                         </list>
                     </ab>
 
@@ -2106,10 +2028,10 @@
                     <l xml:id="SS.1.10.5">
                         <label>1938 ed., 1.10.5</label>
                         <caesura/>
-                         tatra dṛṣṭvā yau varṇṇavaikṛticchāyāṃ cāturasya bhiṣagjānīyāt |
-                        spṛṣṭvā śītoṣṇādīṃ sparśaviśeṣā viparītāviparītāṃ jvaraśophādīṃ |
-                        pṛṣṭvā deśaṃ kālaṃ jātisāmyam ātaṅkam utpatti vedanāsamucchrāyo
-                        balābalam agniṃ vātamūtrapurīṣāṇām apravṛttipravṛttiṃ ceti ||</l>
+                         tatra dṛṣṭvā yau varṇṇavaikṛticchāyāṃ cāturasya bhiṣagjānīyāt | spṛṣṭvā
+                        śītoṣṇādīṃ sparśaviśeṣā viparītāviparītāṃ jvaraśophādīṃ | pṛṣṭvā deśaṃ kālaṃ
+                        jātisāmyam ātaṅkam utpatti vedanāsamucchrāyo balābalam agniṃ
+                        vātamūtrapurīṣāṇām apravṛttipravṛttiṃ ceti ||</l>
 
                     <l xml:id="SS.1.10.7">
                         <label>1938 ed., 1.10.7</label>
@@ -2130,18 +2052,16 @@
                     <l xml:id="SS.1.10.6">
                         <label>1938 ed., 1.10.6</label>
                         <caesura/>
-                         evam abhisamīkṣya sādhyāṃ sādhayed yāpyāṃ yāpayed
-                        asādhyān nopakrāmet | parivatsaroṣitāṃś ca vikārām prāyaśaḥ
-                        parivarjjayet |</l>
+                         evam abhisamīkṣya sādhyāṃ sādhayed yāpyāṃ yāpayed asādhyān nopakrāmet |
+                        parivatsaroṣitāṃś ca vikārām prāyaśaḥ parivarjjayet |</l>
 
                     <l xml:id="SS.1.10.8">
                         <label>1938 ed., 1.10.8</label>
                         <caesura/>
                          tatra sādhyā api vyādhayaḥ prāyaśo duścikitsā bhavanti |
                             śrotriyanṛpatistrībālavṛddhabhīru<pc> </pc>durbala<pc
-                            > </pc>vaidyavidagdha<pc> </pc>vyādhiguhaka<pc
-                            > </pc>daridra<pc> </pc>kṛpaṇa<pc> </pc>krodhanānātmavatāt
-                        ||</l>
+                            > </pc>vaidyavidagdha<pc> </pc>vyādhiguhaka<pc> </pc>daridra<pc
+                            > </pc>kṛpaṇa<pc> </pc>krodhanānātmavatāt ||</l>
 
                     <l xml:id="SS.1.10.9">
                         <label>1938 ed., 1.10.9</label>
@@ -2194,11 +2114,11 @@
                     <l xml:id="SS.1.11.5">
                         <label>1938 ed., 1.11.5</label>
                         <caesura/>
-                         nānauṣadhisamavāyāttridoṣaghnaḥ | śuklatvāt saumyas tasya
-                        saumyasyāpi sato dahanapacanadāraṇaśaktiraviruddhā |
-                        sakhalvāgneyauṣadhibhūya kaḥ | uṣṇastīkṣṇaḥ pācano vilāyanaḥ |
-                        śodhano ropaṇaḥ stambhanollekhanakrimyāmakaphaviṣamedasām upahantā
-                        puṃstvasya cātisevitaḥ |</l>
+                         nānauṣadhisamavāyāttridoṣaghnaḥ | śuklatvāt saumyas tasya saumyasyāpi sato
+                        dahanapacanadāraṇaśaktiraviruddhā | sakhalvāgneyauṣadhibhūya kaḥ |
+                        uṣṇastīkṣṇaḥ pācano vilāyanaḥ | śodhano ropaṇaḥ
+                        stambhanollekhanakrimyāmakaphaviṣamedasām upahantā puṃstvasya cātisevitaḥ
+                        |</l>
 
 
                     <l xml:id="SS.1.11.6">
@@ -2210,32 +2130,27 @@
                     <l xml:id="SS.1.11.7">
                         <label>1938 ed., 1.11.7</label>
                         <caesura/>
-                         tatra pratisāraṇīyaḥ | kuṣṭha<pc> </pc>kiṭibha<pc
-                            > </pc>dardru<pc> </pc>maṇḍala<pc> </pc>kilāsa<pc
-                            > </pc>bhagandarārśorbuda<pc> </pc>duṣṭa<pc
-                            > </pc>vraṇa<pc> </pc>nāḍī<pc> </pc>carma<pc
-                            > </pc>kīla<pc> </pc>tilakālakanaccha<pc
-                            > </pc>vyaṅga<pc> </pc>bāhya<pc> </pc>krimi<pc> </pc>viṣādiṣu
-                        copadiśyate | saptasu ca
-                        mukharogeṣūpajihvopakuśadantavaidarbhamedajoṣṭhaprakopeṣu triṣu ca
-                        rohiṇīṣu eteṣv evānuśastra<pc> </pc>pātanam uktaṃ ||<anchor
-                            n="SS.1.11.7-n1"/>
+                         tatra pratisāraṇīyaḥ | kuṣṭha<pc> </pc>kiṭibha<pc> </pc>dardru<pc
+                            > </pc>maṇḍala<pc> </pc>kilāsa<pc> </pc>bhagandarārśorbuda<pc
+                            > </pc>duṣṭa<pc> </pc>vraṇa<pc> </pc>nāḍī<pc> </pc>carma<pc
+                            > </pc>kīla<pc> </pc>tilakālakanaccha<pc> </pc>vyaṅga<pc
+                            > </pc>bāhya<pc> </pc>krimi<pc> </pc>viṣādiṣu copadiśyate | saptasu ca
+                        mukharogeṣūpajihvopakuśadantavaidarbhamedajoṣṭhaprakopeṣu triṣu ca rohiṇīṣu
+                        eteṣv evānuśastra<pc> </pc>pātanam uktaṃ ||<anchor n="SS.1.11.7-n1"/>
                     </l>
 
                     <ab corresp="#SS.1.11.7" type="apparatus">
                         <list type="Testimonia">
-                            <item corresp="#SS.1.11.7-n1">Ḍalhaṇa reported that some
-                                people read <foreign>evānuśastrapātanam</foreign> as here,
-                                as opposed to the vulgate's
-                                    <foreign>anuśastrapraṇidhānam</foreign>.</item>
+                            <item corresp="#SS.1.11.7-n1">Ḍalhaṇa reported that some people read
+                                    <foreign>evānuśastrapātanam</foreign> as here, as opposed to the
+                                vulgate's <foreign>anuśastrapraṇidhānam</foreign>.</item>
                         </list>
                     </ab>
 
                     <l xml:id="SS.1.11.8">
                         <label>1938 ed., 1.11.8</label>
                         <caesura/>
-                         pānīyas tu
-                        gulmādarāgnisaṃgājīrṇṇānāhaśarkarāśmaryabhyantarakrimiviṣāśassu
+                         pānīyas tu gulmādarāgnisaṃgājīrṇṇānāhaśarkarāśmaryabhyantarakrimiviṣāśassu
                         copayujyate ||</l>
 
                     <l xml:id="SS.1.11.9"/>
@@ -2248,20 +2163,18 @@
                     <l xml:id="SS.1.11.11">
                         <label>1938 ed., 1.11.11</label>
                         <caesura/>
-                         athetaraṃ cikīrṣuḥ | śaradi śucir upavasan praśastadeśajātam
-                        anupahataṃ madhyamavayasaṃ kālamuṣkakam adhivāsyāparedyuḥ
-                        pātayitvā kaṇḍasaḥ prakalpya nivātadeśe citiṅ kṛtvā tilanālair
-                        ādīpayet | athopaśānte 'gnau tad bhasma pṛthag gṛhṇīyāt
-                        bhasmaśarkarāś ca || athānenaiva kalpena
+                         athetaraṃ cikīrṣuḥ | śaradi śucir upavasan praśastadeśajātam anupahataṃ
+                        madhyamavayasaṃ kālamuṣkakam adhivāsyāparedyuḥ pātayitvā kaṇḍasaḥ prakalpya
+                        nivātadeśe citiṅ kṛtvā tilanālair ādīpayet | athopaśānte 'gnau tad bhasma
+                        pṛthag gṛhṇīyāt bhasmaśarkarāś ca || athānenaiva kalpena
                         kuṭajapalāśāśvakarṇṇapāribhadrakabibhītakāragvadhatilvakārkasnuhyāpāmārganaktamālavṛṣakadalīcitrakendrayavṛkṣāsphotāśvamārakasaptacchadāgnimanthāḥ
-                        | catasraḥ kośātakyaḥ samūlaphalaśākhāpatrān dahet tataḥ
-                        kṣāradroṇam udakadroṇaiḥ ṣaḍbhir āloḍya mūtraiś ca yathoktair
-                        mahati kaṭāhe śanaiś śanair davyāvaghaṭṭayan vipacet sa yadā
-                        bhavaty acchoraktas tīkṣṇaḥ picchilaś ca tam ādāyetaraṃ saṃsṛjya
-                        punar api pākāyādhiśrayet tata eva ca kṣārodakakuḍavamadhyardha
-                        kṛtvāpanayet tataḥ kaṭaśarkarābhasmaśarkarāś ca |
-                        kṣīrapakaśaṃkhanābhīr agnivarṇṇāḥ kṛtvāyase pātre tasmiṃ kṣārodake
-                        niṣicya | piṣṭvā tathaiva ca</l>
+                        | catasraḥ kośātakyaḥ samūlaphalaśākhāpatrān dahet tataḥ kṣāradroṇam
+                        udakadroṇaiḥ ṣaḍbhir āloḍya mūtraiś ca yathoktair mahati kaṭāhe śanaiś
+                        śanair davyāvaghaṭṭayan vipacet sa yadā bhavaty acchoraktas tīkṣṇaḥ
+                        picchilaś ca tam ādāyetaraṃ saṃsṛjya punar api pākāyādhiśrayet tata eva ca
+                        kṣārodakakuḍavamadhyardha kṛtvāpanayet tataḥ kaṭaśarkarābhasmaśarkarāś ca |
+                        kṣīrapakaśaṃkhanābhīr agnivarṇṇāḥ kṛtvāyase pātre tasmiṃ kṣārodake niṣicya |
+                        piṣṭvā tathaiva ca</l>
 
                     <l xml:id="SS.1.11.11b"/>
 
@@ -2278,9 +2191,9 @@
                     <l xml:id="SS.1.11.13.1">
                         <label>1.11.13.1</label>
                         <caesura/>
-                         satatam apramattaś ca darvyāvaghaṭāyaṃ vipacet | sa yathā
-                        nātisāndro nātidravaś ca bhavati tathā prayateta | athainam
-                        āgatapākam avatāryānuguptam āyase kumbhe nidadhyāt |</l>
+                         satatam apramattaś ca darvyāvaghaṭāyaṃ vipacet | sa yathā nātisāndro
+                        nātidravaś ca bhavati tathā prayateta | athainam āgatapākam avatāryānuguptam
+                        āyase kumbhe nidadhyāt |</l>
 
 
 
@@ -2313,9 +2226,8 @@
                         <label>1938 ed., 1.11.18</label>
                         <caesura/>
                          tatra kṣārasādhyavyādhiṃ vyādhitam upaveśya nivātāsambādhe deśe
-                        agropaharaṇīyoktopasaṃbhārasaṃbhṛtatanoḥ | anyatamam
-                        avaghṛṣyāvalikhya pracchayitvā vā śalākayā kṣāraṃ pratisārya
-                        vākchatamātram upaikṣeta |</l>
+                        agropaharaṇīyoktopasaṃbhārasaṃbhṛtatanoḥ | anyatamam avaghṛṣyāvalikhya
+                        pracchayitvā vā śalākayā kṣāraṃ pratisārya vākchatamātram upaikṣeta |</l>
 
                     <l xml:id="SS.1.11.19">
                         <label>1938 ed., 1.11.19</label>
@@ -2375,8 +2287,8 @@
                         <label>1938 ed., 1.11.26</label>
                         <caesura/>
                          tatra samyagdagdhe vikāropaśamo lāghavamanāsrāvaś ca | hīne
-                        todakaṇḍūjāḍyāni vyādhivṛddhiś ca | atidagdhe
-                        dāhapākaśramāṅgamadaklamāḥ | pipāsāmaraṇāñ ceti |</l>
+                        todakaṇḍūjāḍyāni vyādhivṛddhiś ca | atidagdhe dāhapākaśramāṅgamadaklamāḥ |
+                        pipāsāmaraṇāñ ceti |</l>
 
                     <l xml:id="SS.1.11.27">
                         <label>1938 ed., 1.11.27</label>
@@ -2393,15 +2305,14 @@
                     <l xml:id="SS.1.11.29">
                         <label>1938 ed., 1.11.29</label>
                         <caesura/>
-                         tathā
-                        marmasirāsnāyusandhitaruṇāsthisevanīgalanābhinakhāntarasepasrotaḥ
+                         tathā marmasirāsnāyusandhitaruṇāsthisevanīgalanābhinakhāntarasepasrotaḥ
                         svalpamāṃsapradeśeṣv akṣṇoś ca na dadyād anyatra varmarogāt |</l>
 
                     <l xml:id="SS.1.11.30">
                         <label>1938 ed., 1.11.30</label>
                         <caesura/>
-                         tatra kṣārasādhyeṣv api vyādhiṣu śūnagātram asthiśūlinam
-                        annadveṣiṇaṃ hṛdayasandhipīḍopadrutañ ca kṣāro na sādhayati ||</l>
+                         tatra kṣārasādhyeṣv api vyādhiṣu śūnagātram asthiśūlinam annadveṣiṇaṃ
+                        hṛdayasandhipīḍopadrutañ ca kṣāro na sādhayati ||</l>
 
                     <l xml:id="SS.1.11.31">
                         <label>1938 ed., 1.11.31</label>
@@ -2410,8 +2321,7 @@
                         <caesura/>
                          viṣāgniśastrāśanimṛtyutulyaḥ kṣāro bhavaty alpamatiprayuktaḥ |
                         <caesura/>
-                         satvapramattena sadā prayukto rogān nihanyād acireṇa ghorān iti
-                        ||</l>
+                         satvapramattena sadā prayukto rogān nihanyād acireṇa ghorān iti ||</l>
 
 
                 </div>
@@ -2430,20 +2340,37 @@
 
                     <l xml:id="SS.1.12.2"/>
 
-                    <l xml:id="SS.1.12.3">
-                        <label>1938 ed., 1.12.3</label>
+                    <l xml:id="SS.1.12.3a">
+                        <label>1938 ed., 1.12.3a</label>
                         <caesura/>
-                         kṣārād agnir garīyāṃ kriyāsu vyākhyātas taddagdhānāṃ rogāṇām
-                        apunarbhavāt | svedaśastrakṣārair asakyānāṃ tatsādhanāc ca |</l>
+                         kṣārād agnir garīyāṃ kriyāsu vyākhyātas</l>
 
-                    <l xml:id="SS.1.12.4">
-                        <label>1938 ed., 1.12.4</label>
+                    <l xml:id="SS.1.12.3b">
+                        <label>1938 ed., 1.12.3b</label>
+                        <caesura/>
+                         taddagdhānāṃ rogāṇām apunarbhavāt | svedaśastrakṣārair asakyānāṃ
+                        tatsādhanāc ca |</l>
+
+                    <l xml:id="SS.1.12.4a">
+                        <label>1938 ed., 1.12.4a</label>
                         <caesura/>
                          athaimāni dahanopakaraṇāni bhavanti |
-                        pippalyajāśakṛdgodantaśaraśalākājamvvoṣṭhetaralohakṣaudraguḍasnehādīni
-                        | tatra pippalyajāśakṛdgodantaśaraśalākāḥ stvaggatānāṃ |
-                        jamvvoṣṭhetaralohāḥ māṃsagatānāṃ | kṣaudraguḍasnehāḥ
-                        sirāsnāyusandhyasthigatānā |</l>
+                        pippalyajāśakṛdgodantaśaraśalākājamvvoṣṭhetaralohakṣaudraguḍasnehādīni |</l>
+
+                    <l xml:id="SS.1.12.4b">
+                        <label>1938 ed., 1.12.4b</label>
+                        <caesura/>
+                        tatra pippalyajāśakṛdgodantaśaraśalākāḥ stvaggatānāṃ |</l>
+
+                    <l xml:id="SS.1.12.4c">
+                        <label>1938 ed., 1.12.4c</label>
+                        <caesura/>
+                         jamvvoṣṭhetaralohāḥ māṃsagatānāṃ |</l>
+
+                    <l xml:id="SS.1.12.4d">
+                        <label>1938 ed., 1.12.4d</label>
+                        <caesura/>
+                        kṣaudraguḍasnehāḥ sirāsnāyusandhyasthigatānā |</l>
 
                     <l xml:id="SS.1.12.5">
                         <label>1938 ed., 1.12.5</label>
@@ -2451,31 +2378,37 @@
                          tatrāgnikarma sarvartuṣu kuryād anyatra śaradgrīṣmābhyāṃ |
                         tatrāpyātyayikegnisādhye vyādhau tatpratyanīkaṃ vidhiṃ kṛtvā</l>
 
-                    <l xml:id="SS.1.12.6">
+                    <l xml:id="SS.1.12.6a">
                         <label>1938 ed., 1.12.6</label>
                         <caesura/>
                          sarvavyādhiṣvṛtuṣu ca picchilam annambhuktavataḥ |</l>
 
+                    <l xml:id="SS.1.12.6b"/>
+
+
                     <l xml:id="SS.1.12.7">
                         <label>1938 ed., 1.12.7</label>
                         <caesura/>
-                         tatra dvividham agnidagdham āhur eke | tvagdagdhaṃ māṃsadagdhañ
-                        ca | iha tu sirāsnāyuṣu sandhyasthiṣv api na pratiṣiddhogniḥ |</l>
+                         tatra dvividham agnidagdham āhur eke | tvagdagdhaṃ māṃsadagdhañ ca | iha tu
+                        sirāsnāyuṣu sandhyasthiṣv api na pratiṣiddho 'gniḥ |</l>
 
                     <l xml:id="SS.1.12.8">
                         <label>1938 ed., 1.12.8</label>
                         <caesura/>
                          tatra śabdaprādurbhāvo durgandhatā tvaksaṃkocaś ca tvagdagdhe |
-                        kapotavarṇṇatālpaśvayathuvedanatā śuṣkasaṃkucitavraṇatā ca
-                        māṃsadagdhe | kṛṣṇonnatavraṇatā srāvasannirodhaśca sirāsnāyudagdhe
+                        kapotavarṇṇatālpaśvayathuvedanatā śuṣkasaṃkucitavraṇatā ca māṃsadagdhe |
+                        kṛṣṇonnatavraṇatā srāvasannirodhaśca sirāsnāyudagdhe
                         rūkṣatāruṇatākarkaśasthiravraṇatā ca sandhyasthidagdhe ||</l>
 
-                    <l xml:id="SS.1.12.9">
-                        <label>1938 ed., 1.12.9</label>
+                    <l xml:id="SS.1.12.9a">
+                        <label>1938 ed., 1.12.9a</label>
                         <caesura/>
-                         tatra śirorogādhimanthayorbhrūlalāṭaśaṅkhadeśeṣu
-                        dahedvartmarogeṣvārdranaktakapraticchannāndṛṣṭiṃ kṛtvā
-                        vartmaromakūpāṃ |</l>
+                         tatra śirorogādhimanthayorbhrūlalāṭaśaṅkhadeśeṣu dahed</l>
+
+                    <l xml:id="SS.1.12.9b">
+                        <label>1938 ed., 1.12.9b</label>
+                        <caesura/>
+                        vartmarogeṣvārdranaktakapraticchannāndṛṣṭiṃ kṛtvā vartmaromakūpāṃ |</l>
 
                     <l xml:id="SS.1.12.10">
                         <label>1938 ed., 1.12.10</label>
@@ -2497,8 +2430,7 @@
                         <caesura/>
                          rogasya saṃsthānam avekṣya dhīmāṃ narasya marmāṇi balābalañ ca |
                         <caesura/>
-                         vyādhin tathartuñ ca samīkṣya samyak tato vyavasyed bhiṣag
-                        agnikarma ||</l>
+                         vyādhin tathartuñ ca samīkṣya samyak tato vyavasyed bhiṣag agnikarma ||</l>
 
 
                     <!--                       1.12.13-->
@@ -2515,31 +2447,28 @@
                     <l xml:id="SS.1.12.14">
                         <label>1938 ed., 1.12.14</label>
                         <caesura/>
-                         athemāni pariharetpittaprakṛtimantaḥ śoṇitaṃ |
-                        bhinnakoṣṭhamanuddhṛtaśalyaṃ
+                         athemāni pariharetpittaprakṛtimantaḥ śoṇitaṃ | bhinnakoṣṭhamanuddhṛtaśalyaṃ
                         bālavṛddhabhīrudurbalamanekavyādhipīḍitamasvedyāṃś ca ||</l>
 
                     <l xml:id="SS.1.12.15">
                         <label>1938 ed., 1.12.15</label>
                         <caesura/>
                          ata ūrddham itarathā dagdhaṃ vakṣyāmaḥ tatra snigdhaṃ rūkṣañ
-                        cāśrityadravyam agnir dahati | atisantapto hi snehaḥ
-                        sūkṣmamārgānusāritvāt tvagādīnanupraviśyāśu dahati |
-                        tasmātsnehadagdhedhikā rujā bhavati |</l>
+                        cāśrityadravyam agnir dahati | atisantapto hi snehaḥ sūkṣmamārgānusāritvāt
+                        tvagādīnanupraviśyāśu dahati | tasmātsnehadagdhedhikā rujā bhavati |</l>
 
                     <l xml:id="SS.1.12.16">
                         <label>1938 ed., 1.12.16</label>
                         <caesura/>
                          tatra pluṣṭaṃ durdagdhaṃ samyagdagdham atidagdham iti caturvidham
-                        agnidagdham bhavati | tatra yad vivaṇṇamuṣyateti mātraṃ tat
-                        pluṣṭaṃ | yatrotptisphoṭanā tīvradāhadoṣavedanā cirāc copaśāmyati
-                        tad durdagdhaṃ | samyagdagdham anavagāḍhaṃ pakvatālavarṇṇaṃ
-                        susaṃsthitaṃ pūrvalakṣaṇasaṃyuktaṃ ca | atidagdhe tu
-                        māṃsāvalaṃbanaṃ gātraviśleṣaḥ sandhivaiguṇyaṃ
-                        sirāsnāyusandhyasthivyāpādanaṃ jvaradāhapipāsāmūrcchāś copadravā
-                        bhavanti | sakrimiś cet vraṇaś cāsya cireṇoparohaty uparūḍhaś ca
-                        vivarṇṇo bhavati | tad etac caturvidham agnidagdhalakṣaṇam
-                        ānupūrvyoktaṃ pūrvakarma<pc> </pc>prasādhakaṃ bhavati ||</l>
+                        agnidagdham bhavati | tatra yad vivaṇṇamuṣyateti mātraṃ tat pluṣṭaṃ |
+                        yatrotptisphoṭanā tīvradāhadoṣavedanā cirāc copaśāmyati tad durdagdhaṃ |
+                        samyagdagdham anavagāḍhaṃ pakvatālavarṇṇaṃ susaṃsthitaṃ
+                        pūrvalakṣaṇasaṃyuktaṃ ca | atidagdhe tu māṃsāvalaṃbanaṃ gātraviśleṣaḥ
+                        sandhivaiguṇyaṃ sirāsnāyusandhyasthivyāpādanaṃ jvaradāhapipāsāmūrcchāś
+                        copadravā bhavanti | sakrimiś cet vraṇaś cāsya cireṇoparohaty uparūḍhaś ca
+                        vivarṇṇo bhavati | tad etac caturvidham agnidagdhalakṣaṇam ānupūrvyoktaṃ
+                            pūrvakarma<pc> </pc>prasādhakaṃ bhavati ||</l>
 
                     <l xml:id="SS.1.12.17">
                         <label>1938 ed., 1.12.17</label>
@@ -2646,8 +2575,8 @@
 
                     <head xml:lang="en">[Adhyāya 13]</head>
 
-                    <note>[NB: Based on H alone up to v. 22 and collated against the 1938
-                        edition, not the 1931 one.]</note>
+                    <note>[NB: Based on H alone up to v. 22 and collated against the 1938 edition,
+                        not the 1931 one.]</note>
 
                     <l xml:id="SS.1.13.1">
                         <label>1 (1938 ed. 1.13.1)</label>
@@ -2660,25 +2589,23 @@
                         <label>2 (1938 ed. 1.13.3)</label>
                         <caesura/>
                          nṛpāḍhya<pc> </pc>sukumāra<pc> </pc>bāla<pc> </pc>sthavira<pc> </pc>bhīru<pc> </pc>nārīṇām
-                        anugrahārthaṃ paramasukumāro 'yaṃ śoṇitāvasecanopāyo 'bhihito
-                        jalaukasaḥ || </l>
+                        anugrahārthaṃ paramasukumāro 'yaṃ śoṇitāvasecanopāyo 'bhihito jalaukasaḥ || </l>
 
                     <l xml:id="SS.1.13.4">
                         <label>3 (1938 ed. 1.13.4)</label>
                         <caesura/>
-                         tatra vātapittakaphaduṣṭaśoṇitaṃ yathāsaṃkhyaṃ
-                        śṛṅgajalaukālābubhir avasecayet | sarvvāṇi sarvvair vā visrāvyaṃ
-                            ||<anchor n="SS.1.13.4-n1"/>
+                         tatra vātapittakaphaduṣṭaśoṇitaṃ yathāsaṃkhyaṃ śṛṅgajalaukālābubhir
+                        avasecayet | sarvvāṇi sarvvair vā visrāvyaṃ ||<anchor n="SS.1.13.4-n1"/>
                     </l>
 
                     <ab corresp="#SS.1.13.4" type="apparatus">
                         <list type="Notes">
 
 
-                            <item corresp="#SS.1.13.4-n1">The 1931 and 1938 editions of
-                                the vulgate report an insertion at this point, although
-                                they report it differently. Ḍalhaṇa reported variant
-                                readings at this point in the text.</item>
+                            <item corresp="#SS.1.13.4-n1">The 1931 and 1938 editions of the vulgate
+                                report an insertion at this point, although they report it
+                                differently. Ḍalhaṇa reported variant readings at this point in the
+                                text.</item>
 
 
                         </list>
@@ -2701,18 +2628,17 @@
                         <caesura/>
                          arddhacandrākṛti mahattanu saptāṅgulāyataṃ |
                         <caesura/>
-                         pracchite dāpayet pūrvvam āsyenācūṣayed balī || <anchor
-                            n="SS.1.13.5.1-n1"/>
+                         pracchite dāpayet pūrvvam āsyenācūṣayed balī || <anchor n="SS.1.13.5.1-n1"
+                        />
                     </l>
 
                     <ab corresp="#SS.1.13.5.1" type="apparatus">
                         <list type="Notes">
 
 
-                            <item corresp="#SS.1.13.5.1-n1"> The 1938 edition of the
-                                vulgate (p. 55, note 4) reports the insertion of this
-                                verse after 1.13.5 at this point. Ḍalhaṇa also reported
-                                this reading. </item>
+                            <item corresp="#SS.1.13.5.1-n1"> The 1938 edition of the vulgate (p. 55,
+                                note 4) reports the insertion of this verse after 1.13.5 at this
+                                point. Ḍalhaṇa also reported this reading. </item>
 
 
                         </list>
@@ -2728,8 +2654,7 @@
                     <l xml:id="SS.1.13.7">
                         <label>1938 ed. 1.13.7</label>
                         <caesura/>
-                         kaṭurūkṣañ ca tīkṣṇañ ca alābu parikīrttitaṃ |<anchor
-                            n="SS.1.13.7-n1"/>
+                         kaṭurūkṣañ ca tīkṣṇañ ca alābu parikīrttitaṃ |<anchor n="SS.1.13.7-n1"/>
                         <caesura/>
                          tasmāc chleṣmopasṛṣṭe tu hitan tad avasecane || </l>
 
@@ -2737,9 +2662,8 @@
                         <list type="notes">
 
 
-                            <item corresp="#SS.1.13.7-n1">The hiatus between
-                                    <foreign>ca</foreign> and <foreign>alābu</foreign> is
-                                required for correct metre.</item>
+                            <item corresp="#SS.1.13.7-n1">The hiatus between <foreign>ca</foreign>
+                                and <foreign>alābu</foreign> is required for correct metre.</item>
 
 
                         </list>
@@ -2747,14 +2671,14 @@
                     <l xml:id="SS.1.13.8">
                         <label>1938 ed. 1.13.8</label>
                         <caesura/>
-                         tatra pracchite tanu<pc> </pc>basti<pc> </pc>paṭalāvanaddhena
-                        śṛṅgeṇa śoṇitam avasecayet | ācūṣaṇād antarddīptenālābunā | </l>
+                         tatra pracchite tanu<pc> </pc>basti<pc> </pc>paṭalāvanaddhena śṛṅgeṇa
+                        śoṇitam avasecayet | ācūṣaṇād antarddīptenālābunā | </l>
 
                     <l xml:id="SS.1.13.9">
                         <label>1938 ed. 1.13.9</label>
                         <caesura/>
-                         jalam āsām āyur ity ato jalāyukāḥ || oko nivāso jalam āsām oka
-                        ity ato jalaukasaḥ ||</l>
+                         jalam āsām āyur ity ato jalāyukāḥ || oko nivāso jalam āsām oka ity ato
+                        jalaukasaḥ ||</l>
 
 
 
@@ -2768,42 +2692,37 @@
                         <label>1938 ed. 1.13.11</label>
                         <caesura/>
                          kṛṣṇā karburā alagardā indrāyudhā sāmudrikā govandanā ceti | tāsv
-                        añjanavarṇṇā pṛthuśīrṣā kṛṣṇā nāma | varmimatsyavad āyatā
-                        cchinnonnatakukṣiḥ karburā nāma | romaśā mahāpārśvā kṛṣṇamukhā
-                        alagardā nāma | indrāyudhavad ūrddhvarājī citrā indrāyudhā nāma |
-                        īṣadasitapītikā vicitrapuṣpākṛticitā sāmudrikā nāma | govṛṣaṇavad
-                        adhobhāge dvidhābhūtākṛtir aṇumukhī govandanā nāma | tābhir daṣṭe
-                        daṃśe śvayathur atimātraṃ kaṇḍūmūrcchā jvaro dāhaś charddir iti
-                        liṅgāni bhavanti || tatra mahāgadaḥ pānālepanādiṣūpayojyaḥ |
-                        indrāyudhādaṣṭam asādhyam ity etāḥ saviṣāḥ sacikitsitā vyākhyātāḥ
-                        || </l>
+                        añjanavarṇṇā pṛthuśīrṣā kṛṣṇā nāma | varmimatsyavad āyatā cchinnonnatakukṣiḥ
+                        karburā nāma | romaśā mahāpārśvā kṛṣṇamukhā alagardā nāma | indrāyudhavad
+                        ūrddhvarājī citrā indrāyudhā nāma | īṣadasitapītikā vicitrapuṣpākṛticitā
+                        sāmudrikā nāma | govṛṣaṇavad adhobhāge dvidhābhūtākṛtir aṇumukhī govandanā
+                        nāma | tābhir daṣṭe daṃśe śvayathur atimātraṃ kaṇḍūmūrcchā jvaro dāhaś
+                        charddir iti liṅgāni bhavanti || tatra mahāgadaḥ pānālepanādiṣūpayojyaḥ |
+                        indrāyudhādaṣṭam asādhyam ity etāḥ saviṣāḥ sacikitsitā vyākhyātāḥ || </l>
 
                     <l xml:id="SS.1.13.12">
                         <label>1938 ed. 1.13.12</label>
                         <caesura/>
-                         atha nirvviṣāḥ | kapilā piṅgalā śaṅkumukhī mūṣikā puṇḍarīkamukhī
-                        sāvarikā ceti | tatra manaḥśilārañjitābhyām iva pārśvābhyāṃ pṛṣṭhe
-                        snigdhamudgavarṇṇā kapilā nāma | kiñcidraktā vṛttakāyā
-                        piṅgalyāśugā piṅgalā nāma | yakṛdvarṇṇā śīghrapāyinī dīrghamukhī
-                        śaṅkumukhī nāma | mūṣikākṛtivarṇṇāniṣṭagandhā mūṣikā nāma |
-                        mudgavarṇṇā puṇḍarīkatulyavaktrā puṇḍarīkā nāma |
-                        padmapatravarṇṇāṣṭādaśāṅgulapramāṇā sāvarikā nāma | sā paśvarthe
-                        tv aviṣā vyākhyātāḥ || </l>
+                         atha nirvviṣāḥ | kapilā piṅgalā śaṅkumukhī mūṣikā puṇḍarīkamukhī sāvarikā
+                        ceti | tatra manaḥśilārañjitābhyām iva pārśvābhyāṃ pṛṣṭhe snigdhamudgavarṇṇā
+                        kapilā nāma | kiñcidraktā vṛttakāyā piṅgalyāśugā piṅgalā nāma | yakṛdvarṇṇā
+                        śīghrapāyinī dīrghamukhī śaṅkumukhī nāma | mūṣikākṛtivarṇṇāniṣṭagandhā
+                        mūṣikā nāma | mudgavarṇṇā puṇḍarīkatulyavaktrā puṇḍarīkā nāma |
+                        padmapatravarṇṇāṣṭādaśāṅgulapramāṇā sāvarikā nāma | sā paśvarthe tv aviṣā
+                        vyākhyātāḥ || </l>
 
                     <l xml:id="SS.1.13.13">
                         <label>1938 ed. 1.13.13</label>
                         <caesura/>
-                         tāsāṃ yavanapāṇḍyasahya<pc> </pc>potanādīni kṣetrāṇi bhavanti |
-                        tāsāṃ mahāśarīrā balavatyaḥ śīghrapāyinyo mahāśanā nirviṣāś ca
-                        viśeṣeṇa bhavanti | </l>
+                         tāsāṃ yavanapāṇḍyasahya<pc> </pc>potanādīni kṣetrāṇi bhavanti | tāsāṃ
+                        mahāśarīrā balavatyaḥ śīghrapāyinyo mahāśanā nirviṣāś ca viśeṣeṇa bhavanti | </l>
 
                     <l xml:id="SS.1.13.14">
                         <label>1938 ed. 1.13.14</label>
                         <caesura/>
-                         tatra saviṣakīṭadardduramūtrapurīṣakothajātāḥ kaluṣeṣv ambhaḥsu
-                        ca saviṣāḥ | padmotpala<pc> </pc>kumuda<pc
-                            > </pc>saugandhika<pc> </pc>śaivāla<pc> </pc>kotha<pc
-                        > </pc>jātā vimaleṣv ambhaḥsu ca nirvviṣāḥ || </l>
+                         tatra saviṣakīṭadardduramūtrapurīṣakothajātāḥ kaluṣeṣv ambhaḥsu ca saviṣāḥ
+                        | padmotpala<pc> </pc>kumuda<pc> </pc>saugandhika<pc> </pc>śaivāla<pc
+                            > </pc>kotha<pc> </pc>jātā vimaleṣv ambhaḥsu ca nirvviṣāḥ || </l>
 
                     <l xml:id="SS.1.13.15">
                         <label>1938 ed. 1.13.15</label>
@@ -2827,12 +2746,11 @@
                         <list type="Emendation">
 
 
-                            <item corresp="#SS.1.13.16-n1">The transmitted Nepalese
-                                reading <foreign>gṛhītvā</foreign> is hard to construe
-                                unless taken over to the start of the next paragraph.
-                                However, then it would sit uneasily before
-                                    <foreign>atha</foreign>, which seems to demarcate the
-                                start of different procedural stages.</item>
+                            <item corresp="#SS.1.13.16-n1">The transmitted Nepalese reading
+                                    <foreign>gṛhītvā</foreign> is hard to construe unless taken over
+                                to the start of the next paragraph. However, then it would sit
+                                uneasily before <foreign>atha</foreign>, which seems to demarcate
+                                the start of different procedural stages.</item>
 
 
                         </list>
@@ -2840,11 +2758,10 @@
                     <l xml:id="SS.1.13.17">
                         <label>1938 ed. 1.13.17</label>
                         <caesura/>
-                         athaitā nave mahati ghaṭe sarastaḍākodakapaṅkān āvāpya nidadhyāt
-                        | bhakṣārthañ cāsām upaharet | śevālaṃ vallūram odakāṃś ca kandānś
-                        cūrṇīkṛtya śayyārthe tṛṇam odakāni patrāṇi tryahāt tryahāc cāsāṃ
-                        jalabhaktan dadyāt | saptarātrāt saptarātrād ghaṭam anyaṃ
-                        saṅkrāmayet || </l>
+                         athaitā nave mahati ghaṭe sarastaḍākodakapaṅkān āvāpya nidadhyāt |
+                        bhakṣārthañ cāsām upaharet | śevālaṃ vallūram odakāṃś ca kandānś cūrṇīkṛtya
+                        śayyārthe tṛṇam odakāni patrāṇi tryahāt tryahāc cāsāṃ jalabhaktan dadyāt |
+                        saptarātrāt saptarātrād ghaṭam anyaṃ saṅkrāmayet || </l>
 
                     <l xml:id="SS.1.13.18">
                         <label>1938 ed. 1.13.18</label>
@@ -2853,18 +2770,18 @@
                         <caesura/>
                          sthūlamadhyāḥ parikliṣṭās tanvyaś cākṣetrajāś ca yāḥ |
                         <caesura/>
-                         agrāhiṇyo 'lpapāyinyaḥ saviṣāś ca na poṣayet ||<anchor
-                            n="SS.1.13.18-n1"/></l>
+                         agrāhiṇyo 'lpapāyinyaḥ saviṣāś ca na poṣayet ||<anchor n="SS.1.13.18-n1"
+                        /></l>
 
 
                     <ab corresp="#SS.1.13.18" type="apparatus">
                         <list type="notes">
 
 
-                            <item corresp="#SS.1.13.18-n1">The vulgate edition notes
-                                "other readings" that correspond to those in the the
-                                Nepalese witnesses for <foreign>tanvyaś cākṣetrajāś ca
-                                    yāḥ</foreign> and <foreign>poṣayet</foreign>.</item>
+                            <item corresp="#SS.1.13.18-n1">The vulgate edition notes "other
+                                readings" that correspond to those in the the Nepalese witnesses for
+                                    <foreign>tanvyaś cākṣetrajāś ca yāḥ</foreign> and
+                                    <foreign>poṣayet</foreign>.</item>
 
 
                         </list>
@@ -2873,13 +2790,13 @@
                     <l xml:id="SS.1.13.19">
                         <label>1938 ed. 1.13.19</label>
                         <caesura/>
-                         atha jalaukāvasekasādhyavyādhiṃ vyādhitam upaveśya saṃveśya vā
-                        virūkṣya tam avakāśaṃ mṛdgomayacūrṇṇair yad yat sarujaṃ syād |
-                        atha jalaukasaḥ sarṣaparajanī<pc> </pc>pradigdha<pc> </pc>gātryaḥ
-                        salilasarakamadhyasañcāriṇī vigatamalāḥ kṛtvā rogaṅ grāhayet
-                            |<anchor n="SS.1.13.19-n1"/> atha na gṛhṇatyāḥ kṣīrabinduṃ
-                        śoṇitabinduṃ vā nidadhyāt | śastrapadāni vā kurvīta | athaivam api
-                        na gṛhṇīyāt anyāṅ grāhayet |</l>
+                         atha jalaukāvasekasādhyavyādhiṃ vyādhitam upaveśya saṃveśya vā virūkṣya tam
+                        avakāśaṃ mṛdgomayacūrṇṇair yad yat sarujaṃ syād | atha jalaukasaḥ
+                            sarṣaparajanī<pc> </pc>pradigdha<pc> </pc>gātryaḥ
+                        salilasarakamadhyasañcāriṇī vigatamalāḥ kṛtvā rogaṅ grāhayet |<anchor
+                            n="SS.1.13.19-n1"/> atha na gṛhṇatyāḥ kṣīrabinduṃ śoṇitabinduṃ vā
+                        nidadhyāt | śastrapadāni vā kurvīta | athaivam api na gṛhṇīyāt anyāṅ
+                        grāhayet |</l>
 
 
 
@@ -2888,8 +2805,8 @@
                         <list type="notes">
 
 
-                            <item corresp="#SS.1.13.19-n1">Note the irregular sandhi of f.
-                                pl. <foreign>-sañcāriṇī</foreign>.</item>
+                            <item corresp="#SS.1.13.19-n1">Note the irregular sandhi of f. pl.
+                                    <foreign>-sañcāriṇī</foreign>.</item>
 
 
                         </list>
@@ -2898,27 +2815,25 @@
                     <l xml:id="SS.1.13.20">
                         <label>1938 ed. 1.13.20</label>
                         <caesura/>
-                         yadā niviśate 'śvakhuravad ānanaṅ kṛtvonnāmya ca skandhaṃ evañ
-                        jānīyād gṛhṇātīti | athainām ārdraplotāvacchannāṅ kṛtvā dhārayet
-                        || </l>
+                         yadā niviśate 'śvakhuravad ānanaṅ kṛtvonnāmya ca skandhaṃ evañ jānīyād
+                        gṛhṇātīti | athainām ārdraplotāvacchannāṅ kṛtvā dhārayet || </l>
 
                     <l xml:id="SS.1.13.21">
                         <label>1938 ed. 1.13.21</label>
                         <caesura/>
-                         atha daṃśe toda<pc> </pc>kaṇḍū<pc> </pc>prādur<pc> </pc>bhāvāj
-                        jānīyāc chuddham ādadātīti | tām apanayet | atha śoṇitagandhena na
-                        muñcet mukham asyāḥ saindhavacūrṇenāvakiret | </l>
+                         atha daṃśe toda<pc> </pc>kaṇḍū<pc> </pc>prādur<pc> </pc>bhāvāj jānīyāc
+                        chuddham ādadātīti | tām apanayet | atha śoṇitagandhena na muñcet mukham
+                        asyāḥ saindhavacūrṇenāvakiret | </l>
 
                     <l xml:id="SS.1.13.22">
                         <label>1938 ed. 1.13.22</label>
                         <caesura/>
-                         athaināṃ śāli<pc> </pc>taṇḍula<pc> </pc>kāṇḍana<pc
-                        > </pc>praliptān taila<pc> </pc>lavaṇābhyaktamukhīṃ
-                        vāmahastagṛhītapucchān dakṣiṇahastāṅguṣṭhāṅgulībhyāṃ śanaiḥ śanair
-                        anulomamārjjayann ā mukhād vāmayec ca yāvat samyagvānteti |
-                        samyagvāntā salilasarake nyastā bhoktukāmā satī cared | yā sīdati
-                        na ceṣṭate sā durvvāntā punaḥ samyag vāmayet | durvāntāyās tu
-                        indrapado nāma vyādhir asādhyo bhavati | </l>
+                         athaināṃ śāli<pc> </pc>taṇḍula<pc> </pc>kāṇḍana<pc> </pc>praliptān
+                            taila<pc> </pc>lavaṇābhyaktamukhīṃ vāmahastagṛhītapucchān
+                        dakṣiṇahastāṅguṣṭhāṅgulībhyāṃ śanaiḥ śanair anulomamārjjayann ā mukhād
+                        vāmayec ca yāvat samyagvānteti | samyagvāntā salilasarake nyastā bhoktukāmā
+                        satī cared | yā sīdati na ceṣṭate sā durvvāntā punaḥ samyag vāmayet |
+                        durvāntāyās tu indrapado nāma vyādhir asādhyo bhavati | </l>
 
 
                     <l xml:id="SS.1.13.22.1">
@@ -2926,8 +2841,7 @@
                         <caesura/>
                          aprahṛṣṭaśiraḥ pāti kāyenodveṣṭate sakṛt |
                         <caesura/>
-                         yā coṣṇaṃ kurute toyaṃ tasyām indrapadaḥ smṛtaḥ ||<anchor
-                            n="SS.1.13.22-n1"/>
+                         yā coṣṇaṃ kurute toyaṃ tasyām indrapadaḥ smṛtaḥ ||<anchor n="SS.1.13.22-n1"/>
                         <caesura/>
                          athaināṃ pūrvvavat sannidadhyāt | </l>
 
@@ -2935,16 +2849,15 @@
                         <list type="Notes">
 
 
-                            <item corresp="#SS.1.13.22-n1">The vulgate, third edition,
-                                reports the reading of this verse in a Nepalese witness,
-                                probably H: <foreign>aprahṛṣṭaśiraḥpādakāyenodveṣṭate
-                                    sakṛt | yā coṣṇaṃ kurute tāpaṃ tasyām indramadaḥ
-                                    smṛtaḥ</foreign> (Ācārya 1938: 58, n. 4).</item>
+                            <item corresp="#SS.1.13.22-n1">The vulgate, third edition, reports the
+                                reading of this verse in a Nepalese witness, probably H:
+                                    <foreign>aprahṛṣṭaśiraḥpādakāyenodveṣṭate sakṛt | yā coṣṇaṃ
+                                    kurute tāpaṃ tasyām indramadaḥ smṛtaḥ</foreign> (Ācārya 1938:
+                                58, n. 4).</item>
 
 
-                            <item>A version of the third pāda of this verse appears as the
-                                last sentence of 1.13.22 in the vulgate edition (Ācārya
-                                1938: 58).</item>
+                            <item>A version of the third pāda of this verse appears as the last
+                                sentence of 1.13.22 in the vulgate edition (Ācārya 1938: 58).</item>
 
 
                         </list>
@@ -2956,9 +2869,8 @@
                     <l xml:id="SS.1.13.23">
                         <label>24 (1938 ed. 1.13.23)</label>
                         <caesura/>
-                         śoṇitasya ca yogāyogam avekṣya jalaukāmukhaṃ madhunāvaghaṭṭayet |
-                        badhnīta vā kaṣāyamadhurasnigdhaśītaiś ca pradehaiḥ pradihyād iti
-                        || </l>
+                         śoṇitasya ca yogāyogam avekṣya jalaukāmukhaṃ madhunāvaghaṭṭayet | badhnīta
+                        vā kaṣāyamadhurasnigdhaśītaiś ca pradehaiḥ pradihyād iti || </l>
 
                     <l xml:id="SS.1.13.23.1">
                         <label>25</label>
@@ -2996,16 +2908,14 @@
                         <caesura/>
                          pāñcabhautikasya caturvidhasyāhārasya ṣaḍrasopetasya
                         dvividhavīryasyāṣṭavidhavīryasya vā anekaguṇopayuktasyāhārasya
-                        samyakpariṇatasya yas tejoguṇabhūtaḥ sāraḥ paramasūkṣmaḥ sa rasa
-                        ity ucyate | tasya hṛdayaṃ sthānaṃ | sa hṛdayāc caturviṃśatir
-                        dhamanīr anupraviśyordhvagā daśa daśa cādhogāminyaś catasras
-                        tiryaggāḥ kṛtsnaṃ śarīram aharahas tarpayati jīvayati yāpayati
-                        vardhayati cādṛṣṭahaitukena karmaṇā | tasya śarīram anusarato
-                        'numānād gatir upalakṣayitavyā kṣayavṛddhihetukī || tasmiṃ
-                        sarvaśarīrāvayavadoṣadhātumalāśayānusāriṇi rase jijñāsā kim ayaṃ
-                        saumyas taijasa iti | sa khalu dravatvād anusaraṇe
-                        snehanajīvanatarpaṇadhāraṇādibhir viśeṣaiḥ saumya ity avagamyate
-                        |</l>
+                        samyakpariṇatasya yas tejoguṇabhūtaḥ sāraḥ paramasūkṣmaḥ sa rasa ity ucyate
+                        | tasya hṛdayaṃ sthānaṃ | sa hṛdayāc caturviṃśatir dhamanīr
+                        anupraviśyordhvagā daśa daśa cādhogāminyaś catasras tiryaggāḥ kṛtsnaṃ
+                        śarīram aharahas tarpayati jīvayati yāpayati vardhayati cādṛṣṭahaitukena
+                        karmaṇā | tasya śarīram anusarato 'numānād gatir upalakṣayitavyā
+                        kṣayavṛddhihetukī || tasmiṃ sarvaśarīrāvayavadoṣadhātumalāśayānusāriṇi rase
+                        jijñāsā kim ayaṃ saumyas taijasa iti | sa khalu dravatvād anusaraṇe
+                        snehanajīvanatarpaṇadhāraṇādibhir viśeṣaiḥ saumya ity avagamyate |</l>
 
                     <l xml:id="SS.1.14.4">
                         <label>1938 ed. 1.14.4</label>
@@ -3065,8 +2975,8 @@
                         <caesura/>
                          bhavati cātra ||
                         <caesura/>
-                         rasajaṃ puruṣaṃ vidyād rasaṃ rakṣeta yatnataḥ | annapānaprayogeṇa
-                        āhāreṇa suyantritaḥ</l>
+                         rasajaṃ puruṣaṃ vidyād rasaṃ rakṣeta yatnataḥ | annapānaprayogeṇa āhāreṇa
+                        suyantritaḥ</l>
 
                     <l xml:id="SS.1.14.13">
                         <label>1938 ed. 1.14.13</label>
@@ -3076,16 +2986,16 @@
                     <l xml:id="SS.1.14.14">
                         <label>1938 ed. 1.14.14</label>
                         <caesura/>
-                         pañcaviṃśati kalāśatāni<anchor n="SS.1.14.14-n1"/> | caturaśītiś
-                        ca nava ca kāṣṭhā ekaikasmin dhātāv avatiṣṭhante | evam māsena
-                        rasaḥ śukrībhavati strīṇāñ cārttavam iti ||</l>
+                         pañcaviṃśati kalāśatāni<anchor n="SS.1.14.14-n1"/> | caturaśītiś ca nava ca
+                        kāṣṭhā ekaikasmin dhātāv avatiṣṭhante | evam māsena rasaḥ śukrībhavati
+                        strīṇāñ cārttavam iti ||</l>
 
                     <ab corresp="#SS.1.14.14" type="apparatus">
                         <list type="notes">
 
 
-                            <item corresp="#SS.1.14.14-n1">The reading of H here resembles
-                                the vulgate.</item>
+                            <item corresp="#SS.1.14.14-n1">The reading of H here resembles the
+                                vulgate.</item>
 
 
                         </list>
@@ -3094,38 +3004,35 @@
                     <l xml:id="SS.1.14.15">
                         <label>1938 ed. 1.14.15</label>
                         <caesura/>
-                         bhavataś cātra || aṣṭādaśasahasrāṇi saṃkhyā hy asmin samuccaye |
-                        kalānān navatiś cāpi svatantraparatantrataḥ || rase gativiśeṣo
-                        'yaṃ mandāgner avasānikaḥ | anayaivoditāgneś ca vijñeyaḥ
-                        kālasaṃkhyayā ||</l>
+                         bhavataś cātra || aṣṭādaśasahasrāṇi saṃkhyā hy asmin samuccaye | kalānān
+                        navatiś cāpi svatantraparatantrataḥ || rase gativiśeṣo 'yaṃ mandāgner
+                        avasānikaḥ | anayaivoditāgneś ca vijñeyaḥ kālasaṃkhyayā ||</l>
 
                     <l xml:id="SS.1.14.16">
                         <label>1938 ed. 1.14.16</label>
                         <caesura/>
-                         sa śabdārci<pc> </pc>jāla<pc> </pc>santānavad aṇunā
-                        viśeṣeṇānusaraty evaṃ śarīraṃ kevalaṃ | </l>
+                         sa śabdārci<pc> </pc>jāla<pc> </pc>santānavad aṇunā viśeṣeṇānusaraty evaṃ
+                        śarīraṃ kevalaṃ | </l>
 
                     <l xml:id="SS.1.14.17">
                         <label>1938 ed. 1.14.17</label>
                         <caesura/>
-                         vyājīkaraṇyas tv auṣadhyaḥ svaguṇabalotkarṣād virecanavad
-                        upayuktāḥ śukraṃ virecayanti || </l>
+                         vyājīkaraṇyas tv auṣadhyaḥ svaguṇabalotkarṣād virecanavad upayuktāḥ śukraṃ
+                        virecayanti || </l>
 
                     <l xml:id="SS.1.14.18">
                         <label>1938 ed. 1.14.18</label>
                         <caesura/>
-                         yathā hi puṣpamukulastho gandho na śakyam ihāstīti vaktuṃ | naiva
-                        nāstīti | atha cāsti satām bhāvānām utpattir iti kṛtvā kevalaṃ tu
-                        saukṣmyān nābhivyajyate | sa eva vivṛtakesare puṣpe
-                        kālāntareṇābhivyakto bhavati | evam bālānām api vayaḥpariṇāmāc
-                        chukraprādurbhāvo bhavati | romarājyārttavādiś ca viśeṣo nārīṇām
-                        |</l>
+                         yathā hi puṣpamukulastho gandho na śakyam ihāstīti vaktuṃ | naiva nāstīti |
+                        atha cāsti satām bhāvānām utpattir iti kṛtvā kevalaṃ tu saukṣmyān
+                        nābhivyajyate | sa eva vivṛtakesare puṣpe kālāntareṇābhivyakto bhavati |
+                        evam bālānām api vayaḥpariṇāmāc chukraprādurbhāvo bhavati |
+                        romarājyārttavādiś ca viśeṣo nārīṇām |</l>
 
                     <l xml:id="SS.1.14.19">
                         <label>1938 ed. 1.14.19</label>
                         <caesura/>
-                         sa evānnaraso 'bhivṛddhānāṃ paripakvaśarīratvād aprīṇano bhavati
-                        |</l>
+                         sa evānnaraso 'bhivṛddhānāṃ paripakvaśarīratvād aprīṇano bhavati |</l>
 
                     <l xml:id="SS.1.14.20">
                         <label>1938 ed. 1.14.20</label>
@@ -3135,19 +3042,17 @@
                     <l xml:id="SS.1.14.21">
                         <label>1938 ed. 1.14.21</label>
                         <caesura/>
-                         teṣāṃ kṣayavṛddhī śoṇitanimitte | tasmāt tad adhikṛtya vakṣyāmaḥ
-                        || tatra saphenilam aruṇaṃ kṛṣṇam paruṣan tanu śīghragamaskandi ca
-                        vātaduṣṭaṃ | nīlam pītaṃ haritaṃ śyāvaṃ visramaniṣṭam
-                        pipīlikāmakṣikāṇāñ ca pittena | gairikodakaprakāśaṃ snigdhaṃ śītaṃ
-                        bahalaṃ picchilaṃ visrāvi māṃsapeśīsamaprabhañ ca śleṣmaṇā |
-                        sarvalakṣaṇayuktaṃ sannipātena | pittavad raktenātikṛṣṇañ ca |
-                        dvidoṣaliṅgasaṃsṛṣṭaṃ dvidoṣaṃ |</l>
+                         teṣāṃ kṣayavṛddhī śoṇitanimitte | tasmāt tad adhikṛtya vakṣyāmaḥ || tatra
+                        saphenilam aruṇaṃ kṛṣṇam paruṣan tanu śīghragamaskandi ca vātaduṣṭaṃ | nīlam
+                        pītaṃ haritaṃ śyāvaṃ visramaniṣṭam pipīlikāmakṣikāṇāñ ca pittena |
+                        gairikodakaprakāśaṃ snigdhaṃ śītaṃ bahalaṃ picchilaṃ visrāvi
+                        māṃsapeśīsamaprabhañ ca śleṣmaṇā | sarvalakṣaṇayuktaṃ sannipātena | pittavad
+                        raktenātikṛṣṇañ ca | dvidoṣaliṅgasaṃsṛṣṭaṃ dvidoṣaṃ |</l>
 
                     <l xml:id="SS.1.14.22">
                         <label>1938 ed. 1.14.22</label>
                         <caesura/>
-                         indragopakaprakāśam asaṃhatam avivarṇṇañ ca prakṛtistham iti
-                        jānīyāt ||</l>
+                         indragopakaprakāśam asaṃhatam avivarṇṇañ ca prakṛtistham iti jānīyāt ||</l>
 
                     <l xml:id="SS.1.14.23">
                         <label>1938 ed. 1.14.23</label>
@@ -3165,8 +3070,8 @@
                     <l xml:id="SS.1.14.26">
                         <label>1938 ed. 1.14.26</label>
                         <caesura/>
-                         tatra ṛjv asaṃkīrṇṇaṃ sūkṣmaṃ samam anavagāḍham anuttānam āśu
-                        śastrañ ca pātayet |</l>
+                         tatra ṛjv asaṃkīrṇṇaṃ sūkṣmaṃ samam anavagāḍham anuttānam āśu śastrañ ca
+                        pātayet |</l>
 
                     <l xml:id="SS.1.14.26a">
                         <label>1938 ed. 1.14.26a</label>
@@ -3182,8 +3087,8 @@
                     <l xml:id="SS.1.14.27">
                         <label>1938 ed. 1.14.27</label>
                         <caesura/>
-                         tatra durviddhe śītavātayor asvinne bhukte ca skannatvāc choṇitan
-                        na sravati | alpaṃ vā sravati ||</l>
+                         tatra durviddhe śītavātayor asvinne bhukte ca skannatvāc choṇitan na
+                        sravati | alpaṃ vā sravati ||</l>
 
                     <l xml:id="SS.1.14.28">
                         <label>1938 ed. 1.14.28</label>
@@ -3202,18 +3107,17 @@
                     <l xml:id="SS.1.14.30">
                         <label>1938 ed. 1.14.30</label>
                         <caesura/>
-                         atyuṣṇātisvinnātividdheṣv ajñasrāvitam atipravarttate | tad
-                        atipravṛttaṃ śirobhitāpam āndhyatimiraprādurbhāvan
-                        cānukṣayākṣepakampapakṣāghātam ekāṅgavikāraṃ hikkākāsaṃ śvāsaṃ
-                        pāṇḍurogaṃ maraṇaṃ vāśu karoti |</l>
+                         atyuṣṇātisvinnātividdheṣv ajñasrāvitam atipravarttate | tad atipravṛttaṃ
+                        śirobhitāpam āndhyatimiraprādurbhāvan cānukṣayākṣepakampapakṣāghātam
+                        ekāṅgavikāraṃ hikkākāsaṃ śvāsaṃ pāṇḍurogaṃ maraṇaṃ vāśu karoti |</l>
 
 
 
                     <l xml:id="SS.1.14.31">
                         <label>1938 ed. 1.14.31</label>
                         <caesura/>
-                         tan nātiśīte nātyuṣṇe nāsvinne nātitāpite yavāgūṃ pratipītasya
-                        śoṇitaṃ mokṣayed bhiṣak ||</l>
+                         tan nātiśīte nātyuṣṇe nāsvinne nātitāpite yavāgūṃ pratipītasya śoṇitaṃ
+                        mokṣayed bhiṣak ||</l>
 
 
                     <l xml:id="SS.1.14.32">
@@ -3243,8 +3147,8 @@
                         <caesura/>
                          atha khalv apravarttamāne | elāśītaśivaḥ
                         kuṣṭhatagarapāṭhābhadradāruviḍaṃgacitrakatrikaṭukāgāradhūmaharidrārkkāṃkuranaktamālaphalair
-                        yathālābhaṃ tribhiś caturbhiḥ | samastair vā lavaṇapragāḍhair
-                        vraṇamukham avagharṣayed evaṃ sādhu vahati ||</l>
+                        yathālābhaṃ tribhiś caturbhiḥ | samastair vā lavaṇapragāḍhair vraṇamukham
+                        avagharṣayed evaṃ sādhu vahati ||</l>
 
                     <l xml:id="SS.1.14.36">
                         <label>1938 ed. 1.14.36</label>
@@ -3252,14 +3156,13 @@
                          athātipravṛtte
                         lodhramadhukapriyaṅgupattāṅgagairikarasāñjanaśaṅkhaśuktiyavamāṣagodhūmasarjarasacūrṇṇair
                         anārdrair vraṇamukham avacūrṇṇyāṅgulyagreṇāvapīḍayet |
-                        sālasarjarjunārimedagranthidhavadhanvanatvagbhir vā cūrṇṇīkṛtābhiḥ
-                        kṣaumeṇa vadhyāsitena samudraphenena lākṣācūrṇṇair vā yathoktair
-                        bandhanadravyair gāḍhaṃ badhnīyāt | vyadhānantaraṃ punar vyadhayet
-                        | śītācchādanabhojanāgārapariṣekaiḥ | śītair ālepaiḥ pradehair
-                        vopacaredagninā vā dahed yathoktaṃ kākolyādikvāthaṃ vā
-                        śarkarāmadhumadhuraṃ pāyayet | eṇahariṇorabhraṃmahiṣaśaśavarāhāṇāṃ
-                        vā rudhiraṃ kṣīrayūṣaṃ rasaiś cāśnīyāt | upadravāṃś ca yathoktān
-                        upacaret ||</l>
+                        sālasarjarjunārimedagranthidhavadhanvanatvagbhir vā cūrṇṇīkṛtābhiḥ kṣaumeṇa
+                        vadhyāsitena samudraphenena lākṣācūrṇṇair vā yathoktair bandhanadravyair
+                        gāḍhaṃ badhnīyāt | vyadhānantaraṃ punar vyadhayet |
+                        śītācchādanabhojanāgārapariṣekaiḥ | śītair ālepaiḥ pradehair vopacaredagninā
+                        vā dahed yathoktaṃ kākolyādikvāthaṃ vā śarkarāmadhumadhuraṃ pāyayet |
+                        eṇahariṇorabhraṃmahiṣaśaśavarāhāṇāṃ vā rudhiraṃ kṣīrayūṣaṃ rasaiś cāśnīyāt |
+                        upadravāṃś ca yathoktān upacaret ||</l>
 
 
                     <l xml:id="SS.1.14.37">
@@ -3342,14 +3245,14 @@
                     <l xml:id="SS.1.15.3">
                         <label>1.15.3</label>
                         <caesura/>
-                         doṣadhātumalamūlaṃ hi śarīraṃ | tasmātphalalakṣaṇameteṣām
-                        upadhārayaś ca |</l>
+                         doṣadhātumalamūlaṃ hi śarīraṃ | tasmātphalalakṣaṇameteṣām upadhārayaś ca
+                        |</l>
 
                     <l xml:id="SS.1.15.4.1">
                         <label>1.15.4.1</label>
                         <caesura/>
-                         tatra spandanodvahanapūraṇavivekadhāraṇalakṣaṇo vāyuḥ pañcadhā
-                        pravibhaktaḥ śarīrantantrayati |</l>
+                         tatra spandanodvahanapūraṇavivekadhāraṇalakṣaṇo vāyuḥ pañcadhā pravibhaktaḥ
+                        śarīrantantrayati |</l>
 
                     <l xml:id="SS.1.15.4.2">
                         <label>1.15.4.2</label>
@@ -3364,15 +3267,14 @@
                     <l xml:id="SS.1.15.5">
                         <label>1.15.5</label>
                         <caesura/>
-                         rasaḥ prīṇayati | raktañjīvayati | māṃsaṃ lepayati medaḥ
-                        snehayati | asthi dhārayati | majjā pūrayati | bījārthaharṣakṛc
-                        chukraṃ kledayati |</l>
+                         rasaḥ prīṇayati | raktañjīvayati | māṃsaṃ lepayati medaḥ snehayati | asthi
+                        dhārayati | majjā pūrayati | bījārthaharṣakṛc chukraṃ kledayati |</l>
 
                     <l xml:id="SS.1.15.6">
                         <label>1.15.6</label>
                         <caesura/>
-                         bastikledakṛn mūtraṃ | prāṇavāyvagnidhāraṇāvaṣṭambhakṛt purīśaṃ |
-                        svedaḥ kledayati |</l>
+                         bastikledakṛn mūtraṃ | prāṇavāyvagnidhāraṇāvaṣṭambhakṛt purīśaṃ | svedaḥ
+                        kledayati |</l>
 
                     <l xml:id="SS.1.15.7">
                         <label>1.15.7</label>
@@ -3387,8 +3289,8 @@
                     <l xml:id="SS.1.15.9">
                         <label>1.15.9</label>
                         <caesura/>
-                         ataḥ sarveṣāṃ kṣayalakṣaṇaṃ vyākhyāsyāmaḥ | tatra vātakṣaye
-                        mandaceṣṭatā alpavāktvamalpapraharṣo mūḍhasañjñatā ca | pittakṣaye
+                         ataḥ sarveṣāṃ kṣayalakṣaṇaṃ vyākhyāsyāmaḥ | tatra vātakṣaye mandaceṣṭatā
+                        alpavāktvamalpapraharṣo mūḍhasañjñatā ca | pittakṣaye
                         mandoṣmāgnitāniṣprabhatā ca | śleṣmakṣaye
                         rūkṣatāntardāhaāmāśayetarāśayaśūnyatāśirasaś ca |</l>
 
@@ -3400,59 +3302,58 @@
                     <l xml:id="SS.1.15.11">
                         <label>1.15.11</label>
                         <caesura/>
-                         rasakṣaye hṛdayapīḍā<pc> </pc>kampaḥ śoṣaḥ śūnyatā tṛṣṇā ca |
-                        śoṇitakṣaye tvakpāruṣyam amlaśītaprārthanā sirāśaithilyañ ca ||
-                        māṃsakṣaye sphiggaṇṇḍauṣṭhopasthoruvakṣaḥ<pc> </pc>kakṣaśuṣkatā
-                        dhamanīnāñ ca śaithilyaṃ | medakṣaye plīhābhivṛddhiḥ sandhiśūnyatā
-                        raukṣyaṃ meduramāṃsaprārthanā ca | asthikṣaye asthiśūlo
-                        dantanakhabhaṃgāraukṣyañ ca | majjākṣaye lpaśukratā parvabhedo
-                        sthitodaḥ śūnyatā | śukrakṣaye meḍhravṛṣaṇavedanāśaktir maithune
-                        cirād vā prasekaḥ praseke cālpaśukraraktadarśanaṃ |</l>
+                         rasakṣaye hṛdayapīḍā<pc> </pc>kampaḥ śoṣaḥ śūnyatā tṛṣṇā ca | śoṇitakṣaye
+                        tvakpāruṣyam amlaśītaprārthanā sirāśaithilyañ ca || māṃsakṣaye
+                            sphiggaṇṇḍauṣṭhopasthoruvakṣaḥ<pc> </pc>kakṣaśuṣkatā dhamanīnāñ ca
+                        śaithilyaṃ | medakṣaye plīhābhivṛddhiḥ sandhiśūnyatā raukṣyaṃ
+                        meduramāṃsaprārthanā ca | asthikṣaye asthiśūlo dantanakhabhaṃgāraukṣyañ ca |
+                        majjākṣaye lpaśukratā parvabhedo sthitodaḥ śūnyatā | śukrakṣaye
+                        meḍhravṛṣaṇavedanāśaktir maithune cirād vā prasekaḥ praseke
+                        cālpaśukraraktadarśanaṃ |</l>
 
                     <l xml:id="SS.1.15.12"/>
 
                     <l xml:id="SS.1.15.13">
                         <label>1.15.13</label>
                         <caesura/>
-                         purīṣakṣaye hṛdayapārśvapīḍā saśabdasya ca vāyor ūdhvagamanaṃ
-                        kukṣau sañcaraṇaṃ ca mūtrakṣaye bastitodo lpamūtratā ca || atrāpi
-                        svayonivardhanadravyopayogaḥ || svedakṣaye stabdharomakūpatā
-                        sparśavaiguṇyaś ca tatrābhyaṅga svedopayogaś ca ||</l>
+                         purīṣakṣaye hṛdayapārśvapīḍā saśabdasya ca vāyor ūdhvagamanaṃ kukṣau
+                        sañcaraṇaṃ ca mūtrakṣaye bastitodo lpamūtratā ca || atrāpi
+                        svayonivardhanadravyopayogaḥ || svedakṣaye stabdharomakūpatā sparśavaiguṇyaś
+                        ca tatrābhyaṅga svedopayogaś ca ||</l>
 
                     <l xml:id="SS.1.15.14">
                         <label>1.15.14</label>
                         <caesura/>
                          ārttavakṣaye yathocitakālādarśanamalpatā vā yonivedanā ca | tatra
-                        saṃśodhanamāgneyānāñ ca dravyānām upayogaḥ || stanyakṣaye stanayo
-                        mlānatā stanyāsambhavaś ca | tatra śleṣmavardhanadravyopayogaḥ ||
-                        garbhakṣaye garbhāspandanamanunnatakukṣitā ca | tatra
-                        prāptabastikālāyāḥ kṣīrabastiprayogo medhyān na prayogaś ca ||</l>
+                        saṃśodhanamāgneyānāñ ca dravyānām upayogaḥ || stanyakṣaye stanayo mlānatā
+                        stanyāsambhavaś ca | tatra śleṣmavardhanadravyopayogaḥ || garbhakṣaye
+                        garbhāspandanamanunnatakukṣitā ca | tatra prāptabastikālāyāḥ
+                        kṣīrabastiprayogo medhyān na prayogaś ca ||</l>
 
                     <l xml:id="SS.1.15.15">
                         <label>1.15.15</label>
                         <caesura/>
-                         ata ūrdhvamatipravṛddhānāṃ doṣadhātūnāṃ lakṣaṇam upadekṣyāmaḥ
-                        tatra vātavṛddhau kārśyaṃ kārṣṇyaṃ gātrasphuraṇatā uṣṇakāmatā
-                        nidrānāśolpabalatvaṃ gāḍhavarcasvatā ca || pittavṛddhau
-                        pītāvabhāsatā santāpaḥśītakāmitvamalpanidratā mūrcchā balahāniḥ
-                        pītaviṇmūtratvañ ca || śleṣmavṛddhau śauklyaṃ śaithyaṃ sthairyaṃ
-                        gauravam agnisādas tandrā nidrā sandhyati śliṣṭatā ca ||</l>
+                         ata ūrdhvamatipravṛddhānāṃ doṣadhātūnāṃ lakṣaṇam upadekṣyāmaḥ tatra
+                        vātavṛddhau kārśyaṃ kārṣṇyaṃ gātrasphuraṇatā uṣṇakāmatā nidrānāśolpabalatvaṃ
+                        gāḍhavarcasvatā ca || pittavṛddhau pītāvabhāsatā
+                        santāpaḥśītakāmitvamalpanidratā mūrcchā balahāniḥ pītaviṇmūtratvañ ca ||
+                        śleṣmavṛddhau śauklyaṃ śaithyaṃ sthairyaṃ gauravam agnisādas tandrā nidrā
+                        sandhyati śliṣṭatā ca ||</l>
 
                     <l xml:id="SS.1.15.16">
                         <label>1.15.16</label>
                         <caesura/>
-                         rasotipravṛddho hṛdaye kledaṃ prasekañ cāpādayati | raktaṃ
-                        raktāṅgākṣitāṃ || māṃsaṃ sphiggaṇḍauṣṭhopasthorubāhujaṅghāsu
-                        vṛddhiṃ gurugātratāñ ca | medaḥ snigdhāṅgatāmudarapārśvavṛddhiṃ
-                        kāsaśvāso daurgandhyañ ca || asthyadhyasthīny adhidantāṃś ca ||
-                        majjā sarvāṅganetragauravaṃ || śukraṃ śukrāśmariti prādurbhāvaṃ
-                        ||</l>
+                         rasotipravṛddho hṛdaye kledaṃ prasekañ cāpādayati | raktaṃ raktāṅgākṣitāṃ
+                        || māṃsaṃ sphiggaṇḍauṣṭhopasthorubāhujaṅghāsu vṛddhiṃ gurugātratāñ ca |
+                        medaḥ snigdhāṅgatāmudarapārśvavṛddhiṃ kāsaśvāso daurgandhyañ ca ||
+                        asthyadhyasthīny adhidantāṃś ca || majjā sarvāṅganetragauravaṃ || śukraṃ
+                        śukrāśmariti prādurbhāvaṃ ||</l>
 
                     <l xml:id="SS.1.15.17">
                         <label>1.15.17</label>
                         <caesura/>
-                         purīśamāṭopaḥ kukṣau śūlañ ca || mūtraṃ muhurmuhuḥ pravṛttiṃ
-                        todañ ca || svedaḥ kaṇḍū daurgandhyañ ca ||</l>
+                         purīśamāṭopaḥ kukṣau śūlañ ca || mūtraṃ muhurmuhuḥ pravṛttiṃ todañ ca ||
+                        svedaḥ kaṇḍū daurgandhyañ ca ||</l>
 
                     <l xml:id="SS.1.15.18">
                         <label>1.15.18</label>
@@ -3470,16 +3371,15 @@
                     <l xml:id="SS.1.15.21">
                         <label>1.15.21</label>
                         <caesura/>
-                         ata ūrdhvam anuvyākhyāsyāmaḥ || rasādīnāṃ śukrāntānāṃ dhātūnāṃ
-                        yat paran tejas tat khalv ojas tad eva balam ity ucyate |
-                        śāstrasiddhāntāt</l>
+                         ata ūrdhvam anuvyākhyāsyāmaḥ || rasādīnāṃ śukrāntānāṃ dhātūnāṃ yat paran
+                        tejas tat khalv ojas tad eva balam ity ucyate | śāstrasiddhāntāt</l>
 
                     <l xml:id="SS.1.15.22">
                         <label>1.15.22</label>
                         <caesura/>
                          tatra balena sthiropacitamāṃsatā sarvaceṣṭāsvapratighātaḥ
-                        svaravarṇṇaprasādo bāhyābhyantarāṇāṃ ca karaṇānām
-                        ātmakāryapratipattir bhavati ||</l>
+                        svaravarṇṇaprasādo bāhyābhyantarāṇāṃ ca karaṇānām ātmakāryapratipattir
+                        bhavati ||</l>
 
                     <l xml:id="SS.1.15.23">
                         <label>1.15.23</label>
@@ -3509,10 +3409,10 @@
                     <l xml:id="SS.1.15.26-27">
                         <label>1.15.26-27</label>
                         <caesura/>
-                         tatra visraṃso vyāpatkṣaya iti liṅgāni bhavanti | sandhiviśleṣo
-                        gātrāṇāṃ sadanaṃ doṣacyavanakriyāsannirodhaś ca visraṃse |
-                        stabdhatā gurugātra tā śopho varṇṇabhedo glānis tandrā nidrā
-                        vyāpanne | māṃsakṣayo mohaḥ pralāpo maraṇam iti ca kṣīṇo |</l>
+                         tatra visraṃso vyāpatkṣaya iti liṅgāni bhavanti | sandhiviśleṣo gātrāṇāṃ
+                        sadanaṃ doṣacyavanakriyāsannirodhaś ca visraṃse | stabdhatā gurugātra tā
+                        śopho varṇṇabhedo glānis tandrā nidrā vyāpanne | māṃsakṣayo mohaḥ pralāpo
+                        maraṇam iti ca kṣīṇo |</l>
 
                     <l xml:id="SS.1.15.28"/>
                     <l xml:id="SS.1.15.29"/>
@@ -3521,8 +3421,8 @@
                     <l xml:id="SS.1.15.31">
                         <label>1.15.31</label>
                         <caesura/>
-                         tatra visraṃse vyāpanne ca kriyāviśeṣair aviruddhair balam
-                        adhyāyayet mūḍhasaṃjñam itarañ ca varjjayet |</l>
+                         tatra visraṃse vyāpanne ca kriyāviśeṣair aviruddhair balam adhyāyayet
+                        mūḍhasaṃjñam itarañ ca varjjayet |</l>
 
                     <l xml:id="SS.1.15.32"/>
                     <l xml:id="SS.1.15.33"/>
@@ -3538,18 +3438,16 @@
                         <label>1.15.35</label>
                         <caesura/>
                          rasanimittam eva sthaulyaṅ kārśyañ ca | tatra
-                        śleṣmalāhārasevitodhyaśanaśīlasyāvyāyāmino divāsvapnaratasya āma
-                        evānnaraso madhurataraś ca śarīram anukramamāṇotisnehān medo
-                        janayati | medaso tipravṛddhatvād vāṭharyam āpādayati | tam
-                        ativaṭharaṃ
+                        śleṣmalāhārasevitodhyaśanaśīlasyāvyāyāmino divāsvapnaratasya āma evānnaraso
+                        madhurataraś ca śarīram anukramamāṇotisnehān medo janayati | medaso
+                        tipravṛddhatvād vāṭharyam āpādayati | tam ativaṭharaṃ
                         kṣudrasvāsapipāsākṣutsvapnasvedadaurgandhyakrathanagātrasādagagadatvāni
-                        kṣipram evāviśanti | saukumāryātmedasaḥ sarvakriyāsvasamarthatvaṃ
-                        bhavati | kaphaphamedo niruddhamārgatvāc cālpavyavāyo bhavati |
-                        āvṛtamārgatvād eva ca śeṣā dhātavo nāpyāyante 'tyartham ato
-                        lpaprāṇo bhavati |
-                        pramehapiḍakājvarabhagandaravidradhivātavikāṇārām anyatamaṃ prāpya
-                        maraṇam upayāti | sarva eva cāsya rogā balavanto bhavanti | kasmād
-                        āvṛtamārgatvāt srotasāmatas tasyotpattihetuṃ parihared utpanne tu
+                        kṣipram evāviśanti | saukumāryātmedasaḥ sarvakriyāsvasamarthatvaṃ bhavati |
+                        kaphaphamedo niruddhamārgatvāc cālpavyavāyo bhavati | āvṛtamārgatvād eva ca
+                        śeṣā dhātavo nāpyāyante 'tyartham ato lpaprāṇo bhavati |
+                        pramehapiḍakājvarabhagandaravidradhivātavikāṇārām anyatamaṃ prāpya maraṇam
+                        upayāti | sarva eva cāsya rogā balavanto bhavanti | kasmād āvṛtamārgatvāt
+                        srotasāmatas tasyotpattihetuṃ parihared utpanne tu
                         śilājatuguggulamūtratriphalāloharajorasāñjanamadhuyavamudgakoradūṣoddālakādīnāṃ
                         virūkṣaṇacchedanīyānāṃ dravyāṇāṃ vidhivad upayogo
                         vyāyāmalekhanabastyupayogaś ceti ||</l>
@@ -3561,25 +3459,22 @@
                         <caesura/>
                          tatra punar
                         vātalāhārasevinotivyavāyavyāyāmādhyayanacintābhayaśokarātrijāgaraṇapipāsākṣutkṣayālpāsanaprabhṛtibhir
-                        upaśoṣito rasadhātuḥ śarīram anukramamāṇaulpatvān na prīṇāyati
-                        tasmād atikārśyaṃ bhavati | sotikṛśaḥ
-                        kṣutpipāsāśītoṣṇavātavarṣābhārādāneṣv
+                        upaśoṣito rasadhātuḥ śarīram anukramamāṇaulpatvān na prīṇāyati tasmād
+                        atikārśyaṃ bhavati | sotikṛśaḥ kṣutpipāsāśītoṣṇavātavarṣābhārādāneṣv
                         asahiṣṇurvātarogaprāyolpaprāṇaḥ kriyāsu ca bhavati | kā
-                        plīhodarāgnisādagulmaraktapittānām anyatamaṃ prāpya maraṇam
-                        upayāti sarva eva cāsya rogā balavanto bhavanti | kasmād
-                        alpaprāṇatvād atas tasyotpattihetum pariharet | utpanne tu
-                        payasyāśvagandhāvidārīvidārigandhāśatāvarīnāgabalānāṃ madhurāṇāṃ
-                        manyāsāṃ cauṣadhīnāṃ vidhivadupayogaḥ |
-                        kṣīradadhighṛtamāṃsaśāliṣaṣṭikayavagodhūmānāṃ ca
-                        divāsvapnabrahmacaryāvyāyāmabṛṃhaṇabastyupayogaś ceti |</l>
+                        plīhodarāgnisādagulmaraktapittānām anyatamaṃ prāpya maraṇam upayāti sarva
+                        eva cāsya rogā balavanto bhavanti | kasmād alpaprāṇatvād atas
+                        tasyotpattihetum pariharet | utpanne tu
+                        payasyāśvagandhāvidārīvidārigandhāśatāvarīnāgabalānāṃ madhurāṇāṃ manyāsāṃ
+                        cauṣadhīnāṃ vidhivadupayogaḥ | kṣīradadhighṛtamāṃsaśāliṣaṣṭikayavagodhūmānāṃ
+                        ca divāsvapnabrahmacaryāvyāyāmabṛṃhaṇabastyupayogaś ceti |</l>
 
                     <l xml:id="SS.1.15.37">
                         <label>1.15.37</label>
                         <caesura/>
-                         yaḥ punar ubhayasādhāraṇāny upasevate tasyānnarasaḥ śarīram
-                        anukramamāṇaḥ samāndhātūnupacinoti samadhātutvān madhyaśarīro
-                        bhavati | sarvakriyāsu ca samarthaḥ
-                        kṣutpipāsāśītoṣṇavātavarṣātapasaho balavāṃś ca bhavati saḥ |
+                         yaḥ punar ubhayasādhāraṇāny upasevate tasyānnarasaḥ śarīram anukramamāṇaḥ
+                        samāndhātūnupacinoti samadhātutvān madhyaśarīro bhavati | sarvakriyāsu ca
+                        samarthaḥ kṣutpipāsāśītoṣṇavātavarṣātapasaho balavāṃś ca bhavati saḥ |
                         satatamanupālayitavya iti ||</l>
 
                     <l xml:id="SS.1.15.38">
@@ -3652,22 +3547,21 @@
                         <caesura/>
                         <label>1938 ed. 1.16.3</label>
                         <caesura/>
-                         rakṣābhūṣaṇanimittam bālasya karṇṇau vyadhayet | tau ṣaṣṭhe māse
-                        saptame vā śuklapakṣe praśasteṣu tithikaraṇamuhūrttanakṣatreṣu
-                            kṛtamaṅgalasvastivācanaṃ<anchor n="SS.1.16.3-n1"/> dhātryaṅke
-                        kumāram upaveśyābhisāntvayamāno bhiṣag vāmahastenākṛṣya karṇṇan
-                        daivakṛte chidre dakṣiṇahastena ṛju vidhyet | pūrvvan dakṣiṇaṃ
-                        kumārasya vāmaṅ kanyāyāḥ | pratanuṃ sūcyā bahalam ārayā
-                            ||2||<anchor n="SS.1.16.3-n2"/></l>
+                         rakṣābhūṣaṇanimittam bālasya karṇṇau vyadhayet | tau ṣaṣṭhe māse saptame vā
+                        śuklapakṣe praśasteṣu tithikaraṇamuhūrttanakṣatreṣu
+                            kṛtamaṅgalasvastivācanaṃ<anchor n="SS.1.16.3-n1"/> dhātryaṅke kumāram
+                        upaveśyābhisāntvayamāno bhiṣag vāmahastenākṛṣya karṇṇan daivakṛte chidre
+                        dakṣiṇahastena ṛju vidhyet | pūrvvan dakṣiṇaṃ kumārasya vāmaṅ kanyāyāḥ |
+                        pratanuṃ sūcyā bahalam ārayā ||2||<anchor n="SS.1.16.3-n2"/></l>
 
 
                     <ab corresp="#SS.1.16.3" type="apparatus">
                         <list type="notes">
                             <item corresp="#SS.1.16.3-n1">The compound
-                                    <foreign>kṛtamaṅgalasvastivācanaṃ</foreign> is an
-                                emendation based on the similar text at Su.śā.3.2.25. </item>
-                            <item corresp="#SS.1.16.3-n2">Ḍalhaṇa recorded the alternative
-                                reading <foreign>bhakṣyaviśeṣair vā</foreign> before
+                                    <foreign>kṛtamaṅgalasvastivācanaṃ</foreign> is an emendation
+                                based on the similar text at Su.śā.3.2.25. </item>
+                            <item corresp="#SS.1.16.3-n2">Ḍalhaṇa recorded the alternative reading
+                                    <foreign>bhakṣyaviśeṣair vā</foreign> before
                                     <foreign>bālakrīḍanakaiḥ pralobhya</foreign> in the
                                 vulgate.</item>
                         </list>
@@ -3678,16 +3572,15 @@
                         <caesura/>
                         <label>1938 ed. 1.16.4</label>
                         <caesura/>
-                         śoṇita<pc> </pc>bahutve 'tivedanāyāṃ cānyadeśaviddham iti jānīyāt
-                        | nirupadravatā taddeśaviddhaliṅgam ||3||<anchor n="SS.1.16.4-n1"
-                        /></l>
+                         śoṇita<pc> </pc>bahutve 'tivedanāyāṃ cānyadeśaviddham iti jānīyāt |
+                        nirupadravatā taddeśaviddhaliṅgam ||3||<anchor n="SS.1.16.4-n1"/></l>
 
 
                     <ab corresp="#SS.1.16.4" type="apparatus">
                         <list type="notes">
-                            <item corresp="#SS.1.16.4-n1">At this point, witness K is
-                                missing a folio, so the rest of this chapter is
-                                constructed on the basis of witnesses N and H.</item>
+                            <item corresp="#SS.1.16.4-n1">At this point, witness K is missing a
+                                folio, so the rest of this chapter is constructed on the basis of
+                                witnesses N and H.</item>
                         </list>
                     </ab>
 
@@ -3705,18 +3598,16 @@
                         <caesura/>
                         <label>1938 ed. 1.16.6</label>
                         <caesura/>
-                         doṣasamudayād apraśastavyadhād vā tatra varttim apahṛtya
-                            yava<pc> </pc>madhuka<pc> </pc>mañjiṣṭhā<pc
-                            > </pc>gandharvva<pc> </pc>hasta<pc> </pc>mūlair
-                        mmadhughṛtapragāḍhair ālepayet | surūḍhañ cainam punar vvidhyet
-                            ||5||<anchor n="SS.1.16.6-n1"/></l>
+                         doṣasamudayād apraśastavyadhād vā tatra varttim apahṛtya yava<pc
+                            > </pc>madhuka<pc> </pc>mañjiṣṭhā<pc> </pc>gandharvva<pc
+                            > </pc>hasta<pc> </pc>mūlair mmadhughṛtapragāḍhair ālepayet | surūḍhañ
+                        cainam punar vvidhyet ||5||<anchor n="SS.1.16.6-n1"/></l>
 
 
                     <ab corresp="#SS.1.16.6" type="apparatus">
                         <list type="notes">
-                            <item corresp="#SS.1.16.6-n1">Ḍalhaṇa (1.16.6) stated that
-                                some do not read <foreign>surūḍhañ cainam punar
-                                    vidhyet</foreign>.</item>
+                            <item corresp="#SS.1.16.6-n1">Ḍalhaṇa (1.16.6) stated that some do not
+                                read <foreign>surūḍhañ cainam punar vidhyet</foreign>.</item>
                         </list>
                     </ab>
 
@@ -3726,15 +3617,15 @@
                         <label>1938 ed. 1.16.7</label>
                         <caesura/>
                          samyagviddham āmatailapariṣekeṇopacaret | tryahāt tryahād varttiṃ
-                            sthūlatarīṃ<anchor n="SS.1.16.7-n1"/> kurvvīta pariṣekañ ca
-                        tam eva ||6||</l>
+                            sthūlatarīṃ<anchor n="SS.1.16.7-n1"/> kurvvīta pariṣekañ ca tam eva
+                        ||6||</l>
 
                     <ab corresp="#SS.1.16.7" type="apparatus">
                         <list type="notes">
                             <item corresp="#SS.1.16.7-n1">The unusual form
-                                    <foreign>sthūlatarīṃ</foreign> is supported by both
-                                manuscripts and we have retained it in spite of only
-                                meagre evidence for the form in epic Sanskrit.</item>
+                                    <foreign>sthūlatarīṃ</foreign> is supported by both manuscripts
+                                and we have retained it in spite of only meagre evidence for the
+                                form in epic Sanskrit.</item>
                         </list>
                     </ab>
 
@@ -3743,8 +3634,8 @@
                         <caesura/>
                         <label>1938 ed. 1.16.8</label>
                         <caesura/>
-                         atha vyapagatadoṣopadrave karṇṇe 'laṃpravarddhanārthaṃ
-                        laghupravarddhanakam āmuñcet ||7||</l>
+                         atha vyapagatadoṣopadrave karṇṇe 'laṃpravarddhanārthaṃ laghupravarddhanakam
+                        āmuñcet ||7||</l>
 
                     <l xml:id="SS.1.16.9">
                         <label>1.16.9</label>
@@ -3760,41 +3651,36 @@
                         <caesura/>
                         <label>1938 ed. 1.16.10</label>
                         <caesura/>
-                         tatra samāsena pañcadaśasandhānākṛtayo bhavanti |<anchor
-                            n="SS.1.16.10-n1"/> tad yathā | nemīsandhānakaḥ |
-                        utpalabhedyakaḥ | vallūrakaḥ | āsaṅgimaḥ | gaṇḍakarṇṇaḥ | āhāryaḥ
-                        | nirvvedhimaḥ | vyāyojimaḥ | kapāṭasandhikaḥ |
+                         tatra samāsena pañcadaśasandhānākṛtayo bhavanti |<anchor n="SS.1.16.10-n1"
+                        /> tad yathā | nemīsandhānakaḥ | utpalabhedyakaḥ | vallūrakaḥ | āsaṅgimaḥ |
+                        gaṇḍakarṇṇaḥ | āhāryaḥ | nirvvedhimaḥ | vyāyojimaḥ | kapāṭasandhikaḥ |
                         arddhakapāṭasandhikaḥ | saṅkṣiptaḥ | hīnakarṇṇaḥ | vallīkarṇṇaḥ |
-                        yaṣṭīkarṇṇaḥ | kākauṣṭhaḥ | iti | teṣu tatra
-                        pṛthulāyatasamobhayapālir nemīsandhānakaḥ |
-                        vṛttāyatasamobhayapālir utpalabhedyakaḥ |
-                        hrasvavṛttasamobhayapālir vallūrakarṇṇakaḥ |
-                        abhyantaradīrghaikapālir āsaṅgimaḥ | bāhya<pc> </pc>dīrghaikapālir
-                        ggaṇḍakarṇṇakaḥ | apālir ubhayato 'py āhāryaḥ | pīṭhopamapālir
-                        nirvvedhimaḥ | aṇusthūlasamaviṣamapālir vyāyojimaḥ |
-                        abhyantaradīrghaikapālir itarālpapāliḥ kapāṭasandhikaḥ |
-                        bāhyadīrghaikapālir itarālpapāliś cārddhakapāṭasandhikaḥ |
-                        tatraite daśakarṇṇasandhivikalpā bandhyā bhavanti | teṣān nāmabhir
-                        evākṛtayaḥ prāyeṇa vyākhyātāḥ | saṃkṣiptādayaḥ pañcāsādhyāḥ |
-                        tatra śuṣkaśaṣkulir itarālpapāliḥ saṃkṣiptaḥ | anadhiṣṭhānapāliḥ
-                        paryantayoś ca kṣīṇamāṃso hīnakarṇṇaḥ | tanuviṣamapālir
-                        vallīkarṇṇaḥ | granthitamāṃsaḥ stabdhasirātatasūkṣmapālir
-                        yaṣṭīkarṇṇaḥ | nirmmāṃsasaṃkṣiptāgrālpaśoṇitapāliḥ kākauṣṭha iti |
-                        baddheṣv api dāha<pc> </pc>pāka<pc> </pc>srāva<pc
-                            > </pc>śopha<pc> </pc>yuktā na siddhim upayānti ||9|| </l>
+                        yaṣṭīkarṇṇaḥ | kākauṣṭhaḥ | iti | teṣu tatra pṛthulāyatasamobhayapālir
+                        nemīsandhānakaḥ | vṛttāyatasamobhayapālir utpalabhedyakaḥ |
+                        hrasvavṛttasamobhayapālir vallūrakarṇṇakaḥ | abhyantaradīrghaikapālir
+                        āsaṅgimaḥ | bāhya<pc> </pc>dīrghaikapālir ggaṇḍakarṇṇakaḥ | apālir ubhayato
+                        'py āhāryaḥ | pīṭhopamapālir nirvvedhimaḥ | aṇusthūlasamaviṣamapālir
+                        vyāyojimaḥ | abhyantaradīrghaikapālir itarālpapāliḥ kapāṭasandhikaḥ |
+                        bāhyadīrghaikapālir itarālpapāliś cārddhakapāṭasandhikaḥ | tatraite
+                        daśakarṇṇasandhivikalpā bandhyā bhavanti | teṣān nāmabhir evākṛtayaḥ prāyeṇa
+                        vyākhyātāḥ | saṃkṣiptādayaḥ pañcāsādhyāḥ | tatra śuṣkaśaṣkulir itarālpapāliḥ
+                        saṃkṣiptaḥ | anadhiṣṭhānapāliḥ paryantayoś ca kṣīṇamāṃso hīnakarṇṇaḥ |
+                        tanuviṣamapālir vallīkarṇṇaḥ | granthitamāṃsaḥ stabdhasirātatasūkṣmapālir
+                        yaṣṭīkarṇṇaḥ | nirmmāṃsasaṃkṣiptāgrālpaśoṇitapāliḥ kākauṣṭha iti | baddheṣv
+                        api dāha<pc> </pc>pāka<pc> </pc>srāva<pc> </pc>śopha<pc> </pc>yuktā na
+                        siddhim upayānti ||9|| </l>
 
 
                     <ab corresp="#SS.1.16.10" type="apparatus">
                         <list type="notes">
-                            <item corresp="#SS.1.16.10-n1">Cakrapāṇi (1.16.9–13) and
-                                Ḍalhaṇa (1.16.10) pointed out that others read
+                            <item corresp="#SS.1.16.10-n1">Cakrapāṇi (1.16.9–13) and Ḍalhaṇa
+                                (1.16.10) pointed out that others read
                                     <foreign>pañcadaśakarṇakṛtayaḥ</foreign> (instead of
-                                    <foreign>pañcadaśasandhānākṛtayaḥ</foreign>). Ḍalhaṇa
-                                (1.16.10) also mentioned that some read
+                                    <foreign>pañcadaśasandhānākṛtayaḥ</foreign>). Ḍalhaṇa (1.16.10)
+                                also mentioned that some read
                                     <foreign>samunnatasamobhayapāliḥ</foreign> (instead of
-                                    <foreign>vṛttāyatasamobhayapālir</foreign>) and others
-                                do not read <foreign>saṃkṣiptādayaḥ
-                                pañcāsādhyāḥ</foreign>.</item>
+                                    <foreign>vṛttāyatasamobhayapālir</foreign>) and others do not
+                                read <foreign>saṃkṣiptādayaḥ pañcāsādhyāḥ</foreign>.</item>
                         </list>
                     </ab>
 
@@ -3807,13 +3693,12 @@
 
                     <ab corresp="#SS.1.16.14cd" type="apparatus">
                         <list type="notes">
-                            <item corresp="#SS.1.16.14cd-n1">The additional verses in A
-                                (from <foreign>bhavanti cātra to śāstravit</foreign>) were
-                                probably also absent in the version of the
-                                    <emph>Suśrutasaṃhitā</emph> commented on by Cakrapāṇi,
-                                who cited them in his commentary as being "read by some"
-                                in regard to the joins (<foreign>sandhāna</foreign>) they
-                                describe.</item>
+                            <item corresp="#SS.1.16.14cd-n1">The additional verses in A (from
+                                    <foreign>bhavanti cātra to śāstravit</foreign>) were probably
+                                also absent in the version of the <emph>Suśrutasaṃhitā</emph>
+                                commented on by Cakrapāṇi, who cited them in his commentary as being
+                                "read by some" in regard to the joins (<foreign>sandhāna</foreign>)
+                                they describe.</item>
                         </list>
                     </ab>
 
@@ -3822,41 +3707,35 @@
                         <caesura/>
                         <label>1938 ed. 1.16.15</label>
                         <caesura/>
-                         ato 'nyatamasya bandhañ cikīrṣuḥ
-                        agropaharaṇīyoktopasambhṛtasambhāraḥ viśeṣataś cātropaharet<anchor
-                            n="SS.1.16.15-n1"/> surāmaṇḍakṣīram udakaṃ
-                        dhānyāmlakapālacūrṇṇañ ceti | tato 'ṅganāṃ puruṣam vā
-                        grathitakeśāntaṃ laghubhuktavantam āptaiḥ suparigṛhītaṃ kṛtvā ca
-                        bandhān upadhārya chedyabhedyalekhyavyadhanair upapādya
-                        karṇṇaśoṇitam avekṣyaitad duṣṭam aduṣṭam veti tato vātaduṣṭe
-                        dhānyāmlodakābhyāṃ pittaduṣṭe śītodakapayobhyāṃ śleṣmaduṣṭe
-                        surāmaṇḍodakābhyāṃ prakṣālya karṇṇam punar avalikhet | anunnatam
+                         ato 'nyatamasya bandhañ cikīrṣuḥ agropaharaṇīyoktopasambhṛtasambhāraḥ
+                        viśeṣataś cātropaharet<anchor n="SS.1.16.15-n1"/> surāmaṇḍakṣīram udakaṃ
+                        dhānyāmlakapālacūrṇṇañ ceti | tato 'ṅganāṃ puruṣam vā grathitakeśāntaṃ
+                        laghubhuktavantam āptaiḥ suparigṛhītaṃ kṛtvā ca bandhān upadhārya
+                        chedyabhedyalekhyavyadhanair upapādya karṇṇaśoṇitam avekṣyaitad duṣṭam
+                        aduṣṭam veti tato vātaduṣṭe dhānyāmlodakābhyāṃ pittaduṣṭe śītodakapayobhyāṃ
+                        śleṣmaduṣṭe surāmaṇḍodakābhyāṃ prakṣālya karṇṇam punar avalikhet | anunnatam
                         ahīnam aviṣamañ ca karṇṇasandhin niveśya sthitaraktaṃ sandarśya
-                        madhughṛtenābhyajya picuplotayor anyatareṇāvaguṇṭhya nātigāḍhan
-                        nātiśithilaṃ sūtreṇāvabadhya kapālacūrṇṇenāvakīryācārikam upadiśet
-                            |<anchor n="SS.1.16.15-n2"/> dvivraṇīyoktena cānnenopacaret
-                        ||10|| </l>
+                        madhughṛtenābhyajya picuplotayor anyatareṇāvaguṇṭhya nātigāḍhan nātiśithilaṃ
+                        sūtreṇāvabadhya kapālacūrṇṇenāvakīryācārikam upadiśet |<anchor
+                            n="SS.1.16.15-n2"/> dvivraṇīyoktena cānnenopacaret ||10|| </l>
 
 
                     <ab corresp="#SS.1.16.15" type="apparatus">
                         <list type="notes">
-                            <item corresp="#SS.1.16.15-n1">The MSS reading
-                                    <foreign>viśeṣataś cāgropaharaṇīyāt</foreign> has been
-                                emended to <foreign>viśeṣataś cātropaharet</foreign> to
-                                make sense of the list of ingredients, which is in the
-                                accusative case. Also, the repetition of
-                                    <foreign>agropaharaṇīyāt</foreign> in the MSS suggests
-                                that its second occurrence, which does not make good sense
-                                here, is a dittographic error.</item>
+                            <item corresp="#SS.1.16.15-n1">The MSS reading <foreign>viśeṣataś
+                                    cāgropaharaṇīyāt</foreign> has been emended to
+                                    <foreign>viśeṣataś cātropaharet</foreign> to make sense of the
+                                list of ingredients, which is in the accusative case. Also, the
+                                repetition of <foreign>agropaharaṇīyāt</foreign> in the MSS suggests
+                                that its second occurrence, which does not make good sense here, is
+                                a dittographic error.</item>
                         </list>
                         <list type="testimonia">
-                            <item corresp="#SS.1.16.15-n2"
-                                    ><foreign>Aṣṭāṅgahṛdayasaṃhitā</foreign> 1.18.52--53:
-                                    <foreign>atha grathitvā keśāntaṃ kṛtvā chedanalekhanam
-                                    | niveśya sandhiṃ suṣamaṃ na nimnaṃ na samunnatam ||
-                                    52 || abhyajya madhusarpirbhyāṃ picuplotāvaguṇṭhitam |
-                                    sūtreṇāgāḍhaśithilaṃ baddhvā cūrṇair avākiret || 53
-                                    ||</foreign>
+                            <item corresp="#SS.1.16.15-n2"><foreign>Aṣṭāṅgahṛdayasaṃhitā</foreign>
+                                1.18.52--53: <foreign>atha grathitvā keśāntaṃ kṛtvā chedanalekhanam
+                                    | niveśya sandhiṃ suṣamaṃ na nimnaṃ na samunnatam || 52 ||
+                                    abhyajya madhusarpirbhyāṃ picuplotāvaguṇṭhitam |
+                                    sūtreṇāgāḍhaśithilaṃ baddhvā cūrṇair avākiret || 53 ||</foreign>
                             </item>
                         </list>
                     </ab>
@@ -3877,10 +3756,10 @@
                         <caesura/>
                         <label>1938 ed. 1.16.17</label>
                         <caesura/>
-                         nātiśuddharaktam atipravṛttaraktaṃ kṣīṇaraktaṃ vā sandadhyāt | sa
-                        hi vātaduṣṭe raktabaddho 'rūḍho paripuṭanavān bhavati | pittaduṣṭe
-                        gāḍhapākarāgavān | śleṣmaduṣṭe stabdhakarṇṇaḥ kaṇḍūmān
-                        atipravṛttasrāvaḥ śophavān kṣīṇālpamāṃso na vṛddhim upaiti ||12|| </l>
+                         nātiśuddharaktam atipravṛttaraktaṃ kṣīṇaraktaṃ vā sandadhyāt | sa hi
+                        vātaduṣṭe raktabaddho 'rūḍho paripuṭanavān bhavati | pittaduṣṭe
+                        gāḍhapākarāgavān | śleṣmaduṣṭe stabdhakarṇṇaḥ kaṇḍūmān atipravṛttasrāvaḥ
+                        śophavān kṣīṇālpamāṃso na vṛddhim upaiti ||12|| </l>
 
                     <l xml:id="SS.1.16.18">
                         <label>1.16.18</label>
@@ -3888,8 +3767,8 @@
                         <label>1938 ed. 1.16.18</label>
                         <caesura/>
                          sa yadā rūḍho nirupadravaḥ karṇṇo bhavati tadainaṃ śanaiḥ śanair
-                        abhivarddhayet | anyathā saṃrambhadāhapākavedanāvān bhavati |
-                        punar api chidyeta ||13|| </l>
+                        abhivarddhayet | anyathā saṃrambhadāhapākavedanāvān bhavati | punar api
+                        chidyeta ||13|| </l>
 
 
                     <l xml:id="SS.1.16.19">
@@ -3898,25 +3777,22 @@
                         <label>1938 ed. 1.16.19</label>
                         <caesura/>
                          athāpraduṣṭasyābhivarddhanārtham abhyaṅgaḥ |
-                        godhāpratudaviṣkirānūpaudakavasāmajjāpayastailaṃ gaurasarṣapajañ
-                        ca yathālābhaṃ
-                        saṃbhṛtyārkālarkabalātibalānantāvidārīmadhukajalaśūkaprativāpan
-                        tailam pācayitvā svanuguptan nidadhyāt ||14||<anchor
-                            n="SS.1.16.19-n1"/></l>
+                        godhāpratudaviṣkirānūpaudakavasāmajjāpayastailaṃ gaurasarṣapajañ ca
+                        yathālābhaṃ saṃbhṛtyārkālarkabalātibalānantāvidārīmadhukajalaśūkaprativāpan
+                        tailam pācayitvā svanuguptan nidadhyāt ||14||<anchor n="SS.1.16.19-n1"/></l>
 
 
                     <ab corresp="#SS.1.16.19" type="apparatus">
                         <list type="notes">
-                            <item corresp="#SS.1.16.19-n1">Ḍalhaṇa (1.16.18) noted that
-                                some read <foreign>rājasarṣapajaṃ</foreign> in the place
-                                of <foreign>gaurasarṣapajaṃ</foreign>. This reading
-                                appears to have been accepted by Cakrapāṇi (1.16.18–20),
-                                who glossed <foreign>rājasarṣapaja</foreign> as
-                                    <foreign>śvetasarṣapa</foreign>. Cakrapāṇi also said
-                                that some read sarpis in the place of
-                                    <foreign>payas</foreign>. In the compound beginning
-                                with <foreign>arka</foreign>, Ḍalhaṇa noted that some read
-                                    <foreign>arkapuṣpī</foreign>.</item>
+                            <item corresp="#SS.1.16.19-n1">Ḍalhaṇa (1.16.18) noted that some read
+                                    <foreign>rājasarṣapajaṃ</foreign> in the place of
+                                    <foreign>gaurasarṣapajaṃ</foreign>. This reading appears to have
+                                been accepted by Cakrapāṇi (1.16.18–20), who glossed
+                                    <foreign>rājasarṣapaja</foreign> as
+                                    <foreign>śvetasarṣapa</foreign>. Cakrapāṇi also said that some
+                                read sarpis in the place of <foreign>payas</foreign>. In the
+                                compound beginning with <foreign>arka</foreign>, Ḍalhaṇa noted that
+                                some read <foreign>arkapuṣpī</foreign>.</item>
                         </list>
                     </ab>
 
@@ -3933,11 +3809,10 @@
 
                     <ab corresp="#SS.1.16.20" type="apparatus">
                         <list type="notes">
-                            <item corresp="#SS.1.16.20-n1">N has a
-                                    <foreign>kākapāda</foreign> after
-                                    <foreign>ane</foreign>, but the missing letter (one
-                                would expect '<foreign>na</foreign>') has not been
-                                supplied in a margin or elsewhere.</item>
+                            <item corresp="#SS.1.16.20-n1">N has a <foreign>kākapāda</foreign> after
+                                    <foreign>ane</foreign>, but the missing letter (one would expect
+                                    '<foreign>na</foreign>') has not been supplied in a margin or
+                                elsewhere.</item>
                         </list>
                     </ab>
 
@@ -3961,9 +3836,9 @@
 
                     <ab corresp="#SS.1.16.23" type="apparatus">
                         <list type="notes">
-                            <item corresp="#SS.1.16.23-n1">Ḍalhaṇa (1.16.23) noted that
-                                some read <foreign>teṣām apāṅgacchedyaṃ hi kāryam
-                                    ābhyantaraṃ bhavet</foreign>.</item>
+                            <item corresp="#SS.1.16.23-n1">Ḍalhaṇa (1.16.23) noted that some read
+                                    <foreign>teṣām apāṅgacchedyaṃ hi kāryam ābhyantaraṃ
+                                    bhavet</foreign>.</item>
                         </list>
                     </ab>
 
@@ -3985,10 +3860,9 @@
 
                     <ab corresp="#SS.1.16.26.0" type="apparatus">
                         <list type="notes">
-                            <item corresp="#SS.1.16.26.0-n1">Ḍalhaṇa (1.16.26) stated that
-                                some read <foreign>suniviṣṭaḥ</foreign> (the reading of
-                                the Nepalese version) instead of
-                                    <foreign>suviśiṣṭaḥ</foreign>.</item>
+                            <item corresp="#SS.1.16.26.0-n1">Ḍalhaṇa (1.16.26) stated that some read
+                                    <foreign>suniviṣṭaḥ</foreign> (the reading of the Nepalese
+                                version) instead of <foreign>suviśiṣṭaḥ</foreign>.</item>
                         </list>
                     </ab>
 
@@ -4035,16 +3909,15 @@
                         <caesura/>
                          nāsāpramāṇaṃ pṛthivīruhāṇāṃ
                         <caesura/>
-                         patraṃ gṛhītvā tv avalambi tasya ||19||<anchor n="SS.1.16.27-n1"
-                        /></l>
+                         patraṃ gṛhītvā tv avalambi tasya ||19||<anchor n="SS.1.16.27-n1"/></l>
 
                     <ab corresp="#SS.1.16.27" type="apparatus">
                         <list type="notes">
-                            <item corresp="#SS.1.16.27-n1">Cakrapāṇidatta said that others
-                                read <foreign>nāsāsandhānavidhim</foreign> here. Ḍalhaṇa
-                                (1.16.27–31) stated that some read, <foreign>chinnāṃ tu
-                                    nāsikāṃ dṛṣṭvā vayaḥsthasya śarīriṇaḥ | nāsānurūpaṃ
-                                    saṃcchidya patraṃ gaṇḍe niveśayet ||</foreign></item>
+                            <item corresp="#SS.1.16.27-n1">Cakrapāṇidatta said that others read
+                                    <foreign>nāsāsandhānavidhim</foreign> here. Ḍalhaṇa (1.16.27–31)
+                                stated that some read, <foreign>chinnāṃ tu nāsikāṃ dṛṣṭvā
+                                    vayaḥsthasya śarīriṇaḥ | nāsānurūpaṃ saṃcchidya patraṃ gaṇḍe
+                                    niveśayet ||</foreign></item>
                         </list>
                     </ab>
 
@@ -4122,51 +3995,46 @@
                     <l xml:id="SS.1.17.3">
                         <label>1.17.3</label>
                         <caesura/>
-                         atha śophasamutthānā granthividradhyalajīprabhṛtayaḥ | prāyeṇa
-                        vyādhayo 'bhihitā anekākṛtayaḥ | tair vvilakṣaṇaḥ pṛthur grathitaḥ
-                        samo viṣamo vā tvagmāṃsasthāyī saṃghātaḥ śarīraikadeśotthitaḥ
-                        śopha ity ucyate | </l>
+                         atha śophasamutthānā granthividradhyalajīprabhṛtayaḥ | prāyeṇa vyādhayo
+                        'bhihitā anekākṛtayaḥ | tair vvilakṣaṇaḥ pṛthur grathitaḥ samo viṣamo vā
+                        tvagmāṃsasthāyī saṃghātaḥ śarīraikadeśotthitaḥ śopha ity ucyate | </l>
 
                     <l xml:id="SS.1.17.4">
                         <label>1.17.4</label>
                         <caesura/>
-                         vātapittakaphaśoṇitasannipātāgantukani raruṇaḥ kṛṣṇo vā paruṣo
-                        mṛdur anavasthitastodādayaś cātra vedanāviśeṣo bhavanti |
-                        pittaśvayathuḥ pītaḥ sarakto vā śīghrānusārīmṛdur dāhādayaś cātra
-                        vedanāviśeṣo bhavanti | śleṣmaśvayathuḥ pāṇḍuḥ śuklo vā kaṭhinaḥ
-                        snigdho mandānusārī kaṇḍvādayaś cātra vedanāviśeṣo bhavanti |
-                        sannipātaśvayathuḥ sarvadoṣaliṅgaviśeṣopetaḥ | pittavac
-                        choṇitajotikṛṣṇaś ca | pittaraktalakṣaṇaś cāgantur lohitāvabhāsaś
+                         vātapittakaphaśoṇitasannipātāgantukani raruṇaḥ kṛṣṇo vā paruṣo mṛdur
+                        anavasthitastodādayaś cātra vedanāviśeṣo bhavanti | pittaśvayathuḥ pītaḥ
+                        sarakto vā śīghrānusārīmṛdur dāhādayaś cātra vedanāviśeṣo bhavanti |
+                        śleṣmaśvayathuḥ pāṇḍuḥ śuklo vā kaṭhinaḥ snigdho mandānusārī kaṇḍvādayaś
+                        cātra vedanāviśeṣo bhavanti | sannipātaśvayathuḥ sarvadoṣaliṅgaviśeṣopetaḥ |
+                        pittavac choṇitajotikṛṣṇaś ca | pittaraktalakṣaṇaś cāgantur lohitāvabhāsaś
                         ca |</l>
 
                     <l xml:id="SS.1.17.5">
                         <label>1.17.5</label>
                         <caesura/>
                          sa yadā bāhyābhyantaraiḥ kriyāviśeṣairna śakyate praśamayituṃ
-                        kriyāviparyayād bahutvād vā doṣāṇāṃ pākayābhimukho bhavati
-                        tasyāmasya pacyamānasya pakvasya ca lakṣaṇam ucyamānam upadhārayaś
-                        ca | tatra mandoṣmatā tvaksāvarṇyan sthairyaṃm
-                        alparujatālpaśophatā cāmalakṣaṇam uddiṣṭaṃ || sūcībhir iva
-                        nistudyate daśyata iva ca pipīlikābhiś chidyate bhidyata iva ca
-                        śastreṇa tāḍyata iva ca daṇḍenabhiḥ pīḍyata iva ca pāṇinā ghaṭyata
-                        iva cāṃgulyā dahyate pacyata iva cāgnikṣārābhyāṃ mūṣā
-                        coṣaparidāhāś ca bhavanti | vṛścikaviddha iva ca
-                        sthānāsanaśayaneṣu na śāntim upaiti | ādhmātabastir ivātataś ca
-                        śopho bhavati tvagvaivarṇyaṃ śophābhivṛddhirjvaro dāhaḥ pipāsā
-                        bhaktā ruciś ca pacyamānaliṅgaṃ ||
-                        vedanopaśāntirnirlohitālpaśophatā ca balīprādurbhāvaḥ
-                        tvakparipoṭanaṃ nimnadarśanam aṅgulyāvapīḍite
-                        bastāvivacodakasañcaraṇaṃ pūyasya prapīḍayaty ekam antam ante
-                        cāvapīḍite muhur muhus todaḥ kaṇḍūranunnatatā vyādher
+                        kriyāviparyayād bahutvād vā doṣāṇāṃ pākayābhimukho bhavati tasyāmasya
+                        pacyamānasya pakvasya ca lakṣaṇam ucyamānam upadhārayaś ca | tatra
+                        mandoṣmatā tvaksāvarṇyan sthairyaṃm alparujatālpaśophatā cāmalakṣaṇam
+                        uddiṣṭaṃ || sūcībhir iva nistudyate daśyata iva ca pipīlikābhiś chidyate
+                        bhidyata iva ca śastreṇa tāḍyata iva ca daṇḍenabhiḥ pīḍyata iva ca pāṇinā
+                        ghaṭyata iva cāṃgulyā dahyate pacyata iva cāgnikṣārābhyāṃ mūṣā coṣaparidāhāś
+                        ca bhavanti | vṛścikaviddha iva ca sthānāsanaśayaneṣu na śāntim upaiti |
+                        ādhmātabastir ivātataś ca śopho bhavati tvagvaivarṇyaṃ śophābhivṛddhirjvaro
+                        dāhaḥ pipāsā bhaktā ruciś ca pacyamānaliṅgaṃ ||
+                        vedanopaśāntirnirlohitālpaśophatā ca balīprādurbhāvaḥ tvakparipoṭanaṃ
+                        nimnadarśanam aṅgulyāvapīḍite bastāvivacodakasañcaraṇaṃ pūyasya prapīḍayaty
+                        ekam antam ante cāvapīḍite muhur muhus todaḥ kaṇḍūranunnatatā vyādher
                         upadravaśāntir bhaktābhikāṅkṣā ca paripakvaliṅgaṃ ||</l>
 
                     <l xml:id="SS.1.17.6">
                         <label>1.17.6</label>
                         <caesura/>
-                         kaphajeṣu khalu rogeṣu gambhīrānugatatvād abhighātajeṣu ca
-                        keṣucid asamastam pakvalakṣaṇaṃ dṛṣṭvā pakvam apakvam iti
-                        manyamāno bhiṣaṅ moham upaiti | tatra hi tvaksavarṇṇatā
-                        śītaśophatālparujatāśmavac ca ghanatā na tatra moham upeyāt |</l>
+                         kaphajeṣu khalu rogeṣu gambhīrānugatatvād abhighātajeṣu ca keṣucid
+                        asamastam pakvalakṣaṇaṃ dṛṣṭvā pakvam apakvam iti manyamāno bhiṣaṅ moham
+                        upaiti | tatra hi tvaksavarṇṇatā śītaśophatālparujatāśmavac ca ghanatā na
+                        tatra moham upeyāt |</l>
 
                     <l xml:id="SS.1.17.7">
                         <label>1.17.7</label>
@@ -4182,8 +4050,7 @@
                         <caesura/>
                          vātād ṛte nāsti rujā na pākaḥ pittād ṛte nāsti kaphāc ca pūyaḥ |
                         <caesura/>
-                         tasmāt samastāḥ paripākakāle pacanti śophaṃ traya eva doṣāḥ
-                        ||</l>
+                         tasmāt samastāḥ paripākakāle pacanti śophaṃ traya eva doṣāḥ ||</l>
 
                     <l xml:id="SS.1.17.8.1">
                         <label>1.17.8ef</label>
@@ -4217,11 +4084,10 @@
                         <label>1.17.10</label>
                         <caesura/>
                          tatrāmacchede sirāsnāyuvyāpādanaṃ śoṇitātipravṛttiḥ
-                        vedanāprādurbhāvovadaraṇam anekopadravadarśanaṃ kṣatavidradhir vā
-                        bhavati | sa yadā tu bhayamohābhyāṃ pakvam apakvam iti manyamānaḥ
-                        ciram upekṣate vyādhiṃ vaidyaḥ | sa gambhīrānugato dvāram
-                        alabhamānaḥ pūyaḥ svamāśayam avadāyotsaṅgaṅ kṛtvā nāḍīñ janayitvā
-                        bhavaty asādhyaḥ ||</l>
+                        vedanāprādurbhāvovadaraṇam anekopadravadarśanaṃ kṣatavidradhir vā bhavati |
+                        sa yadā tu bhayamohābhyāṃ pakvam apakvam iti manyamānaḥ ciram upekṣate
+                        vyādhiṃ vaidyaḥ | sa gambhīrānugato dvāram alabhamānaḥ pūyaḥ svamāśayam
+                        avadāyotsaṅgaṅ kṛtvā nāḍīñ janayitvā bhavaty asādhyaḥ ||</l>
 
                     <l xml:id="SS.1.17.11">
                         <label>1.17.11</label>
@@ -4256,11 +4122,9 @@
                     <l xml:id="SS.1.17.15">
                         <label>1.17.15</label>
                         <caesura/>
-                         yo hy utthitolpo yadi vā mahāṃbhyāt kriyāṃ vinā pākam upaiti
-                        śophaḥ |
+                         yo hy utthitolpo yadi vā mahāṃbhyāt kriyāṃ vinā pākam upaiti śophaḥ |
                         <caesura/>
-                         viśālamūlo viṣamaṃ vidagdhaḥ sa kṛcchratāṃ yāty avagāḍhadoṣaḥ
-                        ||</l>
+                         viśālamūlo viṣamaṃ vidagdhaḥ sa kṛcchratāṃ yāty avagāḍhadoṣaḥ ||</l>
 
                     <l xml:id="SS.1.17.16">
                         <label>1.17.16</label>
@@ -4307,32 +4171,31 @@
                     <l xml:id="SS.1.18.3">
                         <label>1.18.3</label>
                         <caesura/>
-                         ālepana ādya upakrama eṣa sarvaśophānāṃ sāmānyataḥ pradhānatamaś
-                        ca tamprati pratirogam vakṣyāmaḥ |</l>
+                         ālepana ādya upakrama eṣa sarvaśophānāṃ sāmānyataḥ pradhānatamaś ca
+                        tamprati pratirogam vakṣyāmaḥ |</l>
 
                     <l xml:id="SS.1.18.4">
                         <label>1.18.4</label>
                         <caesura/>
                          tatra pratilomam ālimpen nānuloma | pratilome hi samyag auṣadham
-                        avatiṣṭhate | praviśati ca romakūpais tasya pramāṇaṃ
-                        māhiṣārdracarmāt sedham upadiśanti |</l>
+                        avatiṣṭhate | praviśati ca romakūpais tasya pramāṇaṃ māhiṣārdracarmāt sedham
+                        upadiśanti |</l>
 
                     <l xml:id="SS.1.18.5">
                         <label>1.18.5</label>
                         <caesura/>
-                         na ca śuṣkam upekṣitavyam anyatra pīḍayitavyāt | śuṣkam
-                        apārthakaṃ rujākaraś ca bhavati |</l>
+                         na ca śuṣkam upekṣitavyam anyatra pīḍayitavyāt | śuṣkam apārthakaṃ
+                        rujākaraś ca bhavati |</l>
 
                     <l xml:id="SS.1.18.6">
                         <label>1.18.6</label>
                         <caesura/>
-                         ālepapradehayor antaram ālepaḥ śītas tanur aviśoṣī viśoṣī vā |
-                        pradehas tūṣṇaḥ śīto vā bahalobahuviśoṣī ca | tatra
-                        raktapittaprasādakṛdālepaḥ | śodhano ropaṇaḥ śophavedanāpagamaś ca
-                        tasyopayogaḥ kṣatākṣateṣu yastu kṣateṣūpayujyate sa bhūyaḥ kalka
-                        iti saṃjñāṃ labhate | nirudhyālepanasaṃjñaḥ tenāsrāvam anirodho
-                        mṛdupūtimāṃsāpakarṣaṇam antardoṣatā śurvraṇaśuddhiś ca bhavati
-                        |</l>
+                         ālepapradehayor antaram ālepaḥ śītas tanur aviśoṣī viśoṣī vā | pradehas
+                        tūṣṇaḥ śīto vā bahalobahuviśoṣī ca | tatra raktapittaprasādakṛdālepaḥ |
+                        śodhano ropaṇaḥ śophavedanāpagamaś ca tasyopayogaḥ kṣatākṣateṣu yastu
+                        kṣateṣūpayujyate sa bhūyaḥ kalka iti saṃjñāṃ labhate | nirudhyālepanasaṃjñaḥ
+                        tenāsrāvam anirodho mṛdupūtimāṃsāpakarṣaṇam antardoṣatā śurvraṇaśuddhiś ca
+                        bhavati |</l>
 
                     <l xml:id="SS.1.18.8"/>
 
@@ -4371,22 +4234,20 @@
                     <l xml:id="SS.1.18.17">
                         <label>1.18.17</label>
                         <caesura/>
-                         kośadāma śākhāsu
-                        grīvāmeḍhramūtolīmaṇḍalasthavikāyamalakakhaṭvācīnavivandha
-                        vitānagophaṇāḥ pañcāṅgī ceti caturdaśabandhaviśeṣāḥ | teṣān
-                        nāmabhir evākṛtayaḥ prāyeṇa vyākhyātāḥ |</l>
+                         kośadāma śākhāsu grīvāmeḍhramūtolīmaṇḍalasthavikāyamalakakhaṭvācīnavivandha
+                        vitānagophaṇāḥ pañcāṅgī ceti caturdaśabandhaviśeṣāḥ | teṣān nāmabhir
+                        evākṛtayaḥ prāyeṇa vyākhyātāḥ |</l>
 
                     <l xml:id="SS.1.18.18">
                         <label>1.18.18</label>
                         <caesura/>
                          tatra kośañ jaṅghāṅguliparvvasu vidadhyāt | dāmam asaṃbādhe 'ṅge
                         sāndhikūrccakastanāntarakarṇṇeṣu svastikam anuvellitaṃ śākhāsu
-                        grīvāmeḍhrayon mūtolīṃ vṛtteṅge maṇḍalam aṅguṣṭhāṅgulimeḍhrāgreṣu
-                        sthavikā | yamalavraṇābhyāṃ yamalakaṃ | hanuga<gap n="13"
-                            unit="char"/>ṇḍaśaṃkheṣu khaṭvām apāṅgayoś cīnaṃ |
-                        pṛṣṭhodaroraḥsu vibandhaṃ mūrddhni vitāmaṃ |
-                        cipukanāmauṣṭhāṃsabastiṣu goṣphaṇā jatruṇipañcāṅgīm iti | yo vā
-                        yasmin pradeśe suniviṣṭo bhavati tattasmin nidadhyāt | </l>
+                        grīvāmeḍhrayon mūtolīṃ vṛtteṅge maṇḍalam aṅguṣṭhāṅgulimeḍhrāgreṣu sthavikā |
+                        yamalavraṇābhyāṃ yamalakaṃ | hanuga<gap n="13" unit="char"/>ṇḍaśaṃkheṣu
+                        khaṭvām apāṅgayoś cīnaṃ | pṛṣṭhodaroraḥsu vibandhaṃ mūrddhni vitāmaṃ |
+                        cipukanāmauṣṭhāṃsabastiṣu goṣphaṇā jatruṇipañcāṅgīm iti | yo vā yasmin
+                        pradeśe suniviṣṭo bhavati tattasmin nidadhyāt | </l>
 
 
                     <l xml:id="SS.1.18.19">
@@ -4397,23 +4258,22 @@
                     <l xml:id="SS.1.18.20">
                         <label>1.18.20</label>
                         <caesura/>
-                         tatra ghanāṅ kāvalikān datvā cāmaparikṣepam ṛjum anāviddham
-                        asaṅkucitaṃ mṛdu paṭṭan niveśya badhnīyāt | na ca vraṇasyopari
-                        kuryāt | granthim ābādhaṅ karoti | </l>
+                         tatra ghanāṅ kāvalikān datvā cāmaparikṣepam ṛjum anāviddham asaṅkucitaṃ
+                        mṛdu paṭṭan niveśya badhnīyāt | na ca vraṇasyopari kuryāt | granthim ābādhaṅ
+                        karoti | </l>
 
                     <l xml:id="SS.1.18.21">
                         <label>1.18.21</label>
                         <caesura/>
-                         athāsya na ca vikeśikauṣadhetisnigdhetirūkṣe viṣame vā kurvvīta |
-                        kasmād atisnehāt kledayati | raukṣyāc chinatti
-                        durnyāstavraṇacarmmāvagharṣaṇaṃ karoti | yukta snehatyādāśu rohati
-                        | </l>
+                         athāsya na ca vikeśikauṣadhetisnigdhetirūkṣe viṣame vā kurvvīta | kasmād
+                        atisnehāt kledayati | raukṣyāc chinatti durnyāstavraṇacarmmāvagharṣaṇaṃ
+                        karoti | yukta snehatyādāśu rohati | </l>
 
                     <l xml:id="SS.1.18.22">
                         <label>1.18.22</label>
                         <caesura/>
-                         tatra vraṇāyatanaviśeṣād bandhas trividho bhavati | gāḍhas samaḥ
-                        śithila iti | </l>
+                         tatra vraṇāyatanaviśeṣād bandhas trividho bhavati | gāḍhas samaḥ śithila
+                        iti | </l>
 
                     <l xml:id="SS.1.18.23"/>
 
@@ -4421,23 +4281,22 @@
                         <label>1.18.24</label>
                         <caesura/>
                          tatra sphikkukṣivaṃkṣaṇaśiraḥ sugāḍhaḥ |
-                        śākhāvadanakarṇṇakaṇṭhameḍhramuṣkapārśvodarorasmu samaḥ | akṣṇoḥ
-                        sandhiṣu ca śithilaḥ | </l>
+                        śākhāvadanakarṇṇakaṇṭhameḍhramuṣkapārśvodarorasmu samaḥ | akṣṇoḥ sandhiṣu ca
+                        śithilaḥ | </l>
 
                     <l xml:id="SS.1.18.25">
                         <label>1.18.25</label>
                         <caesura/>
-                         tatra paittikaṃ gāḍhasthāne samaṃ badhnīyāt | samasthāne śithilaṃ
-                        | śithilasthāne naiva śoṇitaduṣṭañ ca || ślaiṣmikaṃ śithilasthāne
-                        samaṃ | samasthāne gāḍhaṃ | gāḍhasthāne gāḍhataraṃ | vātaduṣṭañ ca
-                        || </l>
+                         tatra paittikaṃ gāḍhasthāne samaṃ badhnīyāt | samasthāne śithilaṃ |
+                        śithilasthāne naiva śoṇitaduṣṭañ ca || ślaiṣmikaṃ śithilasthāne samaṃ |
+                        samasthāne gāḍhaṃ | gāḍhasthāne gāḍhataraṃ | vātaduṣṭañ ca || </l>
 
                     <l xml:id="SS.1.18.26">
                         <label>1.18.26</label>
                         <caesura/>
-                         tatra paittikaṃ grīṣme dvirahne badhnīyāt | raktopadrutam apy
-                        evaṃ | ślaiṣmikaṃ hemante tṛtīye 'hni | vātopadrutam apy evaṃ |
-                        evaṃ mūhya baṃdhamviparyayañ ca kurvvīta | </l>
+                         tatra paittikaṃ grīṣme dvirahne badhnīyāt | raktopadrutam apy evaṃ |
+                        ślaiṣmikaṃ hemante tṛtīye 'hni | vātopadrutam apy evaṃ | evaṃ mūhya
+                        baṃdhamviparyayañ ca kurvvīta | </l>
 
                     <l xml:id="SS.1.18.27">
                         <label>1.18.27</label>
@@ -4445,9 +4304,9 @@
                          samaśithilasthāneṣu gāḍha baṃdhe vikesikauṣadhanair arthakyaṃ
                         śophavedanāprādurbhbhāvaś ca | gāḍhasamasthāneṣu sithila bandhe
                             vikesikauṣadhapa<add place="left margin">la
-                        ñ</add><!-- some marking characters -->tanam pa<add
-                            place="top margin">ṭṭa</add>sañcārād vraṇava<g
-                            type="punctuation" ref="#newa-double-comma"/>gharṣaṇañ ca | </l>
+                        ñ</add><!-- some marking characters -->tanam pa<add place="top margin"
+                            >ṭṭa</add>sañcārād vraṇava<g type="punctuation" ref="#newa-double-comma"
+                        />gharṣaṇañ ca | </l>
 
                     <l xml:id="SS.1.18.28">
                         <label>1.18.28</label>
@@ -4457,10 +4316,10 @@
                     <l xml:id="SS.1.18.29">
                         <label>1.18.29</label>
                         <caesura/>
-                         abadhyamāne śītavātātaparajovarṣadaṃśamasakamakṣikāpra<g
-                            type="punctuation" ref="#newa-double-comma"/>bhṛtibhir
-                        abhighātaviśeṣair hanyate vraṇaḥ | vividhavedanopadrutaś ca
-                        duṣṭatām upaiti | ālepanādīni cāsya viśopam upayānti || </l>
+                         abadhyamāne śītavātātaparajovarṣadaṃśamasakamakṣikāpra<g type="punctuation"
+                            ref="#newa-double-comma"/>bhṛtibhir abhighātaviśeṣair hanyate vraṇaḥ |
+                        vividhavedanopadrutaś ca duṣṭatām upaiti | ālepanādīni cāsya viśopam
+                        upayānti || </l>
 
                     <l xml:id="SS.1.18.30">
                         <label>1.18.30</label>
@@ -4501,8 +4360,8 @@
                         <caesura/>
                          doṣan dehañ ca vijñāya vraṇan ś ca vraṇakovidaḥ |
                         <caesura/>
-                         ṛtūñ ca parisaṃkhyāya<gap n="1" unit="char"/> tato bandhīn
-                        niveśayed iti ||</l>
+                         ṛtūñ ca parisaṃkhyāya<gap n="1" unit="char"/> tato bandhīn niveśayed iti
+                        ||</l>
 
                     <l xml:id="SS.1.18.trailer"> ḍoḍa ||</l>
 
@@ -4532,8 +4391,8 @@
                     <l xml:id="SS.1.19.3">
                         <label>1.19.3</label>
                         <caesura/>
-                         atha vraṇitasya prathamam evāgāram anvicchet ||
-                        praśastavāstusuniviṣṭaṃ śucyavātātapañca |</l>
+                         atha vraṇitasya prathamam evāgāram anvicchet || praśastavāstusuniviṣṭaṃ
+                        śucyavātātapañca |</l>
 
                     <l xml:id="SS.1.19.4">
                         <label>1.19.4</label>
@@ -4545,8 +4404,8 @@
                     <l xml:id="SS.1.19.5">
                         <label>1.19.5</label>
                         <caesura/>
-                         tasmiñ chayanam asambādhaṃ svāstīrṇaaṇaṃ manojñam prākchīrṣan
-                        saśastraṅ kurvvīta |</l>
+                         tasmiñ chayanam asambādhaṃ svāstīrṇaaṇaṃ manojñam prākchīrṣan saśastraṅ
+                        kurvvīta |</l>
 
                     <l xml:id="SS.1.19.6">
                         <label>1.19.6</label>
@@ -4558,8 +4417,7 @@
                     <l xml:id="SS.1.19.7">
                         <label>1.19.7</label>
                         <caesura/>
-                         tasmin suhṛdbhir anukūlaiḥ priyamvadair upāsyamāno
-                        yatheṣṭamāśīteti ||</l>
+                         tasmin suhṛdbhir anukūlaiḥ priyamvadair upāsyamāno yatheṣṭamāśīteti ||</l>
 
                     <l xml:id="SS.1.19.8">
                         <label>1.19.8</label>
@@ -4583,8 +4441,8 @@
                     <l xml:id="SS.1.19.11">
                         <label>1.19.11</label>
                         <caesura/>
-                         utthāsamvesanaparimārjjanādiṣu cātmaceṣṭāsvapramatto vraṇaṃ
-                        rakṣet || bhavanti cātra||</l>
+                         utthāsamvesanaparimārjjanādiṣu cātmaceṣṭāsvapramatto vraṇaṃ rakṣet ||
+                        bhavanti cātra||</l>
 
                     <l xml:id="SS.1.19.12">
                         <label>1.19.12</label>
@@ -4598,8 +4456,8 @@
                     <l xml:id="SS.1.19.14">
                         <label>1.19.14</label>
                         <caesura/>
-                         gamyānāñ ca strīṇāṃ sandarśanasambhāṣaṇasaṃsparśanāni dūrata eva
-                        pariharet || bhavanti cātra||</l>
+                         gamyānāñ ca strīṇāṃ sandarśanasambhāṣaṇasaṃsparśanāni dūrata eva pariharet
+                        || bhavanti cātra||</l>
 
                     <l xml:id="SS.1.19.15">
                         <label>1.19.15</label>
@@ -4655,10 +4513,9 @@
                         <caesura/>
                          sadā ca
                         nīcanakharomṇāśucināśucivāsasāśāntimaṅgaladevatābrāhmaṇagurupareṇabhavitavyaṃ
-                        || tat kasya hetoḥ hiṃsāvihārāṇi tu
-                        rakṣānsipaśupatikuberakumārānucarāṇi mānsaśoṇitapratvāt
-                        kṣatajanimittam vraṇitam upa sarppanti satkārārthañ jighāṃsūni vā
-                        kadācid bhavanti ||</l>
+                        || tat kasya hetoḥ hiṃsāvihārāṇi tu rakṣānsipaśupatikuberakumārānucarāṇi
+                        mānsaśoṇitapratvāt kṣatajanimittam vraṇitam upa sarppanti satkārārthañ
+                        jighāṃsūni vā kadācid bhavanti ||</l>
 
 
                     <l xml:id="SS.1.19.24">
@@ -4671,9 +4528,9 @@
                     <l xml:id="SS.1.19.25">
                         <label>1.19.25</label>
                         <caesura/>
-                         te tu santarppitā ātmavanna hiṃsyus tasmāt satatam
-                        atandritajanaparivṛto nityadīpodakaśastrasragdāmālaṅkṛta veśmani
-                        sampan maṅgalamano 'nukūlāḥ kathāḥ śṛṇvannāsīta ||</l>
+                         te tu santarppitā ātmavanna hiṃsyus tasmāt satatam atandritajanaparivṛto
+                        nityadīpodakaśastrasragdāmālaṅkṛta veśmani sampan maṅgalamano 'nukūlāḥ
+                        kathāḥ śṛṇvannāsīta ||</l>
 
                     <l xml:id="SS.1.19.26">
                         <label>1.19.26</label>
@@ -4685,8 +4542,8 @@
                     <l xml:id="SS.1.19.27">
                         <label>1.19.27</label>
                         <caesura/>
-                         ṛksāmayajurbhir mmantrairaparaiś cāśīrvvādair upādhyāyabhiṣajāś
-                        ca sandhyayo rakṣāṅkuryuḥ ||</l>
+                         ṛksāmayajurbhir mmantrairaparaiś cāśīrvvādair upādhyāyabhiṣajāś ca
+                        sandhyayo rakṣāṅkuryuḥ ||</l>
 
                     <l xml:id="SS.1.19.28">
                         <label>1.19.28</label>
@@ -4743,8 +4600,8 @@
                         <caesura/>
                          vraṇī vaidyavase tiṣṭhac chīghraṃ vraṇam apohati ||</l>
 
-                    <l xml:id="SS.1.19.36">tau ca ruk ca divāsvāpāt tāś ca mṛtyuś ca
-                        maithunāt ||</l>
+                    <l xml:id="SS.1.19.36">tau ca ruk ca divāsvāpāt tāś ca mṛtyuś ca maithunāt
+                        ||</l>
 
                     <l xml:id="SS.1.19.37">
                         <label>1.19.37</label>
@@ -4768,37 +4625,35 @@
                     <l xml:id="SS.1.20.3">
                         <label>1.20.3</label>
                         <caesura/>
-                         yad vāyoḥ pathyan tat pittasyāpathyam ity anena hetunā na kiñcid
-                        dravyam ekāntena hitam ahitam vāstīti kecid ācāryā bruvate || taṃ
-                        tu na samyak | iha khalu dravyāṇi svabhāvataḥ saṃyogataś ca
-                        ekāntahitāni ekāntāhitāni hitāhitāni ca bhavanti ||</l>
+                         yad vāyoḥ pathyan tat pittasyāpathyam ity anena hetunā na kiñcid dravyam
+                        ekāntena hitam ahitam vāstīti kecid ācāryā bruvate || taṃ tu na samyak | iha
+                        khalu dravyāṇi svabhāvataḥ saṃyogataś ca ekāntahitāni ekāntāhitāni
+                        hitāhitāni ca bhavanti ||</l>
 
                     <l xml:id="SS.1.20.4">
                         <label>1.20.4</label>
                         <caesura/>
-                         tatraikāntāhitāni jātisātmyatvāt |
-                        salilaghṛtadugdhvaudanaprabhṛtīni | ekāntāhitāni tu
-                        dahanapacanamāraṇādiṣu pravṛtttāny agnikṣāraviṣādīni saṃyogatas tv
-                        aparāṇi viṣatulyāni bhavanti | hitāhitāni tu yad vāyoḥ pathyan tat
-                        pittasyāpathyam iti</l>
+                         tatraikāntāhitāni jātisātmyatvāt | salilaghṛtadugdhvaudanaprabhṛtīni |
+                        ekāntāhitāni tu dahanapacanamāraṇādiṣu pravṛtttāny agnikṣāraviṣādīni
+                        saṃyogatas tv aparāṇi viṣatulyāni bhavanti | hitāhitāni tu yad vāyoḥ pathyan
+                        tat pittasyāpathyam iti</l>
 
                     <l xml:id="SS.1.20.5">
                         <label>1.20.5</label>
                         <caesura/>
                          etad dvitvān na sarvvavraṇinām ayam āhārārthe vargga upadiśyate |
-                        raktaśāliṣaṣṭikāṅgukamukundakapāṇḍukakalama
-                        nīvārodravoddālakaśyāmākavāḥ ||
+                        raktaśāliṣaṣṭikāṅgukamukundakapāṇḍukakalama nīvārodravoddālakaśyāmākavāḥ ||
                         eṇahariṇakuraṅgāmṛgamātṛkāsvadaṃṣṭrīkrakaralāvatittirikapiñjalavarttīrakavarttakāḥ
                         || mudgavanamasūramukuṣṭhahareṇaavāḍhakīsatīnāḥ ||
-                        cillīvāstūkasuniṣarṇṇakajīvantī taṇḍulīyakamaṇḍūkaparṇṇāḥ | gavyaṃ
-                        ghṛtaṃ saindhavadāḍimāmalakam ity eṣa varggaḥ sarvvavraṇinyaḥ
-                        sāmānyataḥ pathyatamaḥ |</l>
+                        cillīvāstūkasuniṣarṇṇakajīvantī taṇḍulīyakamaṇḍūkaparṇṇāḥ | gavyaṃ ghṛtaṃ
+                        saindhavadāḍimāmalakam ity eṣa varggaḥ sarvvavraṇinyaḥ sāmānyataḥ
+                        pathyatamaḥ |</l>
 
                     <l xml:id="SS.1.20.6">
                         <label>1.20.6</label>
                         <caesura/>
-                         tathā brahmacaryanivātaśayaṇoṣṇodakādivāsvapnāvyāyāmādhūmasevā ca
-                        ekāntaḥ pathyatamāni |</l>
+                         tathā brahmacaryanivātaśayaṇoṣṇodakādivāsvapnāvyāyāmādhūmasevā ca ekāntaḥ
+                        pathyatamāni |</l>
 
                     <l xml:id="SS.1.20.7">
                         <label>1.20.7</label>
@@ -4825,16 +4680,14 @@
                         <label>1.20.14</label>
                         <caesura/>
                          kapotām̐ś ca sarṣapatailasiddhām̐ś ca nāśnīyāt |
-                        kapiñjalamayūralāvatittirigodhāś cairaṇḍakāṣṭhasiddhā
-                        eraṇḍatailana nādyāt |
+                        kapiñjalamayūralāvatittirigodhāś cairaṇḍakāṣṭhasiddhā eraṇḍatailana nādyāt |
                         madhughṛtasamaghṛtamadhucāntarikṣaudakānupānaṃ | kāṃsabhājane
-                        daśarātraparyuṣitaṃ sarppiḥ | madhunoṣṇena vā dadhimadyañ ca |
-                        pittena cāmamāṃsāni | surākṛsarapāyasām̐śca naikadhyamaśnīyāt |
-                        sauvīreṇa sahatilasaṣkulī | takreṇa madhughṛtadhānāpṛṣatamāṃsāni |
-                        godhāmmadhunā | kṣaudrāsavena matsyāṃ | pṛṣatamāṃsam vā
-                        maireyamādhvīkābhyāṃ | matsyānupotakayā sahaikṣuvikṛtīś ca sarvvāḥ
-                        | guḍaṅkākamācyāmadhunā mūlakāni ca | naikadhyamadhunā varāhaṃ |
-                        dadhnā kukkuṭaṃ | madyena balākāṃ |</l>
+                        daśarātraparyuṣitaṃ sarppiḥ | madhunoṣṇena vā dadhimadyañ ca | pittena
+                        cāmamāṃsāni | surākṛsarapāyasām̐śca naikadhyamaśnīyāt | sauvīreṇa
+                        sahatilasaṣkulī | takreṇa madhughṛtadhānāpṛṣatamāṃsāni | godhāmmadhunā |
+                        kṣaudrāsavena matsyāṃ | pṛṣatamāṃsam vā maireyamādhvīkābhyāṃ |
+                        matsyānupotakayā sahaikṣuvikṛtīś ca sarvvāḥ | guḍaṅkākamācyāmadhunā mūlakāni
+                        ca | naikadhyamadhunā varāhaṃ | dadhnā kukkuṭaṃ | madyena balākāṃ |</l>
 
                     <l xml:id="SS.1.20.15"/>
 
@@ -4843,10 +4696,10 @@
                     <l xml:id="SS.1.20.17">
                         <label>1.20.17</label>
                         <caesura/>
-                         taratamayogayuktāṃś ca | bhāvānatirūkṣam atisnigdham atyuṣṇam
-                        atiśītam evamādīn vivarjjayet | na madhunoṣṇaṃ | noṣṇa noṣṇārtto |
-                        na madhunātilakalkenopotakāṃ | na pippalīmatsyavesayā |
-                        priyaṅgvanuliptena pāyasamaśnīyāt || </l>
+                         taratamayogayuktāṃś ca | bhāvānatirūkṣam atisnigdham atyuṣṇam atiśītam
+                        evamādīn vivarjjayet | na madhunoṣṇaṃ | noṣṇa noṣṇārtto | na
+                        madhunātilakalkenopotakāṃ | na pippalīmatsyavesayā | priyaṅgvanuliptena
+                        pāyasamaśnīyāt || </l>
 
                     <l xml:id="SS.1.20.18">
                         <label>1.20.18</label>
@@ -4924,11 +4777,11 @@
                     <l xml:id="SS.1.21.3">
                         <label>1.21.3</label>
                         <caesura/>
-                         vātapittaśleṣmāṇa eva dehe sambhavahetavo bhavanti || tair
-                        evāsyāvyāpanair adhomadhyorddhasanniviṣṭaiḥ śarīram idan dhāryate|
-                        agāram iva sthūṇābhir ataś ca tristhūṇam ity āhur ity eke| ta eva
-                        ca vyāpannāḥ pralayahetavo bhavanti tad ebhiḥ śoṇitacaturtthaiḥ
-                        sambhavasthitipralayeṣv apy avirahitaṃ śarīram bhavati || </l>
+                         vātapittaśleṣmāṇa eva dehe sambhavahetavo bhavanti || tair evāsyāvyāpanair
+                        adhomadhyorddhasanniviṣṭaiḥ śarīram idan dhāryate| agāram iva sthūṇābhir
+                        ataś ca tristhūṇam ity āhur ity eke| ta eva ca vyāpannāḥ pralayahetavo
+                        bhavanti tad ebhiḥ śoṇitacaturtthaiḥ sambhavasthitipralayeṣv apy avirahitaṃ
+                        śarīram bhavati || </l>
 
                     <l xml:id="SS.1.21.4">
                         <label>1.21.4</label>
@@ -4942,24 +4795,22 @@
                     <l xml:id="SS.1.21.5">
                         <label>1.21.5</label>
                         <caesura/>
-                         tatra vā gatigandhopādāno dhātuḥ | tapa santāpe | śliṣa āliṅgane
-                        | eṣāṃ kṛdvihitaiḥ pratyayair vvātaṃ pittaṃ śleṣmā iti rūpāṇi
-                        bhavanti || </l>
+                         tatra vā gatigandhopādāno dhātuḥ | tapa santāpe | śliṣa āliṅgane | eṣāṃ
+                        kṛdvihitaiḥ pratyayair vvātaṃ pittaṃ śleṣmā iti rūpāṇi bhavanti || </l>
 
                     <l xml:id="SS.1.21.6">
                         <label>1.21.6</label>
                         <caesura/>
                          teṣāṃ sthānāny ata ūrddhvam vakṣyāmaḥ || tatra samāsena vāyuḥ
-                        śroṇīgudasaṃśrayaḥ | pakvāmāsayamadhyastham pittasya | āmāsayaḥ
-                        śleṣmaṇaḥ || </l>
+                        śroṇīgudasaṃśrayaḥ | pakvāmāsayamadhyastham pittasya | āmāsayaḥ śleṣmaṇaḥ || </l>
 
                     <l xml:id="SS.1.21.7">
                         <label>1.21.7</label>
                         <caesura/>
-                         ataḥ param pañcadhā vibhajyante | tatra vātasya vātavyādhike
-                        vakṣyāmaḥ | pittasya yakṛtplīhānau hṛdayan dṛṣṭis tvag iti |
-                        pūrvvoktan tu śleṣmaṇas tūrasaḥ kaṇṭhaḥ śiraḥ sandhaya iti ||
-                        etāni khalu doṣasthānāny avyāpannānām bhavanti | pūrvvoktañ ca || </l>
+                         ataḥ param pañcadhā vibhajyante | tatra vātasya vātavyādhike vakṣyāmaḥ |
+                        pittasya yakṛtplīhānau hṛdayan dṛṣṭis tvag iti | pūrvvoktan tu śleṣmaṇas
+                        tūrasaḥ kaṇṭhaḥ śiraḥ sandhaya iti || etāni khalu doṣasthānāny avyāpannānām
+                        bhavanti | pūrvvoktañ ca || </l>
 
                     <l xml:id="SS.1.21.8">
                         <label>1.21.8</label>
@@ -4971,25 +4822,23 @@
                     <l xml:id="SS.1.21.9">
                         <label>1.21.9</label>
                         <caesura/>
-                         tatra jijñāsyate || kim pittavyatirekeṇānyo 'gnirutāho pittam
-                        evāgnir iti | atrocyate | na khalu pittavyatirekeṇānyo 'gnir
-                        upalabhyate | āgneyatvāt pitte dahanapacanādiṣu pravarttamāno
-                        'gnivad upacāraḥ kriyante ntaragnir iti | kṣiṇe vāgniguṇe
-                        tatsamānadravyopayogād ativṛddhe śītakriyopayogād āgamāc ca
-                        paśyāmo na khalu pittavyatirekeṇānyo 'gnir iti | </l>
+                         tatra jijñāsyate || kim pittavyatirekeṇānyo 'gnirutāho pittam evāgnir iti |
+                        atrocyate | na khalu pittavyatirekeṇānyo 'gnir upalabhyate | āgneyatvāt
+                        pitte dahanapacanādiṣu pravarttamāno 'gnivad upacāraḥ kriyante ntaragnir iti
+                        | kṣiṇe vāgniguṇe tatsamānadravyopayogād ativṛddhe śītakriyopayogād āgamāc
+                        ca paśyāmo na khalu pittavyatirekeṇānyo 'gnir iti | </l>
 
                     <l xml:id="SS.1.21.10">
                         <label>1.21.10</label>
                         <caesura/>
-                         tat tu dṛṣṭahetukena viśeṣeṇa pakvāmāsayamadhyasthaṃ caturvvidham
-                        apy annam pacati vivecayati ca doṣarasamūtrapurīṣāṇi | tatrastham
-                        eva cātmaśaktyā śeṣāṇām pittasthānānāṃ śarīrasya
-                        cāgnikarmmaṇānugrahaṅ karoti | tasmin pitte pācako 'gnir iti
-                        saṃjñā || yakṛtplīhnoḥ pittan tasmin rañjako gnir iti saṃjñā sa
-                        rasasya rāgakṛd uktaḥ | yat tu hṛdistham pittan tasmin sādhako
-                        'gnir iti saṃjñā śobhitaprārthitamanorathasādhanakṛd uktaḥ || yat
-                        tu dṛṣṭyām pittaṃ tasminn ālocako 'gnir iti saṃjñā sa rūpagrahaṇe
-                        dhikṛtaḥ || yat tu tvaci pittan tasya bhrājako 'gnir iti saṃjñā so
+                         tat tu dṛṣṭahetukena viśeṣeṇa pakvāmāsayamadhyasthaṃ caturvvidham apy annam
+                        pacati vivecayati ca doṣarasamūtrapurīṣāṇi | tatrastham eva cātmaśaktyā
+                        śeṣāṇām pittasthānānāṃ śarīrasya cāgnikarmmaṇānugrahaṅ karoti | tasmin pitte
+                        pācako 'gnir iti saṃjñā || yakṛtplīhnoḥ pittan tasmin rañjako gnir iti
+                        saṃjñā sa rasasya rāgakṛd uktaḥ | yat tu hṛdistham pittan tasmin sādhako
+                        'gnir iti saṃjñā śobhitaprārthitamanorathasādhanakṛd uktaḥ || yat tu dṛṣṭyām
+                        pittaṃ tasminn ālocako 'gnir iti saṃjñā sa rūpagrahaṇe dhikṛtaḥ || yat tu
+                        tvaci pittan tasya bhrājako 'gnir iti saṃjñā so
                         'bhyaṅgaparisekāvagāhālayanādīnāṃ kriyādravyādīnāṃ pācayitā |||| </l>
 
                     <l xml:id="SS.1.21.11">
@@ -5005,9 +4854,9 @@
                         <label>1.21.12</label>
                         <caesura/>
                          ata ūrdhvaṃ śleṣmasthānāny anuvyākhyāsyāmaḥ || tatrāmāsayaḥ
-                        pittāsayasyopari tatpratyanīkatvād ūrdhvagatitvāt tejasaś candra
-                        ivādityasya sa caturvvidhasyāhārasyādhāraḥ sa ca tatraudakair
-                        guṇaiḥ praklinno bhinnasaṃghātas sukhajaro bhavati || </l>
+                        pittāsayasyopari tatpratyanīkatvād ūrdhvagatitvāt tejasaś candra ivādityasya
+                        sa caturvvidhasyāhārasyādhāraḥ sa ca tatraudakair guṇaiḥ praklinno
+                        bhinnasaṃghātas sukhajaro bhavati || </l>
 
 
 
@@ -5022,13 +4871,12 @@
                         <label>1.21.14</label>
                         <caesura/>
                          sa tatra sthitaḥ svaśaktyā śeṣāṇāṃ śleṣmasthānānāṃ
-                        śarīrasyodakakarmmaṇānugrahaṅ karoti || uraḥsthas tu
-                        trikasandhāraṇam ātmavīryyeṇānnarasasahitena hṛdayāvalambanam
-                        varaṇañ ca karoti | kaṇṭhasthas tu jihvendriyasya saumyatvāt
-                        samyagrasajñāne vivarttate || śiraḥsthas tu
-                        snehasantarppaṇādhikṛtatvād indriyāṇām ātmavīryyeṇānugrahaṃ karoti
-                        || sandhisthas tu sandhisaṃśleṣāt sarvvaṃ sandhisaṃśleṣāt
-                        sarvvasandhyagranuhaṅ karoti || </l>
+                        śarīrasyodakakarmmaṇānugrahaṅ karoti || uraḥsthas tu trikasandhāraṇam
+                        ātmavīryyeṇānnarasasahitena hṛdayāvalambanam varaṇañ ca karoti | kaṇṭhasthas
+                        tu jihvendriyasya saumyatvāt samyagrasajñāne vivarttate || śiraḥsthas tu
+                        snehasantarppaṇādhikṛtatvād indriyāṇām ātmavīryyeṇānugrahaṃ karoti ||
+                        sandhisthas tu sandhisaṃśleṣāt sarvvaṃ sandhisaṃśleṣāt sarvvasandhyagranuhaṅ
+                        karoti || </l>
 
 
 
@@ -5056,10 +4904,10 @@
                     <l xml:id="SS.1.21.18">
                         <label>1.21.18</label>
                         <caesura/>
-                         etāni khalu doṣasthānāny atra sañcīyante doṣāḥ | prāk
-                        sañcayahetur uktaḥ || sañcitānāṃ khalu doṣāṇāṃ
-                        stabdhapūrṇṇakoṣṭhatā pītāvabhāsatā mandoṣmatā cāṅgānāṃ gauravam
-                        ālasyañ ceti liṅgāni bhavanti | tatra prathamaḥ kriyākālaḥ || </l>
+                         etāni khalu doṣasthānāny atra sañcīyante doṣāḥ | prāk sañcayahetur uktaḥ ||
+                        sañcitānāṃ khalu doṣāṇāṃ stabdhapūrṇṇakoṣṭhatā pītāvabhāsatā mandoṣmatā
+                        cāṅgānāṃ gauravam ālasyañ ceti liṅgāni bhavanti | tatra prathamaḥ kriyākālaḥ
+                        || </l>
 
                     <l xml:id="SS.1.21.19">
                         <label>1.21.19</label>
@@ -5123,24 +4971,22 @@
                     <l xml:id="SS.1.21.27">
                         <label>1.21.27</label>
                         <caesura/>
-                         teṣān tu prakopāt
-                        koṣṭhatodasañcaraṇāmlīkādāhapipāsānnadveṣahṛdayotkledā bhavanti |
-                        tatra dvitīyaḥ kriyākālaḥ || </l>
+                         teṣān tu prakopāt koṣṭhatodasañcaraṇāmlīkādāhapipāsānnadveṣahṛdayotkledā
+                        bhavanti | tatra dvitīyaḥ kriyākālaḥ || </l>
 
                     <l xml:id="SS.1.21.28">
                         <label>1.21.28</label>
                         <caesura/>
-                         ata ūrdhvam prasaraṃ vakṣyāmaḥ | teṣām ebhir ātaṅkaviśeṣaiḥ
-                        prakupitānām piṣṭakiṇvodakasamavāya ivābhyudgatānām prasaro
-                        bhavati | teṣām vāyur ggatimattvāt prasaraṇahetuḥ | saty apy
-                        ācaitanye sa hi rajobhūyiṣṭhaḥ | rajaś ca pravarttakam bhāvānām
-                        yathā mahānudakasañcayo 'tipravṛddhatvāt | setum avadāryāparair
-                        udakair vvyāmiśraḥ sarvvataḥ pradhāvaty evan doṣāḥ | ekaikaśo
-                        dvandvaśaḥ samastāḥ śoṇitasahitā vā tatra vātaḥ pittaṃ śleṣmā
-                        śoṇitaṃ | vātapitte | vātaśleṣmāṇau | pittaśleṣmāṇau | vātaśoṇite
-                        | pittaśoṇite | śleṣmaśoṇite | vātapittaśoṇitāni |
-                        vātaśleṣmaśoṇitāni | pittaśleṣmaśoṇitāni | vātapittakaphāḥ |
-                        vātapittakaphaśoṇitānīti | evam pañcadaśadhā prasaranti || </l>
+                         ata ūrdhvam prasaraṃ vakṣyāmaḥ | teṣām ebhir ātaṅkaviśeṣaiḥ prakupitānām
+                        piṣṭakiṇvodakasamavāya ivābhyudgatānām prasaro bhavati | teṣām vāyur
+                        ggatimattvāt prasaraṇahetuḥ | saty apy ācaitanye sa hi rajobhūyiṣṭhaḥ |
+                        rajaś ca pravarttakam bhāvānām yathā mahānudakasañcayo 'tipravṛddhatvāt |
+                        setum avadāryāparair udakair vvyāmiśraḥ sarvvataḥ pradhāvaty evan doṣāḥ |
+                        ekaikaśo dvandvaśaḥ samastāḥ śoṇitasahitā vā tatra vātaḥ pittaṃ śleṣmā
+                        śoṇitaṃ | vātapitte | vātaśleṣmāṇau | pittaśleṣmāṇau | vātaśoṇite |
+                        pittaśoṇite | śleṣmaśoṇite | vātapittaśoṇitāni | vātaśleṣmaśoṇitāni |
+                        pittaśleṣmaśoṇitāni | vātapittakaphāḥ | vātapittakaphaśoṇitānīti | evam
+                        pañcadaśadhā prasaranti || </l>
 
                     <l xml:id="SS.1.21.29">
                         <label>1.21.29</label>
@@ -5152,8 +4998,7 @@
                     <l xml:id="SS.1.21.30">
                         <label>1.21.30</label>
                         <caesura/>
-                         nātyarthaṅ kupitaś cāpi līno mārggeṣu ti<g ref="#newa-gap-filler"
-                        />ṣṭhati |
+                         nātyarthaṅ kupitaś cāpi līno mārggeṣu ti<g ref="#newa-gap-filler"/>ṣṭhati |
                         <caesura/>
                          niḥpratyanīkaḥ kālena hetum āsādya kupyati || </l>
 
@@ -5168,28 +5013,26 @@
                     <l xml:id="SS.1.21.32">
                         <label>1.21.32</label>
                         <caesura/>
-                         evaṃ prakṣubhitānāṃ prasaratāṃ vimārgagamanam āṭopo dhūmāyanam
-                        arocakaś charddir iti liṅgāni bhavanti | tatra tṛtīyaḥ kriyākālaḥ
-                        || </l>
+                         evaṃ prakṣubhitānāṃ prasaratāṃ vimārgagamanam āṭopo dhūmāyanam arocakaś
+                        charddir iti liṅgāni bhavanti | tatra tṛtīyaḥ kriyākālaḥ || </l>
 
                     <l xml:id="SS.1.21.33">
                         <label>1.21.33</label>
                         <caesura/>
-                         ata ūrddhvaṃ sthānasaṃśrayam vakṣyāmaḥ | evaṃ khalu prasṛtās
-                        tāṃs tāñ charīrapradeśān āgamya tāṃs tān vyādhīñ janayanti | taṃ
-                        prati pratirogaṃ vakṣyāmaḥ | te yadodar dhayaḥ sanniveśaṅ kurvanti
-                        te gulmavṛdhyudarāgnisaṅgānāhavisūcikātīsāraprabhṛtīñ janayanti ||
-                        bastigatāḥ pramehāśmarīmūtrāghātamūtradoṣaprabhṛtīn || gudagatās
-                        tu bhagandarārsaprabhṛtīn || meḍhragatās tu
-                        parivarttikāpadaṃśaśūkadoṣaprabhṛtīn || vṛṣaṇagatā vṛṣaṇavṛddhīn
-                        || ūrddhvajatrugatā ūrddhvagā galagaṇḍāpacīprabhṛtīn ||
-                        tvaṅmānsasoṇitagatāḥ kṣudrarogān kuṣṭhādīṃ visarpāṃś ca ||
-                        māṃsagatā granthyapacyarbudagalagaṇḍālajīprabhṛtīn || asthigatā
-                        vidradhyanuśayīprabhṛtīn || pādagatāḥ ślīpadavātasoṇitaprabhṛtīn
-                        || sarvagatāḥ jvaraśukradoṣasarvāṅgarogaprabhṛtīn || evam anyeṣv
-                        api sthāneṣu rogāṇāṃ doṣasanniveśaṃ jānīyāt || teṣām evam
-                        abhisanniviṣṭānām pūrvarūpaprādurbhāvo bhavati | tatra caturthaḥ
-                        kriyākālaḥ || </l>
+                         ata ūrddhvaṃ sthānasaṃśrayam vakṣyāmaḥ | evaṃ khalu prasṛtās tāṃs tāñ
+                        charīrapradeśān āgamya tāṃs tān vyādhīñ janayanti | taṃ prati pratirogaṃ
+                        vakṣyāmaḥ | te yadodar dhayaḥ sanniveśaṅ kurvanti te
+                        gulmavṛdhyudarāgnisaṅgānāhavisūcikātīsāraprabhṛtīñ janayanti || bastigatāḥ
+                        pramehāśmarīmūtrāghātamūtradoṣaprabhṛtīn || gudagatās tu
+                        bhagandarārsaprabhṛtīn || meḍhragatās tu
+                        parivarttikāpadaṃśaśūkadoṣaprabhṛtīn || vṛṣaṇagatā vṛṣaṇavṛddhīn ||
+                        ūrddhvajatrugatā ūrddhvagā galagaṇḍāpacīprabhṛtīn || tvaṅmānsasoṇitagatāḥ
+                        kṣudrarogān kuṣṭhādīṃ visarpāṃś ca || māṃsagatā
+                        granthyapacyarbudagalagaṇḍālajīprabhṛtīn || asthigatā
+                        vidradhyanuśayīprabhṛtīn || pādagatāḥ ślīpadavātasoṇitaprabhṛtīn ||
+                        sarvagatāḥ jvaraśukradoṣasarvāṅgarogaprabhṛtīn || evam anyeṣv api sthāneṣu
+                        rogāṇāṃ doṣasanniveśaṃ jānīyāt || teṣām evam abhisanniviṣṭānām
+                        pūrvarūpaprādurbhāvo bhavati | tatra caturthaḥ kriyākālaḥ || </l>
 
                     <l xml:id="SS.1.21.34">
                         <label>1.21.34</label>
@@ -5201,9 +5044,9 @@
                     <l xml:id="SS.1.21.35">
                         <label>1.21.35</label>
                         <caesura/>
-                         ata ūrddhvam asyāvadīrṇṇasya vraṇabhāvam āpannasya ṣaṣṭhaḥ
-                        kriyākālaḥ || jvarātīsāraprabhṛtīnāñ ca dīrghakālānubandhaḥ |
-                        tatrāpratikriyamāṇo sādhyatām upaiti || </l>
+                         ata ūrddhvam asyāvadīrṇṇasya vraṇabhāvam āpannasya ṣaṣṭhaḥ kriyākālaḥ ||
+                        jvarātīsāraprabhṛtīnāñ ca dīrghakālānubandhaḥ | tatrāpratikriyamāṇo
+                        sādhyatām upaiti || </l>
 
                     <l xml:id="SS.1.21.36">
                         <label>1.21.36</label>
@@ -5260,57 +5103,54 @@
                     <l xml:id="SS.1.22.3">
                         <label>1.22.3</label>
                         <caesura/>
-                         tvaṅmānsasirāsnāyvasthisandhikoṣṭhamarmāṇy aṣṭau vraṇavastūni
-                        bhavanti | atra sarvavraṇasanniveśaḥ || </l>
+                         tvaṅmānsasirāsnāyvasthisandhikoṣṭhamarmāṇy aṣṭau vraṇavastūni bhavanti |
+                        atra sarvavraṇasanniveśaḥ || </l>
 
                     <l xml:id="SS.1.22.4">
                         <label>1.22.4</label>
                         <caesura/>
-                         tatrādyaikavastusanniveśī tvagbhedī vraṇaḥ sūpacaro bhavati |
-                        śeṣās tv āsrāvā vijñeyāḥ | ya evam uttiṣṭhanty avadīvyante ca | </l>
+                         tatrādyaikavastusanniveśī tvagbhedī vraṇaḥ sūpacaro bhavati | śeṣās tv
+                        āsrāvā vijñeyāḥ | ya evam uttiṣṭhanty avadīvyante ca | </l>
 
                     <l xml:id="SS.1.22.5">
                         <label>1.22.5</label>
                         <caesura/>
-                         āyataś caturasro vṛttas tripuṭaka iti vraṇākṛtisamāsaḥ |
-                        viśeṣatas tu vikṛtākṛ𑑛tayo durupakramā bhavanti || </l>
+                         āyataś caturasro vṛttas tripuṭaka iti vraṇākṛtisamāsaḥ | viśeṣatas tu
+                        vikṛtākṛ𑑛tayo durupakramā bhavanti || </l>
 
                     <l xml:id="SS.1.22.6">
                         <label>1.22.6</label>
                         <caesura/>
-                         sarva eva vraṇāḥ kṣipraṃ saṃrohanty ātmavatāṃ subhiṣagbhiś
-                        copakrāntāḥ | anātmavatāṃ majñaiś copakrāntāḥ praduṣyanti
-                        pravṛdvatvād doṣāṇāṃ | </l>
+                         sarva eva vraṇāḥ kṣipraṃ saṃrohanty ātmavatāṃ subhiṣagbhiś copakrāntāḥ |
+                        anātmavatāṃ majñaiś copakrāntāḥ praduṣyanti pravṛdvatvād doṣāṇāṃ | </l>
 
                     <l xml:id="SS.1.22.7">
                         <label>1.22.7</label>
                         <caesura/>
-                         tatrātisamvṛto vivṛtaḥ kaṭhinotimātram atimṛdur utsannovasannaḥ
-                        śītotyuṣṇaḥ kṛṣṇaraktapītaśuklādivarṇṇaiṣv apy arthavarṇṇaḥ
+                         tatrātisamvṛto vivṛtaḥ kaṭhinotimātram atimṛdur utsannovasannaḥ śītotyuṣṇaḥ
+                        kṛṣṇaraktapītaśuklādivarṇṇaiṣv apy arthavarṇṇaḥ
                         pūtimāṃsasirāsnāyupratipūrṇṇaḥ pūtipūyāśrāvī ūnmārgy utsaṅgy
                         amanojñadarśanagandhotyarthavedanāvān
                         dāhapākarāgakaṇḍūśophapiṭakopadrutotyarthaduṣṭaśoṇitasrāvī
-                        dīrghakālānubandhī ceti duṣṭavraṇaliṅgāni || tatra doṣocchrāyam
-                        avekṣya yathāsvaṃ prakurvīta || </l>
+                        dīrghakālānubandhī ceti duṣṭavraṇaliṅgāni || tatra doṣocchrāyam avekṣya
+                        yathāsvaṃ prakurvīta || </l>
 
                     <l xml:id="SS.1.22.8a">
                         <label>1.22.8</label>
                         <caesura/>
-                         atha sarvāsrāvām vakṣyāmaḥ | tatra ghṛṣṭāsu chinnāsu vā tvakṣu
-                        tvaksphuṭite bhinnevadārite vā salilaprakāśo bhavaty āsrāvaḥ
-                        kiñcid visraḥ pītāvabhāsaś ca | māṃsagate tu sarpiḥ prakāśaḥ
-                        sāndraḥ svetaḥ picchilaś ca | sirāgatas tu sadyaś chinnāsu sirāsu
-                        raktātipravṛttiḥ pakvāsu ca toyanāḍībhir ivāgamanaṃ pūyasya
-                        āśrāvaś cātra tanur vicchinnaḥ sapheno vasāpratimaḥ saraktaś ca |
-                        snāyugatas tu snigdho ghanaḥ siṃghaṇakapratimaḥ saraktaś ca |
-                        asthigatas tu asthiny abhihate sphuṭite bhinne 'vadārite vā
-                        doṣabhakṣitatvāc chuktidhautam ivābhāti asthiniḥsāraś ca bhavati |
-                        āsrāvaś cātra tanur vicchinno majjāmiśraḥ sarudhirasnigdhaś ca
-                        sandhigatas tu pīḍyamāno na pravarttate |
-                        tathākuñcanaprasāraṇonnāmanavināmanoskāsanapradhāvanaiḥ sravati |
-                        āsrāvaś cātra tanur vicchinnaḥ picchilovalambī sarudhironmathitaś
-                        ca bhavati | koṣṭhagatas tu mūtrapurīṣapūyarudhirodakāni sravati |
-                        marmagatas tu nocyate tvagādiṣv evāvaruddhatvāt || </l>
+                         atha sarvāsrāvām vakṣyāmaḥ | tatra ghṛṣṭāsu chinnāsu vā tvakṣu tvaksphuṭite
+                        bhinnevadārite vā salilaprakāśo bhavaty āsrāvaḥ kiñcid visraḥ pītāvabhāsaś
+                        ca | māṃsagate tu sarpiḥ prakāśaḥ sāndraḥ svetaḥ picchilaś ca | sirāgatas tu
+                        sadyaś chinnāsu sirāsu raktātipravṛttiḥ pakvāsu ca toyanāḍībhir ivāgamanaṃ
+                        pūyasya āśrāvaś cātra tanur vicchinnaḥ sapheno vasāpratimaḥ saraktaś ca |
+                        snāyugatas tu snigdho ghanaḥ siṃghaṇakapratimaḥ saraktaś ca | asthigatas tu
+                        asthiny abhihate sphuṭite bhinne 'vadārite vā doṣabhakṣitatvāc chuktidhautam
+                        ivābhāti asthiniḥsāraś ca bhavati | āsrāvaś cātra tanur vicchinno
+                        majjāmiśraḥ sarudhirasnigdhaś ca sandhigatas tu pīḍyamāno na pravarttate |
+                        tathākuñcanaprasāraṇonnāmanavināmanoskāsanapradhāvanaiḥ sravati | āsrāvaś
+                        cātra tanur vicchinnaḥ picchilovalambī sarudhironmathitaś ca bhavati |
+                        koṣṭhagatas tu mūtrapurīṣapūyarudhirodakāni sravati | marmagatas tu nocyate
+                        tvagādiṣv evāvaruddhatvāt || </l>
 
                     <l xml:id="SS.1.22.8b"/>
                     <l xml:id="SS.1.22.9"/>
@@ -5321,24 +5161,22 @@
                         <caesura/>
                          atha sarvavraṇavedanām vakṣyāmaḥ ||
                         todanabhedanacchedanatāḍanāvamanthanāyāmanavikṣepaṇacumucumāyananirddarśanāvabhañjanasphoṭanavidāraṇotpāṭanakampanavividhaśūlaviśleṣaṇavikiraṇapūraṇastambhanaśvapanākuñcanāṅkuśikāḥ
-                        sambhavanti | vividhā vā yatra muhurmuhur vedanā āgacchanti tam
-                        vātikam iti vidyāt | ūṣācoṣaparidāhadhūmāyanāni
-                        yatrāṅgārāvakīrṇṇam iva vedanā sarujaṃ tīkṣṇasampātipacyate yatra
-                        coṣmābhir vṛddhir bhavati kṣate kṣārāvasiktavac ca yatra
-                        vedanāviśeṣāḥ ghotāta m paittikam iti viṃdyāt | pittavad
+                        sambhavanti | vividhā vā yatra muhurmuhur vedanā āgacchanti tam vātikam iti
+                        vidyāt | ūṣācoṣaparidāhadhūmāyanāni yatrāṅgārāvakīrṇṇam iva vedanā sarujaṃ
+                        tīkṣṇasampātipacyate yatra coṣmābhir vṛddhir bhavati kṣate kṣārāvasiktavac
+                        ca yatra vedanāviśeṣāḥ ghotāta m paittikam iti viṃdyāt | pittavad
                         raktasamutthañ jānīyāt | viśeṣo raktado raktasrāvaś ca bhavati |
-                        kaṇḍūrgurutvaṃ suptatā svedolpavedanatvaṃ stambhaḥ śaityañ ca
-                        yatra taṃ ślaiṣmikam iti vidyāt | yatra sarvavedanāsamutpattis taṃ
-                        sānnipātikam iti vidyāt || </l>
+                        kaṇḍūrgurutvaṃ suptatā svedolpavedanatvaṃ stambhaḥ śaityañ ca yatra taṃ
+                        ślaiṣmikam iti vidyāt | yatra sarvavedanāsamutpattis taṃ sānnipātikam iti
+                        vidyāt || </l>
 
                     <l xml:id="SS.1.22.12">
                         <label>1.22.12</label>
                         <caesura/>
                          ata ūrddhvaṃ sarvavarṇṇām vakṣyāmaḥ | bhasmakaposthivarṇṇaḥ
-                        paruṣoruṇavarṇṇaḥ kṛṣṇa iti mārutajasya | nīlaḥ śyāvo haritaḥ
-                        pītaḥ kṛṣṇo raktaḥ piṅgala iti pittaraktasamutthayoḥ |
-                        śvetasnigdhaḥ pāṇḍur iti śleṣmajasya | sarvavarṇṇopetaḥ
-                        sānnipātika || </l>
+                        paruṣoruṇavarṇṇaḥ kṛṣṇa iti mārutajasya | nīlaḥ śyāvo haritaḥ pītaḥ kṛṣṇo
+                        raktaḥ piṅgala iti pittaraktasamutthayoḥ | śvetasnigdhaḥ pāṇḍur iti
+                        śleṣmajasya | sarvavarṇṇopetaḥ sānnipātika || </l>
 
                     <l xml:id="SS.1.22.13">
                         <label>1.22.13</label>
@@ -5367,22 +5205,20 @@
                     <l xml:id="SS.1.23.3">
                         <label>1.23.3</label>
                         <caesura/>
-                         tatra vayasthānāṃ dṛḍhānāṃ prāṇavatāṃ satvavatām ātmavatāñ ca
-                        sucikitsyā vraṇā bhavanti || ekaikasmin vā puruṣe yatraitad
-                        guṇapañcakaṃ bhavati tasya khalu sādhanīyatamāḥ tatra vayasthānāṃ
-                        pratyagradhātutvād āśu vraṇasaṃroho bhavati | dṛḍhānāṃ
-                        sthirabahumāṃsatvāc chastram avacāryamāṇaṃ sirāsnāyvādīn viśeṣān
-                        na prāpnoti prāṇavatām vedanābhighātāhārayantraṇādibhir nna glānir
-                        bbhavati | satvavatān dāruṇair api kriyāviśeṣair nna vyathā
-                        bhavati | ātmavatām punar mmitāhāravihārādibhir upadeśair
-                        nnānyathā matiḥ pravarttate | sarvvañ caiṣāṃ sādhur bbhavati |
-                        tasmād eṣāṃ sukhasādhanīyatamāḥ || </l>
+                         tatra vayasthānāṃ dṛḍhānāṃ prāṇavatāṃ satvavatām ātmavatāñ ca sucikitsyā
+                        vraṇā bhavanti || ekaikasmin vā puruṣe yatraitad guṇapañcakaṃ bhavati tasya
+                        khalu sādhanīyatamāḥ tatra vayasthānāṃ pratyagradhātutvād āśu vraṇasaṃroho
+                        bhavati | dṛḍhānāṃ sthirabahumāṃsatvāc chastram avacāryamāṇaṃ sirāsnāyvādīn
+                        viśeṣān na prāpnoti prāṇavatām vedanābhighātāhārayantraṇādibhir nna glānir
+                        bbhavati | satvavatān dāruṇair api kriyāviśeṣair nna vyathā bhavati |
+                        ātmavatām punar mmitāhāravihārādibhir upadeśair nnānyathā matiḥ pravarttate
+                        | sarvvañ caiṣāṃ sādhur bbhavati | tasmād eṣāṃ sukhasādhanīyatamāḥ || </l>
 
                     <l xml:id="SS.1.23.4">
                         <label>1.23.4</label>
                         <caesura/>
-                         ta eva viparītaguṇāḥ | vṛddhakṛṣālpaprāṇabhīruṣv anātmavatsu ca
-                        draṣṭavyāḥ || </l>
+                         ta eva viparītaguṇāḥ | vṛddhakṛṣālpaprāṇabhīruṣv anātmavatsu ca draṣṭavyāḥ
+                        || </l>
 
                     <l xml:id="SS.1.23.5">
                         <label>1.23.5</label>
@@ -5395,8 +5231,8 @@
                         <caesura/>
                          akṣidantanāsāapāṅgaśrotranābhijaṭharasevanīnitambapārśvakukṣistanakakṣasandhibhāgagatāḥ
                         saphenapūyānilaraktavāhinontaḥśalyāś ca duścikitsyāḥ ||
-                        romāntopanakhamanmajaṅghāsthisaṃśritāś ca bhagandaram api
-                        cāntarmmukhaṃ sevanīkakcupasthasaṃśritam iti || </l>
+                        romāntopanakhamanmajaṅghāsthisaṃśritāś ca bhagandaram api cāntarmmukhaṃ
+                        sevanīkakcupasthasaṃśritam iti || </l>
 
                     <l xml:id="SS.1.23.7">
                         <label>1.23.7</label>
@@ -5409,8 +5245,8 @@
                         <label>1.23.8</label>
                         <caesura/>
                          avapāṭikāniruddhaprakāsasanniruddhagudajaṭharagranthikṣatakrimayaḥ
-                        pratiśyāyajāḥ koṣṭhajāś ca tvagdoṣiṇām pramehiṇām vā ye
-                        pratikṣateṣu dṛśyante śarkkarā sikatāmehī vātakuṇḍālikāṣṭhīlā
+                        pratiśyāyajāḥ koṣṭhajāś ca tvagdoṣiṇām pramehiṇām vā ye pratikṣateṣu
+                        dṛśyante śarkkarā sikatāmehī vātakuṇḍālikāṣṭhīlā
                         dantaśarkkaropakuśakaṇṭhakāśālūkaniṣkoṣaṇadūṣitā dantaveṣṭā
                         visarppāsthikṣatoraḥkṣatayaś ca yāpyāḥ || </l>
 
@@ -5440,15 +5276,14 @@
                     <l xml:id="SS.1.23.11.1">
                         <label>1.23.11.1</label>
                         <caesura/>
-                        <seg sameAs="SS.1.23.10cd">kriyāyān tu nivṛttāyāṃ sadya eva
-                            vinaśyati</seg> |<anchor n="SS.1.23.11.1-n1"/>
+                        <seg sameAs="SS.1.23.10cd">kriyāyān tu nivṛttāyāṃ sadya eva vinaśyati</seg>
+                            |<anchor n="SS.1.23.11.1-n1"/>
                         <caesura/>
                          viṣkambhapatanād yadvad gṛhasya patanaṃ dhruvaṃ ||</l>
 
                     <ab corresp="#SS.1.23.11.1" type="apparatus">
                         <list type="notes">
-                            <item corresp="#SS.1.23.11.1-n1">This repeats
-                                1.23.10cd.</item>
+                            <item corresp="#SS.1.23.11.1-n1">This repeats 1.23.10cd.</item>
                         </list>
                     </ab>
 
@@ -5456,18 +5291,16 @@
                         <label>1.23.12</label>
                         <caesura/>
                          ata ūrddhvam asādhyān padekṣyāmaḥ || māṃsapiṇḍavad udgatāḥ
-                        prasekinontaḥpūyā vedanāvantaḥ | aśvāpānavad udvṛttauṣṭhāḥ kecit
-                        kaṭhinā gośṛṅgavad udgatāḥ | mṛdumāṃsaprarohāḥ | apare
-                        duṣṭarudhirāśrāviṇaḥ | tantupicchilāsrāviṇo vā madhyonnatāḥ |
-                        kecid avasannaśuṣiraparyantāḥ | śaṇatūlavat snāyujālavanto
-                        durddarśanāḥ | vasāmedomajjāmastuluṅgāśrāviṇaś ca | doṣasamutthā
-                        pītāsitamūtrapurīṣavātavāhinaś ca koṣṭhaprāptāḥ | ta evobhayato
-                        bhāgaṃ vraṇamukheṣu pūyaraktanirvvāhiṇaḥ kṣīṇamāṃsānāñ ca sarvvato
-                        gatayas tv aṇumukhān māṃsabudbudavantaḥ saśabdavātavāhinaś ca
+                        prasekinontaḥpūyā vedanāvantaḥ | aśvāpānavad udvṛttauṣṭhāḥ kecit kaṭhinā
+                        gośṛṅgavad udgatāḥ | mṛdumāṃsaprarohāḥ | apare duṣṭarudhirāśrāviṇaḥ |
+                        tantupicchilāsrāviṇo vā madhyonnatāḥ | kecid avasannaśuṣiraparyantāḥ |
+                        śaṇatūlavat snāyujālavanto durddarśanāḥ | vasāmedomajjāmastuluṅgāśrāviṇaś ca
+                        | doṣasamutthā pītāsitamūtrapurīṣavātavāhinaś ca koṣṭhaprāptāḥ | ta
+                        evobhayato bhāgaṃ vraṇamukheṣu pūyaraktanirvvāhiṇaḥ kṣīṇamāṃsānāñ ca
+                        sarvvato gatayas tv aṇumukhān māṃsabudbudavantaḥ saśabdavātavāhinaś ca
                         śiraḥkaṇṭhasthāḥ | kṣīṇamāṃsānāñ ca pūyarudhiranirvvāpinaḥ |
                         arocakāvipākakāsaśvāsopadravayuktāḥ | bhinne ca śiraḥkapāla yatra
-                        mastuluṅgadarśanan tridoṣaliṅgaprādurbhāvaḥ | kāsaśvāsau vā
-                        yasyeti || </l>
+                        mastuluṅgadarśanan tridoṣaliṅgaprādurbhāvaḥ | kāsaśvāsau vā yasyeti || </l>
 
                     <l xml:id="SS.1.23.13">
                         <label>1.23.13</label>
@@ -5542,8 +5375,7 @@
 
                     <head xml:lang="en">[Adhyāya 24]</head>
 
-                    <note xml:lang="en">[collation based on N (1.24.1–7) and K
-                        (1.24.7–12).]</note>
+                    <note xml:lang="en">[collation based on N (1.24.1–7) and K (1.24.7–12).]</note>
 
                     <l xml:id="SS.1.24.1">
                         <label>1938 ed. 1.24.1</label>
@@ -5563,53 +5395,48 @@
                         <label>1938 ed. 1.24.4</label>
                         <caesura/>
                          asmiṃs tu śāstre sarvatra sāmānyāt sarveṣāṃ vyādhīnāṃ
-                        yathāsthaulyenāvarodhaḥ kriyate | prāgabhihitaṃ tadduḥkhasaṃyogād
-                        vyādhir iti || tac ca duḥkhaṃ trividhaṃ | ādhyātmikam
-                        ādhibhautikam ādhidaivikam iti | tac ca duḥkhaṃ saptavidhe vyādhāv
-                        upanipatati | saptavidhās tu vyādhayaḥ | tad yathā
-                        ādibalapravṛttāḥ | janmabalapravṛttāḥ | doṣabalapravṛttāḥ |
-                        saṃghātabalapravṛttāḥ | daivabalapravṛttāḥ | svabhāvabalapravṛttāḥ
-                        | iti || </l>
+                        yathāsthaulyenāvarodhaḥ kriyate | prāgabhihitaṃ tadduḥkhasaṃyogād vyādhir
+                        iti || tac ca duḥkhaṃ trividhaṃ | ādhyātmikam ādhibhautikam ādhidaivikam iti
+                        | tac ca duḥkhaṃ saptavidhe vyādhāv upanipatati | saptavidhās tu vyādhayaḥ |
+                        tad yathā ādibalapravṛttāḥ | janmabalapravṛttāḥ | doṣabalapravṛttāḥ |
+                        saṃghātabalapravṛttāḥ | daivabalapravṛttāḥ | svabhāvabalapravṛttāḥ | iti || </l>
 
                     <l xml:id="SS.1.24.5">
                         <label>1938 ed. 1.24.5</label>
                         <caesura/>
-                         tatrādibalapravṛttā nāma śukraśoṇitadoṣānvayāḥ |
-                        kuṣṭhārśaḥprabhṛtayaḥ | te 'pi dvivividhā mātṛjāpitṛjāś ca ||
-                        janmabalapravṛttā nāma ye mātur apacārāt
-                        paṅgujaḍajātyandhamūkabadhiraminminavāmanaprabhṛtayo jāyante te
-                        dvividhā rasakṛtā dauhṛdāpacārakṛtāś ca || doṣabalapravṛttā nāma
-                        ya ātaṅkāpacārakṛtās te dvividhāḥ | śārīrā mānasāś ca || </l>
+                         tatrādibalapravṛttā nāma śukraśoṇitadoṣānvayāḥ | kuṣṭhārśaḥprabhṛtayaḥ | te
+                        'pi dvivividhā mātṛjāpitṛjāś ca || janmabalapravṛttā nāma ye mātur apacārāt
+                        paṅgujaḍajātyandhamūkabadhiraminminavāmanaprabhṛtayo jāyante te dvividhā
+                        rasakṛtā dauhṛdāpacārakṛtāś ca || doṣabalapravṛttā nāma ya ātaṅkāpacārakṛtās
+                        te dvividhāḥ | śārīrā mānasāś ca || </l>
 
                     <l xml:id="SS.1.24.7a">
                         <label>1938 ed. 1.24.7a</label>
                         <caesura/>
-                         kālabalapravṛttā nāma ye śītoṣṇavātavarṣāprabhṛtibhiḥ samutpannās
-                        te 'pi dvividhā vyāpannā avyāpannāś ca ||<anchor n="SS.1.24.7a-n1"
-                        /></l>
+                         kālabalapravṛttā nāma ye śītoṣṇavātavarṣāprabhṛtibhiḥ samutpannās te 'pi
+                        dvividhā vyāpannā avyāpannāś ca ||<anchor n="SS.1.24.7a-n1"/></l>
 
                     <ab corresp="#SS.1.24.7a" type="apparatus">
                         <list type="notes">
-                            <item corresp="#SS.1.24.7a-n1">In the 1931 vulgate edition,
-                                this passage comes after 1.24.6, before
-                                    <foreign>daivabalapravṛttā …</foreign>.</item>
+                            <item corresp="#SS.1.24.7a-n1">In the 1931 vulgate edition, this passage
+                                comes after 1.24.6, before <foreign>daivabalapravṛttā
+                                …</foreign>.</item>
                         </list>
                     </ab>
 
                     <l xml:id="SS.1.24.6">
                         <label>1938 ed. 1.24.6</label>
                         <caesura/>
-                         saṃghātabalapravṛttā nāma ya āgantava ādhibhautikās te dvividhāḥ
-                        | durbalasya balavadvigrahāc chastrādikṛtāś ca |</l>
+                         saṃghātabalapravṛttā nāma ya āgantava ādhibhautikās te dvividhāḥ |
+                        durbalasya balavadvigrahāc chastrādikṛtāś ca |</l>
 
                     <l xml:id="SS.1.24.7">
                         <label>1938 ed. 1.24.7</label>
                         <caesura/>
-                         daivabalapravṛttā nāma ya aupasargikā dvividhā
-                        abhicārābhiśāpābhiṣaṅgajāḥ || svabhāvabalapravṛttā nāma
-                        kṣutpipāsājarāmṛtyunidrāprabhṛtaya iti | te 'pi dvividhā rakṣakṛtā
-                        arakṣakṛtāḥ | rakṣakṛtaḥ kālakṛtaḥ | arakṣakṛto 'kālakṛtaḥ || atra
-                        sarvatra vyādhyuparodhaḥ | </l>
+                         daivabalapravṛttā nāma ya aupasargikā dvividhā abhicārābhiśāpābhiṣaṅgajāḥ
+                        || svabhāvabalapravṛttā nāma kṣutpipāsājarāmṛtyunidrāprabhṛtaya iti | te 'pi
+                        dvividhā rakṣakṛtā arakṣakṛtāḥ | rakṣakṛtaḥ kālakṛtaḥ | arakṣakṛto
+                        'kālakṛtaḥ || atra sarvatra vyādhyuparodhaḥ | </l>
 
                     <l xml:id="SS.1.24.8">
                         <label>1938 ed. 1.24.8</label>
@@ -5617,31 +5444,28 @@
                          sarveṣāṃ ca vyādhīnām vātapittaśleṣmāṇa eva mūlaṃ | talliṅgatvād
                         dṛṣṭaphalatvād āgamāc ca paśyāmaḥ | yathā hi kṛtsnaṃ vikārajātaṃ
                         vaiśvarūpyeṇa vyavasthitaṃ | satva<pc> </pc>rajas<pc> </pc>tamāṃsy
-                        avyatiricya varttante | evam eva kṛtsnaṃ vikārajātaṃ
-                        vaiśvarūpyeṇāvasthitaṃ | avyatiricya vātapittaśleṣmāṇo varttante |
-                        doṣadhātumalasaṃsargād āyatanaviśeṣān nimittataś caiṣāṃ vikalpo
-                        bhavati | doṣadūṣiteṣv atyarthañ ca dhātuṣu saṃjñā bhavati ||
-                        rasajo 'yaṃ raktajo 'yaṃ māṃsajo 'yaṃ medojo 'yaṃ asthijo 'yaṃ
-                        majjajo 'yaṃ śukrajo 'yaṃ vyādhir iti || </l>
+                        avyatiricya varttante | evam eva kṛtsnaṃ vikārajātaṃ vaiśvarūpyeṇāvasthitaṃ
+                        | avyatiricya vātapittaśleṣmāṇo varttante | doṣadhātumalasaṃsargād
+                        āyatanaviśeṣān nimittataś caiṣāṃ vikalpo bhavati | doṣadūṣiteṣv atyarthañ ca
+                        dhātuṣu saṃjñā bhavati || rasajo 'yaṃ raktajo 'yaṃ māṃsajo 'yaṃ medojo 'yaṃ
+                        asthijo 'yaṃ majjajo 'yaṃ śukrajo 'yaṃ vyādhir iti || </l>
 
                     <l xml:id="SS.1.24.9">
                         <label>1938 ed. 1.24.9</label>
                         <caesura/>
                          aśraddhārocakapipāsāṅgamardajvarahṛllāsātṛptigauravapāṇḍurogasrotorodhakārśyavairasyāṅgasādāḥ
-                        | akālapalitatimiradarśanarasadoṣajā vikārāḥ ||
-                        kuṣṭhavisarpapiṭakās
+                        | akālapalitatimiradarśanarasadoṣajā vikārāḥ || kuṣṭhavisarpapiṭakās
                         tilakālakanacchavyaṅgamasakanīlikākoṭhaplīhagulmavidradhyarśo
-                        'rbudāsṛgdararaktapittaprabhṛtayo raktadoṣāt ||
-                        gudamukhameḍhrapākāś
+                        'rbudāsṛgdararaktapittaprabhṛtayo raktadoṣāt || gudamukhameḍhrapākāś
                         cādhimāṃśārbbudārsopajihvopakuśagalaśuṇḍikāmāṃśasaṃghātoṣṭhaprakopagalagaṇḍagaṇḍamālāprabhṛtayo
                         māṃsadoṣāt ||
                         granthivṛddhigalagaṇḍārbbudoṣṭhaprakopamadhumehātisthaulyaprabhṛtayo
                         medodoṣāt || adhyasthidantāsthitodaśūlādayo 'sthidoṣāt ||
-                        tamodarśamūrcchābhramapārśvagauravahṛcchūlasthūlamūlorujambheti
-                        majjadoṣāt || klaibyam apraharṣaś ca śukradoṣāt || tvagdoṣaḥ saṅgo
-                        'tipravṛrttir vā malānāṃ malāyatanadoṣāt || indriyāṇāṃ ayathā
-                        pravṛttir apravṛttir vā indriyāyatanadoṣād ity eṣa samāso vistaraṃ
-                        nimittāni caiṣām pratirogam vakṣyāmaḥ || </l>
+                        tamodarśamūrcchābhramapārśvagauravahṛcchūlasthūlamūlorujambheti majjadoṣāt
+                        || klaibyam apraharṣaś ca śukradoṣāt || tvagdoṣaḥ saṅgo 'tipravṛrttir vā
+                        malānāṃ malāyatanadoṣāt || indriyāṇāṃ ayathā pravṛttir apravṛttir vā
+                        indriyāyatanadoṣād ity eṣa samāso vistaraṃ nimittāni caiṣām pratirogam
+                        vakṣyāmaḥ || </l>
 
                     <l xml:id="SS.1.24.10">
                         <label>1938 ed. 1.24.10</label>
@@ -5650,13 +5474,13 @@
                         <caesura/>
                          kupitānāṃ hi doṣāṇāṃ śarīre paridhāvatāṃ |
                         <caesura/>
-                         yatra saṅgaḥ savaiguṇyād<anchor n="SS.1.24.10-n1"/> vyādhis
-                        tatropajāyate || </l>
+                         yatra saṅgaḥ savaiguṇyād<anchor n="SS.1.24.10-n1"/> vyādhis tatropajāyate
+                        || </l>
 
                     <ab corresp="#SS.1.24.10" type="apparatus">
                         <list type="notes">
-                            <item corresp="#SS.1.24.10-n1">Ḍalhaṇa pointed out that others
-                                read <foreign>svavaiguṇyād</foreign> (instead of
+                            <item corresp="#SS.1.24.10-n1">Ḍalhaṇa pointed out that others read
+                                    <foreign>svavaiguṇyād</foreign> (instead of
                                     <foreign>khavaiguṇyād</foreign>).</item>
                         </list>
                     </ab>
@@ -5664,17 +5488,16 @@
                     <l xml:id="SS.1.24.11">
                         <label>1938 ed. 1.24.11</label>
                         <caesura/>
-                         bhūyo 'tra jijñāsate | kim vātapittaśleṣmāṇāṃ jvarātisārādīnāṃ ca
-                        nityaṃ saṃsleṣaḥ paricchedo veti | yadi nityaṃ saṃśleṣaḥ syān
-                        nityāturā eva sarvaprāṇinaḥ syuḥ | athāpi anyathābhāvo vātādīnāṃ
-                        jvarādīnāṃ cānyatra varttamānasyānyasya liṅgaṃ na bhavatīti |
-                        kṛtvā vātādayo jvarādīṇāṃ mūlānīti tan na || atrocyate || doṣān
-                        pratyākhyāya jvarādayo na bhavanti | atha ca nityaṃ sambandhaḥ |
-                        yathā hi vidyudvātāsanivarṣaṇyākāśaṃ pratyākhyāya na bhavanti |
-                        satyapyākāse kadācic ca na bhavanti | atha ca nimittato bhavanti |
-                        taraṅgabudbudādayaś codakaviśeṣāḥ | evam vātādīnāṃ jvarādīnāñ ca
-                        na nityasaṃśleṣo na vicchedaḥ śāśvatikaḥ | atha ca nimittataḥ |
-                        tebhya evotpattir iti || </l>
+                         bhūyo 'tra jijñāsate | kim vātapittaśleṣmāṇāṃ jvarātisārādīnāṃ ca nityaṃ
+                        saṃsleṣaḥ paricchedo veti | yadi nityaṃ saṃśleṣaḥ syān nityāturā eva
+                        sarvaprāṇinaḥ syuḥ | athāpi anyathābhāvo vātādīnāṃ jvarādīnāṃ cānyatra
+                        varttamānasyānyasya liṅgaṃ na bhavatīti | kṛtvā vātādayo jvarādīṇāṃ mūlānīti
+                        tan na || atrocyate || doṣān pratyākhyāya jvarādayo na bhavanti | atha ca
+                        nityaṃ sambandhaḥ | yathā hi vidyudvātāsanivarṣaṇyākāśaṃ pratyākhyāya na
+                        bhavanti | satyapyākāse kadācic ca na bhavanti | atha ca nimittato bhavanti
+                        | taraṅgabudbudādayaś codakaviśeṣāḥ | evam vātādīnāṃ jvarādīnāñ ca na
+                        nityasaṃśleṣo na vicchedaḥ śāśvatikaḥ | atha ca nimittataḥ | tebhya
+                        evotpattir iti || </l>
 
 
 
@@ -5705,13 +5528,13 @@
                         <caesura/>
                         <anchor n="SS.1.25.3-4-n1"/>chedyās tu
                         bhagandarārśorbudaduṣṭavraṇanāḍīcarmakīlatilakālakamedogranthiśleṣmanimittāś
-                        cāmas tathā māṃsasirāsnāyukothamāṃsakandīmāṃsāsthigatam api ca
-                        śalyam uttavaḥ śataponako jatumaṇir valmīkamadhūṣodhimāṃsaḥ
+                        cāmas tathā māṃsasirāsnāyukothamāṃsakandīmāṃsāsthigatam api ca śalyam
+                        uttavaḥ śataponako jatumaṇir valmīkamadhūṣodhimāṃsaḥ
                         māṃsasaṃghātagalaśuṇḍikā ity evam ādayo vikārāḥ || </l>
                     <ab corresp="#SS.1.25.3-4" type="apparatus">
                         <list type="notes">
-                            <item corresp="#SS.1.25.3-4-n1">Prose from here to 12ab. These
-                                passages are in verse in the vulgate.</item>
+                            <item corresp="#SS.1.25.3-4-n1">Prose from here to 12ab. These passages
+                                are in verse in the vulgate.</item>
                         </list>
                     </ab>
 
@@ -5724,18 +5547,17 @@
                     <l xml:id="SS.1.25.5-8">
                         <label>1.25.5-8</label>
                         <caesura/>
-                         bhedyās tu sarvajamṛte vidradhyanuśayī pramehapiṭakā granthayaś
-                        ca visarpāś cāditas trayas trayo vṛddhayaś ca vidārikāvamanthau
-                        puṣkarikānāḍyastanarogāś ca sahopadaṃśaiḥ śophāś cāsarvasarāḥ
-                        prāyaśaḥ kṣudrarogās tathā tālupuppuṭatuṇḍikerīgilāyuprabhṛtayo
-                        ntaḥ pūyaśalyāḥ pañca medaḥ samutthā aśmarīhetor bastiś ca || </l>
+                         bhedyās tu sarvajamṛte vidradhyanuśayī pramehapiṭakā granthayaś ca visarpāś
+                        cāditas trayas trayo vṛddhayaś ca vidārikāvamanthau puṣkarikānāḍyastanarogāś
+                        ca sahopadaṃśaiḥ śophāś cāsarvasarāḥ prāyaśaḥ kṣudrarogās tathā
+                        tālupuppuṭatuṇḍikerīgilāyuprabhṛtayo ntaḥ pūyaśalyāḥ pañca medaḥ samutthā
+                        aśmarīhetor bastiś ca || </l>
 
                     <l xml:id="SS.1.25.9">
                         <label>1938 ed. 1.25.9</label>
                         <caesura/>
-                         lekhyāś catasro rohiṇyaḥ vraṇanetravarmādyadhijihvopajihve
-                        māṃsocchrayaḥ kilā<cb n="1"/>so dantavaidarbhaḥ pañca medojāś ca
-                        ||</l>
+                         lekhyāś catasro rohiṇyaḥ vraṇanetravarmādyadhijihvopajihve māṃsocchrayaḥ
+                            kilā<cb n="1"/>so dantavaidarbhaḥ pañca medojāś ca ||</l>
 
                     <l xml:id="SS.1.25.10ab"/>
 
@@ -5747,9 +5569,8 @@
                     <l xml:id="SS.1.25.11-12ab">
                         <label>1938 ed. 1.25.11-12ab</label>
                         <caesura/>
-                         eṣyās tu gatimanto vraṇā nāḍyaḥ śalyāni ca | āharttavyās tu
-                        dantāntaḥ śarkarāśmarīmūḍhagarbhakarṇṇamalaśalyāni pādaśarkarā ca
-                        || </l>
+                         eṣyās tu gatimanto vraṇā nāḍyaḥ śalyāni ca | āharttavyās tu dantāntaḥ
+                        śarkarāśmarīmūḍhagarbhakarṇṇamalaśalyāni pādaśarkarā ca || </l>
 
                     <l xml:id="SS.1.25.12cd">
                         <label>1938 ed. 1.25.12cd</label>
@@ -5830,19 +5651,18 @@
                         <caesura/>
                          śirolalāṭākṣikṛṭakarṇṇeṣv anāsāgaṇḍakṛkāṭikā |
                         <caesura/>
-                         bāhūdarasphikṣāyuprajananamuṣkādiṣu pradeseṣv acaleṣu māṃsavatsu
-                        ca śīvyet | janukurparajaṃghādiṣu pracaleṣv alpamāṃseṣu na sīvyet
-                        | vāyunirvāhino ntalohitaśalyāḥ saviṣāṃś ca tatra vās īvyaṃ vraṇam
-                        abhisamīkṣya celāsthipāṃsutṛṇaromaśuṣkaraktādīny apohotkṛtyākṛṣya
-                        yathāsthānaṃ sthāyayitvā snāyusūtravālānāṃ manyatamena sīvyet |
-                        saṇāśmantakamūrvātaśīnāṃ vā valkalaiḥ | sūcyas tu tisra
-                        upadiśyante | dvyaṅgulā tryaṅgulā dhanuvakreti | tatra māṃsaleṣv
-                        avakāśeṣu tryasrāḥ satvāsthisv alpamāṃseṣu ca dvyaṅgulā vṛttā yat
-                        kāmāsamayor marmasu ca dhanuvat cakrārdhaṃ tṛtīyāṃguleti || phuṇi
-                        kātūnasevanyāveṃllitakaṃ rajagranthibandhaṃ ceti | samāsena
-                        sevanavikalpāḥ | teṣān nāmabhir evākṛtayaḥ prāyeṇa vyākhyātāḥ
-                        teṣāṃ prahāram āsādyopayogāṃ budhyāvekṣya na cātisannikṛṣṭāṃ
-                        viprakṛṣṭām alpagrāhiṇīm atibahu grāhiṇīm vā sūcīm pātayet ||
+                         bāhūdarasphikṣāyuprajananamuṣkādiṣu pradeseṣv acaleṣu māṃsavatsu ca śīvyet
+                        | janukurparajaṃghādiṣu pracaleṣv alpamāṃseṣu na sīvyet | vāyunirvāhino
+                        ntalohitaśalyāḥ saviṣāṃś ca tatra vās īvyaṃ vraṇam abhisamīkṣya
+                        celāsthipāṃsutṛṇaromaśuṣkaraktādīny apohotkṛtyākṛṣya yathāsthānaṃ
+                        sthāyayitvā snāyusūtravālānāṃ manyatamena sīvyet | saṇāśmantakamūrvātaśīnāṃ
+                        vā valkalaiḥ | sūcyas tu tisra upadiśyante | dvyaṅgulā tryaṅgulā
+                        dhanuvakreti | tatra māṃsaleṣv avakāśeṣu tryasrāḥ satvāsthisv alpamāṃseṣu ca
+                        dvyaṅgulā vṛttā yat kāmāsamayor marmasu ca dhanuvat cakrārdhaṃ tṛtīyāṃguleti
+                        || phuṇi kātūnasevanyāveṃllitakaṃ rajagranthibandhaṃ ceti | samāsena
+                        sevanavikalpāḥ | teṣān nāmabhir evākṛtayaḥ prāyeṇa vyākhyātāḥ teṣāṃ prahāram
+                        āsādyopayogāṃ budhyāvekṣya na cātisannikṛṣṭāṃ viprakṛṣṭām alpagrāhiṇīm
+                        atibahu grāhiṇīm vā sūcīm pātayet ||
                         <caesura/>
                          bhavati cātra ||
                         <caesura/>
@@ -5851,14 +5671,14 @@
                          alpagrahāt tadvad eva vraṇe kuryād atas tyajet ||
                         <caesura/>
                          samyak sīvitam avekṣya madhughṛtayutair añja<lb n="3"
-                        />namadhukalodhrapriyaṅguśallakīphalarasāñjanakṣaumamasīcūrṇṇaiḥ
-                        pratisārya bandhenopacaret ||<anchor n="SS.1.25.17-28-n1"/>
+                        />namadhukalodhrapriyaṅguśallakīphalarasāñjanakṣaumamasīcūrṇṇaiḥ pratisārya
+                        bandhenopacaret ||<anchor n="SS.1.25.17-28-n1"/>
                     </l>
 
                     <ab corresp="#SS.1.25.17-28" type="apparatus">
                         <list type="notes">
-                            <item corresp="#SS.1.25.17-28-n1">This passage replaces
-                                vulgate 17-28..</item>
+                            <item corresp="#SS.1.25.17-28-n1">This passage replaces vulgate
+                                17-28..</item>
                         </list>
                     </ab>
 
@@ -5939,9 +5759,8 @@
                     <l xml:id="SS.1.25.35">
                         <label>1938 ed. 1.25.35</label>
                         <caesura/>
-                         māṃsodakābhaṃ rudhiraṃ ca gacchet sarvendriyārthoparamas tathaiva
-                        | daśārdhasaṃkhyeṣv atha vikṣateṣu sāmānyato marmasu liṅgam uktam
-                        || </l>
+                         māṃsodakābhaṃ rudhiraṃ ca gacchet sarvendriyārthoparamas tathaiva |
+                        daśārdhasaṃkhyeṣv atha vikṣateṣu sāmānyato marmasu liṅgam uktam || </l>
 
                     <l xml:id="SS.1.25.36">
                         <label>1938 ed. 1.25.36</label>
@@ -6058,8 +5877,7 @@
                     <l xml:id="SS.1.26.3">
                         <label>1938 ed. 1.26.3</label>
                         <caesura/>
-                         atha śalyahiṃsāyān dhātus tasya yat pratyayasya śalyam iti rūpam
-                        bhavati | </l>
+                         atha śalyahiṃsāyān dhātus tasya yat pratyayasya śalyam iti rūpam bhavati | </l>
 
                     <l xml:id="SS.1.26.4">
                         <label>1938 ed. 1.26.4</label>
@@ -6069,15 +5887,13 @@
                     <l xml:id="SS.1.26.5">
                         <label>1938 ed. 1.26.5</label>
                         <caesura/>
-                         sarvaśarīrābādhakaraṃ śalyaṃ tadihopadiśyata ity ataḥ
-                        śalyaśāstram || </l>
+                         sarvaśarīrābādhakaraṃ śalyaṃ tadihopadiśyata ity ataḥ śalyaśāstram || </l>
 
                     <l xml:id="SS.1.26.6">
                         <label>1938 ed. 1.26.6</label>
                         <caesura/>
-                         tatra śārīrāṇi dantanakharomādīni | dhātavo na malā doṣāś ca
-                        duṣṭāḥ āgantūni śarīraśalyavyatirekeṇa yāvanto bhāvāḥ duḥkham
-                        utpādayanti || </l>
+                         tatra śārīrāṇi dantanakharomādīni | dhātavo na malā doṣāś ca duṣṭāḥ
+                        āgantūni śarīraśalyavyatirekeṇa yāvanto bhāvāḥ duḥkham utpādayanti || </l>
 
                     <l xml:id="SS.1.26.6.1"> bhavati cātra ||
                         <caesura/>
@@ -6092,55 +5908,49 @@
                     <l xml:id="SS.1.26.9-10">
                         <label>1938 ed. 1.26.9</label>
                         <caesura/>
-                         tāni vegakṣayāt pratighātād vā tvagādiṣu vraṇavastuṣv
-                        avatiṣṭhante dhamanīsroto 'sthivivarapeśīprabhṛtiṣu vā
-                        śarīrapradeśeṣu ||
-                        <label>1938 ed. 1.26.10</label>
+                         tāni vegakṣayāt pratighātād vā tvagādiṣu vraṇavastuṣv avatiṣṭhante
+                        dhamanīsroto 'sthivivarapeśīprabhṛtiṣu vā śarīrapradeśeṣu || <label>1938 ed.
+                            1.26.10</label>
                         <caesura/>
-                         tatra śalyalakṣaṇam ucyamānam upadhāraya | tat tu dvividhaṃ
-                        sāmānyaṃ vaiśeṣikaṃ ca | śyāvaṃ piḍakācitaṃ śophavedanāvantaṃ
-                        muhurmuhuḥ śoṇitāsrāviṇaṃ budbudavad unnataṃ mṛdumāṃsaṃ ca vraṇaṃ
-                        jānīyāt saśalyo 'yam iti | sāmānyam etal lakṣaṇam uktam |
-                        vaiśeṣikaṃ tu tvaggate vivarṇaḥ śopho bhavaty āyataḥ kaṭhinaś ca
-                        māṃsagate śophābhivṛddhiḥ śalyamārgānupasaṃrohaḥ pīḍanāsahiṣṇutā
-                        coṣapākau ca peśyantarasthe 'py etad eva coṣaśophavarjaṃ sirāgate
-                        sirādhmānam sirāśūlaṃ sirāśophaś ca snāyugate snāyujālotkṣepaṇaṃ
-                        saṃrambhaś cogrā ruk ca srotogate srotasāṃ svakarmaguṇahāniḥ;
-                        dhamanīsthe saphenaṃ raktam īrayann anilaḥ saśabdo nirgacchaty
-                        aṅgamardaḥ pipāsā hṛllāsaś ca asthigate vividhavedanāprādurbhāvaḥ
-                        śophaś ca asthivivaragate 'sthipūrṇatā'sthitodaḥ saṃharṣo balavāṃś
-                        ca sandhigate 'sthivacceṣṭoparamaś ca koṣṭhagata āṭopānāhau
-                        mūtrapurīṣāhāradarśanaṃ ca vraṇamukhāt marmagate marmaviddhāvac
-                        ceṣṭate | sūkṣmagatiṣu śalyeṣv etāny eva lakṣaṇāny aspaṣṭāni
+                         tatra śalyalakṣaṇam ucyamānam upadhāraya | tat tu dvividhaṃ sāmānyaṃ
+                        vaiśeṣikaṃ ca | śyāvaṃ piḍakācitaṃ śophavedanāvantaṃ muhurmuhuḥ
+                        śoṇitāsrāviṇaṃ budbudavad unnataṃ mṛdumāṃsaṃ ca vraṇaṃ jānīyāt saśalyo 'yam
+                        iti | sāmānyam etal lakṣaṇam uktam | vaiśeṣikaṃ tu tvaggate vivarṇaḥ śopho
+                        bhavaty āyataḥ kaṭhinaś ca māṃsagate śophābhivṛddhiḥ śalyamārgānupasaṃrohaḥ
+                        pīḍanāsahiṣṇutā coṣapākau ca peśyantarasthe 'py etad eva coṣaśophavarjaṃ
+                        sirāgate sirādhmānam sirāśūlaṃ sirāśophaś ca snāyugate snāyujālotkṣepaṇaṃ
+                        saṃrambhaś cogrā ruk ca srotogate srotasāṃ svakarmaguṇahāniḥ; dhamanīsthe
+                        saphenaṃ raktam īrayann anilaḥ saśabdo nirgacchaty aṅgamardaḥ pipāsā
+                        hṛllāsaś ca asthigate vividhavedanāprādurbhāvaḥ śophaś ca asthivivaragate
+                        'sthipūrṇatā'sthitodaḥ saṃharṣo balavāṃś ca sandhigate 'sthivacceṣṭoparamaś
+                        ca koṣṭhagata āṭopānāhau mūtrapurīṣāhāradarśanaṃ ca vraṇamukhāt marmagate
+                        marmaviddhāvac ceṣṭate | sūkṣmagatiṣu śalyeṣv etāny eva lakṣaṇāny aspaṣṭāni
                         bhavanti || </l>
 
                     <l xml:id="SS.1.26.11">
                         <label>1938 ed. 1.26.11</label>
                         <caesura/>
-                         mahānty alpāni vā śuddhadehānām anulomasanniviṣṭāni rohanti
-                        viśeṣataḥ kaṇṭhasrotaḥsirātvakpeśyasthivivareṣu
-                        doṣaprakopavyāyāmābhighātājīrṇebhyaḥ pracalitāni punarbādhante || </l>
+                         mahānty alpāni vā śuddhadehānām anulomasanniviṣṭāni rohanti viśeṣataḥ
+                        kaṇṭhasrotaḥsirātvakpeśyasthivivareṣu doṣaprakopavyāyāmābhighātājīrṇebhyaḥ
+                        pracalitāni punarbādhante || </l>
 
                     <l xml:id="SS.1.26.12">
                         <label>1938 ed. 1.26.12</label>
                         <caesura/>
-                         tatra tvakpranaṣṭe snigdhasvinnāyāṃ
-                        mṛnmāṣayavagodhūmagomayamṛditāyāṃ tvaci yatra saṃrambho vedanā vā
-                        bhavati tatra śalyaṃ vijānīyāt styānaghṛtamṛccandanakalkair vā
-                        pradigdhāyāṃ śalyoṣmaṇā+āśu visarati ghṛtam upaśuṣyati vā lepo
-                        yatra tatra śalyaṃ vijānīyāt māṃsapranaṣṭe snehasvedādibhiḥ
-                        kriyāviśeṣair aviruddair āturam upapādayet karśitasya tu
-                        śithilībhūtam anavabaddhaṃ kṣubhyamāṇaṃ yatra saṃrambhaṃ vedanāṃ
-                        vā janayati tatra śalyaṃ vijānīyāt koṣṭhāsthisandhipeśīvivareṣv
-                        avasthitam evam eva parīkṣeta sirādhamanīsrotaḥsnāyupranaṣṭe
-                        khaṇḍacakrasaṃyukte yāne vyādhitam āropyāśu viṣame 'dhvani yāyād
-                        yatra saṃrambho vedanā vā bhavati tatra śalyaṃ jānīyāt
-                        asthipranaṣṭe snehasvedopapannānyasthīni bandhanapīḍanābhyāṃ
-                        bhṛśam upācared yatra saṃrambho vedanā vā bhavati tatra śalyaṃ
-                        jānīyāt sandhipranaṣṭe snehasvedopapannān sandhīn
-                        prasaraṇākuñcanabandhanapīḍanair bhṛśam upācaret yatra saṃrambho
-                        vedanā vā bhavati tatra śalyaṃ vijānīyāt marmapranaṣṭe tv
-                        ananyabhāvān marmaṇām uktaṃ parīkṣaṇaṃ bhavati || </l>
+                         tatra tvakpranaṣṭe snigdhasvinnāyāṃ mṛnmāṣayavagodhūmagomayamṛditāyāṃ tvaci
+                        yatra saṃrambho vedanā vā bhavati tatra śalyaṃ vijānīyāt
+                        styānaghṛtamṛccandanakalkair vā pradigdhāyāṃ śalyoṣmaṇā+āśu visarati ghṛtam
+                        upaśuṣyati vā lepo yatra tatra śalyaṃ vijānīyāt māṃsapranaṣṭe
+                        snehasvedādibhiḥ kriyāviśeṣair aviruddair āturam upapādayet karśitasya tu
+                        śithilībhūtam anavabaddhaṃ kṣubhyamāṇaṃ yatra saṃrambhaṃ vedanāṃ vā janayati
+                        tatra śalyaṃ vijānīyāt koṣṭhāsthisandhipeśīvivareṣv avasthitam evam eva
+                        parīkṣeta sirādhamanīsrotaḥsnāyupranaṣṭe khaṇḍacakrasaṃyukte yāne vyādhitam
+                        āropyāśu viṣame 'dhvani yāyād yatra saṃrambho vedanā vā bhavati tatra śalyaṃ
+                        jānīyāt asthipranaṣṭe snehasvedopapannānyasthīni bandhanapīḍanābhyāṃ bhṛśam
+                        upācared yatra saṃrambho vedanā vā bhavati tatra śalyaṃ jānīyāt
+                        sandhipranaṣṭe snehasvedopapannān sandhīn prasaraṇākuñcanabandhanapīḍanair
+                        bhṛśam upācaret yatra saṃrambho vedanā vā bhavati tatra śalyaṃ vijānīyāt
+                        marmapranaṣṭe tv ananyabhāvān marmaṇām uktaṃ parīkṣaṇaṃ bhavati || </l>
 
                     <l xml:id="SS.1.26.13">
                         <label>1938 ed. 1.26.13</label>
@@ -6148,8 +5958,8 @@
                          sāmānyalakṣaṇam api ca
                         hastiskandhāśvapṛṣṭhaparvatadrumārohaṇadhanurvyāyāmadrutayānaniyuddhādhvagamanalaṅghanaprataraṇaplavanavyāyāmair
                         jṛmbhodgārakāsakṣavathuṣṭhīvanahasanaprāṇāyāmair
-                        vātamūtrapurīṣaśukrotsargair vā yatra saṃrambho vedanā vā bhavati
-                        tatra śalyaṃ jānīyāt || </l>
+                        vātamūtrapurīṣaśukrotsargair vā yatra saṃrambho vedanā vā bhavati tatra
+                        śalyaṃ jānīyāt || </l>
 
 
 
@@ -6242,47 +6052,45 @@
                     <l xml:id="SS.1.27.4">
                         <label>1938 ed. 1.27.4</label>
                         <caesura/>
-                         tatra samāsenānavabaddhaśalyoddharaṇārthaṃ pañcadaśa hetūn
-                        vakṣyāmaḥ | tad yathā svabhāvaḥ pācanaṃ bhedanaṃ dāraṇaṃ pīḍanaṃ
-                        pramārjanaṃ nirdhmāpanaṃ vamanaṃ virecanaṃ prakṣālanaṃ pratimarśaḥ
-                        pravāhaṇaṃ ācūṣaṇaṃ ayaskānto harṣaś ceti || </l>
+                         tatra samāsenānavabaddhaśalyoddharaṇārthaṃ pañcadaśa hetūn vakṣyāmaḥ | tad
+                        yathā svabhāvaḥ pācanaṃ bhedanaṃ dāraṇaṃ pīḍanaṃ pramārjanaṃ nirdhmāpanaṃ
+                        vamanaṃ virecanaṃ prakṣālanaṃ pratimarśaḥ pravāhaṇaṃ ācūṣaṇaṃ ayaskānto
+                        harṣaś ceti || </l>
 
                     <l xml:id="SS.1.27.5">
                         <label>1938 ed. 1.27.5</label>
                         <caesura/>
                          tatrāśrukṣavathūdgārakāsamūtrapurīṣānilaiḥ svabhāvabalapravṛttair
                         nayanādibhyaḥ patati māṃsāvagāḍhaṃ śalyamavidahyamānaṃ pācayitvā
-                        prakothā(ā.pā)ttasya pūyaśoṇitavegād gauravād vā patati |
-                        pakvamabhidyamānaṃ bhedayed dārayed vā | bhinnamanirasyamānaṃ
-                        pīḍanīyaiḥ pīḍayet pāṇibhir vā | aṇūny akṣaśalyāni
-                        pariṣecanādhmāpanair bālavastrapāṇibhiḥ pramārjayet |
-                        āhāraśeṣaśleṣmahīnāṇuśalyāni śvasanotkāsanapradhamanair nirdhamet
-                        | annaśalyāni vamanāṅgulipratimarśaprabhṛtibhiḥ | virecanaiḥ
-                        pakvāśayagatāni | vraṇadoṣāśayagatāni prakṣālanaiḥ |
-                        vātamūtrapurīṣagarbhasaṅgeṣu pravāhaṇamuktaṃ |
-                        mārutodakasaviṣarudhiraduṣṭastanyeṣv ācūṣaṇam āsyena viṣāṇair vā |
-                        anulomam anavabaddham akarṇam analpavraṇamukham ayaskāntena | hṛdy
-                        avasthitam anekakāraṇotpannaṃ śokaśalyaṃ harṣeṇeti || </l>
+                        prakothā(ā.pā)ttasya pūyaśoṇitavegād gauravād vā patati | pakvamabhidyamānaṃ
+                        bhedayed dārayed vā | bhinnamanirasyamānaṃ pīḍanīyaiḥ pīḍayet pāṇibhir vā |
+                        aṇūny akṣaśalyāni pariṣecanādhmāpanair bālavastrapāṇibhiḥ pramārjayet |
+                        āhāraśeṣaśleṣmahīnāṇuśalyāni śvasanotkāsanapradhamanair nirdhamet |
+                        annaśalyāni vamanāṅgulipratimarśaprabhṛtibhiḥ | virecanaiḥ pakvāśayagatāni |
+                        vraṇadoṣāśayagatāni prakṣālanaiḥ | vātamūtrapurīṣagarbhasaṅgeṣu
+                        pravāhaṇamuktaṃ | mārutodakasaviṣarudhiraduṣṭastanyeṣv ācūṣaṇam āsyena
+                        viṣāṇair vā | anulomam anavabaddham akarṇam analpavraṇamukham ayaskāntena |
+                        hṛdy avasthitam anekakāraṇotpannaṃ śokaśalyaṃ harṣeṇeti || </l>
 
                     <l xml:id="SS.1.27.6">
                         <label>1938 ed. 1.27.6</label>
                         <caesura/>
-                         sarvaśalyānāṃ tu mahatām aṇūnāṃ vā dvāv evāharaṇahetū bhavataḥ
-                        pratilomo 'nulomaś ca || </l>
+                         sarvaśalyānāṃ tu mahatām aṇūnāṃ vā dvāv evāharaṇahetū bhavataḥ pratilomo
+                        'nulomaś ca || </l>
 
                     <l xml:id="SS.1.27.7-8">
                         <label>1938 ed. 1.27.7</label>
                         <caesura/>
-                         tatra pratilomamarvācīnamānayet anulomaṃ parācīnam ||
-                        <label>1938 ed. 1.27.8</label>
+                         tatra pratilomamarvācīnamānayet anulomaṃ parācīnam || <label>1938 ed.
+                            1.27.8</label>
                         <caesura/>
                          uttuṇḍitaṃ chitvā nirghātayecchedanīyamukham || </l>
 
                     <l xml:id="SS.1.27.9">
                         <label>1938 ed. 1.27.9</label>
                         <caesura/>
-                         chedanīyamukhānyapi kukṣivakṣaḥkakṣāvaṃkṣaṇaparśukāntarapatitāni
-                        ca hastaśakyaṃ yathāmārgeṇa hastenaivāpahartuṃ prayateta || </l>
+                         chedanīyamukhānyapi kukṣivakṣaḥkakṣāvaṃkṣaṇaparśukāntarapatitāni ca
+                        hastaśakyaṃ yathāmārgeṇa hastenaivāpahartuṃ prayateta || </l>
 
                     <l xml:id="SS.1.27.10">
                         <label>1938 ed. 1.27.10</label>
@@ -6303,9 +6111,9 @@
                         <caesura/>
                          tataḥ śalyam uddhṛtya nirlohitaṃ vraṇaṃ kṛtvā svedārham
                         agnighṛtaprabhṛtibhiḥ saṃsvedya vidahya pradihya sarpirmadhubhyāṃ
-                        baddhvā+ācārikam upadiśet | (? sirāsnāyuvilagnaṃ śalākādibhir
-                        vimocyāpanayet śvayathugrastavāraṅgaṃ samavapīḍya śvayathuṃ
-                        durbalavāraṅgaṃ kuśādibhir baddhvā |) </l>
+                        baddhvā+ācārikam upadiśet | (? sirāsnāyuvilagnaṃ śalākādibhir vimocyāpanayet
+                        śvayathugrastavāraṅgaṃ samavapīḍya śvayathuṃ durbalavāraṅgaṃ kuśādibhir
+                        baddhvā |) </l>
 
                     <l xml:id="SS.1.27.13">
                         <label>1938 ed. 1.27.13</label>
@@ -6316,60 +6124,57 @@
                     <l xml:id="SS.1.27.14">
                         <label>1938 ed. 1.27.14</label>
                         <caesura/>
-                         asthivivarapraviṣṭam asthividaṣṭaṃ vā'vagṛhya pādābhyāṃ
-                        yantreṇāpaharet aśakyamevaṃ vā balavadbhiḥ suparigṛhītasya
-                        yantreṇa grāhayitvā śalyavāraṅgaṃ pravibhujya dhanurguṇair
-                        baddhaikataś cāsya pañcāṅgyām upasaṃyatasyāśvasya vaktrakavike
-                        badhnīyāt athainaṃ kaśayā tāḍayed yathonnamayan śiro vegena śalyam
-                        uddharati dṛḍhāṃ vā vṛkṣaśākhām avanamya tasyāṃ pūrvavad
+                         asthivivarapraviṣṭam asthividaṣṭaṃ vā'vagṛhya pādābhyāṃ yantreṇāpaharet
+                        aśakyamevaṃ vā balavadbhiḥ suparigṛhītasya yantreṇa grāhayitvā śalyavāraṅgaṃ
+                        pravibhujya dhanurguṇair baddhaikataś cāsya pañcāṅgyām upasaṃyatasyāśvasya
+                        vaktrakavike badhnīyāt athainaṃ kaśayā tāḍayed yathonnamayan śiro vegena
+                        śalyam uddharati dṛḍhāṃ vā vṛkṣaśākhām avanamya tasyāṃ pūrvavad
                         baddhvoddharet || </l>
 
                     <l xml:id="SS.1.27.15">
                         <label>1938 ed. 1.27.15</label>
                         <caesura/>
-                         adeśottuṇḍitamaṣṭhīlāśmamudgarāṇāmnyatamasya prahāreṇa vicālya
-                        yathāmārgam eva yantreṇa || </l>
+                         adeśottuṇḍitamaṣṭhīlāśmamudgarāṇāmnyatamasya prahāreṇa vicālya yathāmārgam
+                        eva yantreṇa || </l>
 
                     <l xml:id="SS.1.27.16">
                         <label>1938 ed. 1.27.16</label>
                         <caesura/>
-                         (? yantreṇa ) vimṛditakarṇāni
-                        karṇavantyanābādhakaradeśottuṇḍitāni purastādeva || </l>
+                         (? yantreṇa ) vimṛditakarṇāni karṇavantyanābādhakaradeśottuṇḍitāni
+                        purastādeva || </l>
 
                     <l xml:id="SS.1.27.17">
                         <label>1938 ed. 1.27.17</label>
                         <caesura/>
-                         jātuṣe kaṇṭhāsakte kaṇṭhe nāḍīṃ praveśyāgnitaptāṃ ca śalākāṃ tayā
-                        'vagṛhya śītābhir adbhiḥ pariṣicya sthirībhūtām uddharet || </l>
+                         jātuṣe kaṇṭhāsakte kaṇṭhe nāḍīṃ praveśyāgnitaptāṃ ca śalākāṃ tayā 'vagṛhya
+                        śītābhir adbhiḥ pariṣicya sthirībhūtām uddharet || </l>
 
                     <l xml:id="SS.1.27.18-21">
                         <label>1938 ed. 1.27.18</label>
                         <caesura/>
                          ajātuṣaṃ jatumadhūcchiṣṭapraliptayā śalākayā pūrvakalpenetyeke ||
-                        <label>1938 ed. 1.27.19</label>
+                            <label>1938 ed. 1.27.19</label>
                         <caesura/>
                          asthiśalyamanyadvā tiryakkaṇṭhāsaktamavekṣya keśoṇḍukaṃ
-                        dṛḍhaikasūtrabaddhaṃ dravabhaktopahitaṃ pāyayed ākaṇṭhāt
-                        pūrṇakoṣṭhaṃ ca vāmayet vamataś ca śalyaikadeśasaktaṃ jñātvā
-                        sūtraṃ sahasā tvākṣipet mṛdunā vā dantadhāvanakūrcakenāpaharet
-                        praṇudedvā'ntaḥ | kṣatakaṇṭhāya ca madhusarpiṣī leḍhuṃ
-                        prayacchettriphalācūrṇaṃ vā madhuśarkarāvimiśram ||
-                        <label>1938 ed. 1.27.20</label>
+                        dṛḍhaikasūtrabaddhaṃ dravabhaktopahitaṃ pāyayed ākaṇṭhāt pūrṇakoṣṭhaṃ ca
+                        vāmayet vamataś ca śalyaikadeśasaktaṃ jñātvā sūtraṃ sahasā tvākṣipet mṛdunā
+                        vā dantadhāvanakūrcakenāpaharet praṇudedvā'ntaḥ | kṣatakaṇṭhāya ca
+                        madhusarpiṣī leḍhuṃ prayacchettriphalācūrṇaṃ vā madhuśarkarāvimiśram ||
+                            <label>1938 ed. 1.27.20</label>
                         <caesura/>
-                         udakapūrṇodaramavākśirasamavapīḍayed dhunīyādvāmayed vā
-                        bhasmarāśau vā nikhanedāmukhāt ||
-                        <label>1938 ed. 1.27.21</label>
+                         udakapūrṇodaramavākśirasamavapīḍayed dhunīyādvāmayed vā bhasmarāśau vā
+                        nikhanedāmukhāt || <label>1938 ed. 1.27.21</label>
                         <caesura/>
-                         grāsaśalye tu kaṇṭhāsakte niḥśaṅkamanavabuddhaṃ skandhe
-                        muṣṭinā'bhihanyāt snehaṃ madyaṃ pānīyaṃ vā pāyayet || </l>
+                         grāsaśalye tu kaṇṭhāsakte niḥśaṅkamanavabuddhaṃ skandhe muṣṭinā'bhihanyāt
+                        snehaṃ madyaṃ pānīyaṃ vā pāyayet || </l>
 
                     <l xml:id="SS.1.27.22">
                         <label>1938 ed. 1.27.22</label>
                         <caesura/>
-                         bāhurajjulatāpāśaiḥ kaṇṭhapīḍanādvāyuḥ prakupitaḥ śleṣmāṇaṃ
-                        kopayitvā sroto niruṇaddhi lālāsrāvaṃ phenāgamanaṃ saṃjñānāśaṃ
-                        cāpādayati tamabhyajya saṃsvedya śirovirecanaṃ tasmai tīkṣṇaṃ
-                        dadyādrasaṃ ca vātaghnaṃ vidadhyād iti || </l>
+                         bāhurajjulatāpāśaiḥ kaṇṭhapīḍanādvāyuḥ prakupitaḥ śleṣmāṇaṃ kopayitvā sroto
+                        niruṇaddhi lālāsrāvaṃ phenāgamanaṃ saṃjñānāśaṃ cāpādayati tamabhyajya
+                        saṃsvedya śirovirecanaṃ tasmai tīkṣṇaṃ dadyādrasaṃ ca vātaghnaṃ vidadhyād
+                        iti || </l>
 
                     <l xml:id="SS.1.27.23">
                         <label>1938 ed. 1.27.23</label>
@@ -6403,8 +6208,8 @@
                         <caesura/>
                          vaikalyaṃ maraṇaṃ cā'pi tasmād yatnād vinirharet || </l>
 
-                    <l xml:id="SS.1.27.trailer">iti suśrutasaṃhitāyāṃ sūtrasthāne
-                        śalyāpanayanīyo nāma saptaviṃśatitamo 'dhyāyaḥ || </l>
+                    <l xml:id="SS.1.27.trailer">iti suśrutasaṃhitāyāṃ sūtrasthāne śalyāpanayanīyo
+                        nāma saptaviṃśatitamo 'dhyāyaḥ || </l>
                 </div>
 
 
@@ -6561,8 +6366,7 @@
                     <l xml:id="SS.1.29.1">
                         <label>1938 ed. 1.29.1</label>
                         <caesura/>
-                         athāto viparītāviparītasvapnanidarśanīyam adhyāyaṃ vyākhyāsyāmaḥ
-                        || </l>
+                         athāto viparītāviparītasvapnanidarśanīyam adhyāyaṃ vyākhyāsyāmaḥ || </l>
 
 
 
@@ -6984,8 +6788,7 @@
                         <caesura/>
                          yasya vaṃśo nalo vā'pi tālo vorasi jāyate || </l>
 
-                    <l xml:id="SS.1.29.60.1"> mastakādyaś ca tālo vā ucchritā vīṇuvīrudhaḥ
-                        || </l>
+                    <l xml:id="SS.1.29.60.1"> mastakādyaś ca tālo vā ucchritā vīṇuvīrudhaḥ || </l>
 
                     <l xml:id="SS.1.29.61">
                         <label>1938 ed. 1.29.61</label>
@@ -7164,8 +6967,7 @@
                          sa dīrghāyur iti jñeyas tasmai karma samācaret || </l>
 
                     <l xml:id="SS.1.29.trailer">iti suśrutasaṃhitāyāṃ sūtrasthāne
-                        viparītāviparītasvapnanidarśanīyo nāmaikonatriṃśattamo 'dhyāyaḥ ||
-                    </l>
+                        viparītāviparītasvapnanidarśanīyo nāmaikonatriṃśattamo 'dhyāyaḥ || </l>
                 </div>
 
 


### PR DESCRIPTION
I was checking the Sūtrasthāna of the so-called _Suśrutapāṭhaśuddhi_. I found that it has only chapter 12 from the _sūtrasthāna_, transcribed by Harshal. I thought it could be a good start to do a comparison. It appeared to me that the text is just the Saṃhitā itself with Ḍalhaṇa's Nibandhasaṅgraha. Its version is closer to the vulgate than the Nepalese version.  

I added the file to our existing sūtrasthāna folder and adjusted the xml ids so that the file can be collated against other witnesses. I worked only on the first 10 chunks of chapter 12 and added the same chunks of the _Nibandhasaṅgraha_ in the 1938 vulgate edition. If they are added to Saktumiva, we should be able to see the differences. 